### PR TITLE
enable automerge on dependabot prs that pass required checks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '37 4 * * 1'
 
+concurrency:
+  group: codeql-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for non-major updates
+        if: >
+          steps.metadata.outputs.dependency-group != 'bun-major' &&
+          steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-outdated-prs.yml
+++ b/.github/workflows/update-outdated-prs.yml
@@ -1,0 +1,40 @@
+name: Update outdated PR branches
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update out-of-date PR branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          gh pr list --repo "$GITHUB_REPOSITORY" --base main --state open \
+            --json number,author,isDraft,mergeStateStatus \
+            --jq '.[] | select(.isDraft|not) | select(.mergeStateStatus == "BEHIND") | "\(.number)\t\(.author.login)"' \
+          | while IFS=$'\t' read -r number author; do
+              echo "Updating PR #$number ($author)..."
+              case "$author" in
+                dependabot[bot]|app/dependabot)
+                  # Dependabot rebase retriggers checks; GITHUB_TOKEN branch updates do not.
+                  gh pr comment "$number" --repo "$GITHUB_REPOSITORY" --body "@dependabot rebase"
+                  ;;
+                *)
+                  gh pr update-branch "$number" --repo "$GITHUB_REPOSITORY" || {
+                    echo "Skipped PR #$number (update failed — likely conflicts)"
+                  }
+                  ;;
+              esac
+            done


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the merging of Dependabot pull requests for non-major updates. The workflow ensures that only safe, non-breaking dependency updates from Dependabot are automatically merged, reducing manual intervention and keeping dependencies up to date.

**Dependabot auto-merge workflow:**

* Added `.github/workflows/dependabot-auto-merge.yml` to automatically enable auto-merge for Dependabot pull requests that are not major version updates, using the `dependabot/fetch-metadata` action and the GitHub CLI.