### PR TITLE
release handles PR rules on main

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -6,12 +6,9 @@ name: Auto Tag
 # Order matters: the version bump is committed to main FIRST, and the tag
 # is placed on that commit.
 #
-# Requires a RELEASE_TOKEN secret. Tags pushed with the default GITHUB_TOKEN
-# do not trigger `on: push: tags`, so release workflows would never fire.
-#
-# The token needs write access to repository contents.
-#   - Fine-grained PAT: Contents -> Read and write, scoped to this repo
-#   - Classic PAT:      public_repo (or `repo` if private)
+# Pushes use the job GITHUB_TOKEN (contents: write). Tags created with that
+# token do not re-trigger other `on: push: tags` workflows, so Release is
+# started explicitly via workflow_dispatch after the tag is pushed.
 
 on:
   push:
@@ -34,7 +31,8 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write
+  actions: write
 
 jobs:
   tag:
@@ -48,17 +46,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
-
-      - name: Fail early if RELEASE_TOKEN is missing
-        env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        run: |
-          if [ -z "$RELEASE_TOKEN" ]; then
-            echo "::error::RELEASE_TOKEN is not set. A tag pushed with the default" \
-                 "GITHUB_TOKEN will not trigger tag-based release workflows."
-            exit 1
-          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -105,6 +92,7 @@ jobs:
           npm version "$NEXT" --no-git-tag-version --allow-same-version
 
       - name: Commit, tag, and push
+        id: push
         run: |
           set -euo pipefail
           NEXT="${{ steps.version.outputs.next }}"
@@ -125,3 +113,14 @@ jobs:
           echo "### Released \`v$NEXT\`" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Bumped from \`${{ steps.version.outputs.current }}\`." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Trigger Release workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEXT: ${{ steps.version.outputs.next }}
+        run: |
+          set -euo pipefail
+          # GITHUB_TOKEN tag pushes do not fire `on: push: tags`. Always
+          # dispatch Release so npm publish still runs for this version.
+          gh workflow run release.yml --ref "v${NEXT}"
+          echo "Dispatched Release for v${NEXT}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,14 +1,15 @@
 name: Auto Tag
 
-# Cuts a release tag when dependencies change on main -- primarily so
+# Cuts a release when dependencies change on main -- primarily so
 # Dependabot security updates ship to users instead of sitting in the repo.
 #
-# Order matters: the version bump is committed to main FIRST, and the tag
-# is placed on that commit.
+# Repository rules require pull requests into main (no direct push). Flow:
+#   1. Open a release/* branch with the version bump
+#   2. Open a PR and enable auto-merge (waits for required checks)
+#   3. After merge, tag the merge commit on main and dispatch Release
 #
-# Pushes use the job GITHUB_TOKEN (contents: write). Tags created with that
-# token do not re-trigger other `on: push: tags` workflows, so Release is
-# started explicitly via workflow_dispatch after the tag is pushed.
+# Tags created with GITHUB_TOKEN do not re-trigger `on: push: tags`, so
+# Release is started via workflow_dispatch.
 
 on:
   push:
@@ -33,6 +34,7 @@ concurrency:
 permissions:
   contents: write
   actions: write
+  pull-requests: write
 
 jobs:
   tag:
@@ -64,7 +66,6 @@ jobs:
 
           BUMP="${{ github.event.inputs.bump || 'patch' }}"
           IFS=. read -r MAJOR MINOR PATCH <<< "$CURRENT"
-          # strip any prerelease suffix from PATCH
           PATCH=${PATCH%%-*}
 
           case "$BUMP" in
@@ -83,6 +84,7 @@ jobs:
 
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "next=$NEXT"       >> "$GITHUB_OUTPUT"
+          echo "branch=release/v$NEXT" >> "$GITHUB_OUTPUT"
           echo "Bumping $CURRENT -> $NEXT ($BUMP)"
 
       - name: Apply version to package.json
@@ -91,36 +93,101 @@ jobs:
           NEXT="${{ steps.version.outputs.next }}"
           npm version "$NEXT" --no-git-tag-version --allow-same-version
 
-      - name: Commit, tag, and push
-        id: push
+      - name: Open release PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEXT: ${{ steps.version.outputs.next }}
+          CURRENT: ${{ steps.version.outputs.current }}
+          BRANCH: ${{ steps.version.outputs.branch }}
         run: |
           set -euo pipefail
-          NEXT="${{ steps.version.outputs.next }}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          git checkout -b "$BRANCH"
           git add package.json
-          # Include lockfile if npm/bun rewrote it
           git add -u bun.lock package-lock.json yarn.lock pnpm-lock.yaml 2>/dev/null || true
           git commit -m "chore(release): v$NEXT"
+          git push -u origin "$BRANCH"
 
-          git tag -a "v$NEXT" -m "Release v$NEXT"
-          git push origin HEAD:main
-          git push origin "v$NEXT"
+          # Avoid duplicate open PRs for the same branch
+          PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$PR" ]; then
+            echo "Reusing open PR #$PR"
+          else
+            gh pr create \
+              --title "chore(release): v$NEXT" \
+              --body "$(printf '%s\n' \
+                "Automated version bump \`$CURRENT\` → \`$NEXT\` from Auto Tag." \
+                "" \
+                "After merge, Auto Tag will create tag \`v$NEXT\` and dispatch the Release workflow.")" \
+              --base main \
+              --head "$BRANCH"
+            PR=$(gh pr view "$BRANCH" --json number --jq .number)
+            echo "Opened PR #$PR"
+          fi
 
-          echo "Tagged v$NEXT"
-          echo "### Released \`v$NEXT\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Bumped from \`${{ steps.version.outputs.current }}\`." >> "$GITHUB_STEP_SUMMARY"
+          echo "number=$PR" >> "$GITHUB_OUTPUT"
 
-      - name: Trigger Release workflow
+          # Auto-merge when required checks (Test, CodeQL) pass.
+          # Repo allows squash/rebase only (ruleset).
+          gh pr merge "$PR" --auto --squash || {
+            echo "::warning::Could not enable auto-merge (may already be enabled or admin merge required)."
+          }
+
+          echo "### Release PR" >> "$GITHUB_STEP_SUMMARY"
+          echo "Opened/updated PR #$PR for \`v$NEXT\`." >> "$GITHUB_STEP_SUMMARY"
+          echo "Waiting for required checks, then auto-merge." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Wait for PR merge
         env:
           GH_TOKEN: ${{ github.token }}
+          PR: ${{ steps.pr.outputs.number }}
           NEXT: ${{ steps.version.outputs.next }}
         run: |
           set -euo pipefail
-          # GITHUB_TOKEN tag pushes do not fire `on: push: tags`. Always
-          # dispatch Release so npm publish still runs for this version.
+          # Up to ~30 minutes for Test + CodeQL
+          for i in $(seq 1 90); do
+            STATE=$(gh pr view "$PR" --json state,mergedAt --jq '{state,mergedAt}')
+            MERGED=$(echo "$STATE" | jq -r '.mergedAt // empty')
+            OPEN=$(echo "$STATE" | jq -r '.state')
+            if [ -n "$MERGED" ]; then
+              echo "PR #$PR merged at $MERGED"
+              exit 0
+            fi
+            if [ "$OPEN" = "CLOSED" ]; then
+              echo "::error::PR #$PR was closed without merging"
+              exit 1
+            fi
+            echo "Waiting for merge ($i/90)..."
+            sleep 20
+          done
+          echo "::error::Timed out waiting for PR #$PR to merge"
+          exit 1
+
+      - name: Tag merge commit and dispatch Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEXT: ${{ steps.version.outputs.next }}
+          CURRENT: ${{ steps.version.outputs.current }}
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          git checkout main
+          git reset --hard origin/main
+
+          if git rev-parse -q --verify "refs/tags/v$NEXT" >/dev/null; then
+            echo "Tag v$NEXT already exists"
+          else
+            git tag -a "v$NEXT" -m "Release v$NEXT"
+            git push origin "v$NEXT"
+            echo "Tagged v$NEXT"
+          fi
+
+          # GITHUB_TOKEN tag pushes do not fire `on: push: tags`
           gh workflow run release.yml --ref "v${NEXT}"
-          echo "Dispatched Release for v${NEXT}" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "### Released \`v$NEXT\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Bumped from \`$CURRENT\`. Release workflow dispatched." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
This pull request updates the `.github/workflows/auto-tag.yml` workflow to improve the release automation process by shifting from direct tagging on `main` to a safer, PR-based flow. The new approach opens a release branch, creates a pull request for version bumps, waits for checks and auto-merges, then tags the merge commit and dispatches the release workflow. It also updates permissions and cleans up token handling.

**Release workflow improvements:**

* Changed the release flow to open a `release/*` branch, create a PR for version bumps, auto-merge after required checks, then tag the merge commit and dispatch the Release workflow. This ensures compliance with repository rules and provides a safer, more auditable process. [[1]](diffhunk://#diff-ef3c74ba11f319b8d5e0c7fd469a18171302fddef9b43d8a5b5a924f7ff6a494L3-R12) [[2]](diffhunk://#diff-ef3c74ba11f319b8d5e0c7fd469a18171302fddef9b43d8a5b5a924f7ff6a494L107-R193)
* Added a new step to wait for the PR to be merged before proceeding with tagging and release dispatch, ensuring the tag is always created on the correct commit.
* Updated the workflow to use the default `GITHUB_TOKEN` for all operations, removing the need for a separate `RELEASE_TOKEN` and the associated early-fail logic.

**Permissions and configuration:**

* Increased workflow permissions to allow writing to `contents`, `actions`, and `pull-requests`, supporting the new PR-based flow and required actions.

**Other improvements:**

* Added `branch=release/v$NEXT` to outputs for easier branch management and improved log/step summaries for better traceability.