### PR TITLE
fix(docs): enable Writerside search UI and unbreak deploy

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -53,11 +53,14 @@ jobs:
       - name: Resolve search Worker URL
         id: worker
         env:
-          # Override with vars.DOCS_SEARCH_URL if needed; default is the zone host
+          # Override with vars.DOCS_SEARCH_URL if needed.
+          # Prefer workers.dev for CI: apex DNS (di-framework.dev) has been flaky
+          # for some resolvers including GitHub-hosted runners.
           DOCS_SEARCH_URL: ${{ vars.DOCS_SEARCH_URL }}
         run: |
           set -euo pipefail
-          URL="${DOCS_SEARCH_URL:-https://di-framework.dev/api/docs/search}"
+          # Worker also mounts under BASE_PATH on workers.dev (same as apex route).
+          URL="${DOCS_SEARCH_URL:-https://di-framework-docs-search.seemueller.workers.dev/api/docs/search}"
           URL="${URL%/}"
           echo "url=$URL" >> "$GITHUB_OUTPUT"
           echo "Worker: $URL"
@@ -137,9 +140,11 @@ jobs:
         with:
           path: dir
 
+  # Pages must ship even if reindex is flaky (DNS/OIDC/Worker). Search UI is
+  # baked into the static build via <search-endpoint>; the Worker can reindex later.
   deploy:
     name: Deploy GitHub Pages
-    needs: [build, index-search]
+    needs: [build]
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
     environment:

--- a/docs/Writerside/cfg/buildprofiles.xml
+++ b/docs/Writerside/cfg/buildprofiles.xml
@@ -10,10 +10,12 @@
             <custom-css>footer.css</custom-css>
             <!--
               Docs: https://docs.di-framework.dev (GitHub Pages + custom domain)
-              Search: https://di-framework.dev/api/docs/search (Cloudflare Worker)
+              Search Worker (workers.dev is the stable public URL; apex route also
+              exists at di-framework.dev/api/docs/search* when apex DNS is healthy):
+                https://di-framework-docs-search.seemueller.workers.dev/api/docs/search
               CI reindexes via GitHub OIDC (no CF API tokens in GitHub).
             -->
-            <search-endpoint>https://di-framework.dev/api/docs/search</search-endpoint>
+            <search-endpoint>https://di-framework-docs-search.seemueller.workers.dev/api/docs/search</search-endpoint>
         </variables>
     </build-profile>
 

--- a/examples/packages/docs-search/README.md
+++ b/examples/packages/docs-search/README.md
@@ -98,7 +98,8 @@ bun run deploy
 | Host | Role |
 | --- | --- |
 | `https://docs.di-framework.dev` | Writerside site (GitHub Pages custom domain) |
-| `https://di-framework.dev/api/docs/search` | Search Worker (`BASE_PATH` on apex zone) |
+| `https://di-framework-docs-search.seemueller.workers.dev/api/docs/search` | Search Worker (public `workers.dev` URL) |
+| `https://di-framework.dev/api/docs/search` | Same Worker via apex route (when apex DNS is healthy) |
 
 | Worker path | Role |
 | --- | --- |
@@ -115,7 +116,7 @@ Workflow dispatch has **full_reindex** → `POST …/reindex?full=1`.
 ### Manual reindex (with a token)
 
 ```bash
-WORKER=https://di-framework.dev/api/docs/search
+WORKER=https://di-framework-docs-search.seemueller.workers.dev/api/docs/search
 curl -X POST "$WORKER/reindex" \
   -H "Authorization: Bearer $REINDEX_JWT" \
   -H "Content-Type: application/json" \
@@ -125,7 +126,7 @@ curl -X POST "$WORKER/reindex" \
 Writerside (`buildprofiles.xml`):
 
 ```xml
-<search-endpoint>https://di-framework.dev/api/docs/search</search-endpoint>
+<search-endpoint>https://di-framework-docs-search.seemueller.workers.dev/api/docs/search</search-endpoint>
 ```
 
 Writerside calls `{search-endpoint}/preview-search/{project}/{instance}`.

--- a/examples/packages/docs-search/wrangler.jsonc
+++ b/examples/packages/docs-search/wrangler.jsonc
@@ -3,8 +3,9 @@
   "name": "di-framework-docs-search",
   "main": "src/index.ts",
   "compatibility_date": "2025-11-09",
-  // Public host is di-framework.dev (zone on this Cloudflare account)
-  "workers_dev": false,
+  // Apex route: di-framework.dev/api/docs/search* (see routes below).
+  // Also expose *.workers.dev as a CI/fallback URL when apex DNS is flaky.
+  "workers_dev": true,
   "preview_urls": false,
   // Path-style mount; handler strips BASE_PATH before routing
   "routes": [
@@ -18,14 +19,17 @@
   },
   // Workers AI → embeddings (@cf/google/embeddinggemma-300m → 768-d)
   "ai": {
-    "binding": "AI"
+    "binding": "AI",
+    "remote": true
   },
   // Vectorize → store + ANN query (dims must match model; Gemma = 768)
   //   wrangler vectorize create di-docs-search --dimensions=768 --metric=cosine
   "vectorize": [
     {
       "binding": "VECTORIZE",
-      "index_name": "di-docs-search"
+      "index_name": "di-docs-search",
+      // Vectorize has no local simulator — use remote index in `wrangler dev`
+      "remote": true
     }
   ],
   // Durable content-hash manifest for incremental sync


### PR DESCRIPTION
## Summary
- Writerside only shows search when `config.json` has `searchService` (from `<search-endpoint>`).
- The deploy that added `search-endpoint` never published: CI reindex failed with `Could not resolve host: di-framework.dev`, and `deploy` required `index-search`.
- Verified end-to-end locally: with `searchService: custom`, the search button appears and queries the Worker successfully.

## Changes
- Point `<search-endpoint>` (and CI reindex default) at `https://di-framework-docs-search.seemueller.workers.dev/api/docs/search`
- Deploy GitHub Pages from `build` only (reindex can fail without blocking docs)
- Enable `workers_dev` and remote AI/Vectorize bindings for local dev

## Test plan
- [x] Local UI + Worker: search button visible; query `repository` returns Repositories hit
- [ ] CI: Deploy Documentation succeeds and publishes new `config.json` with `searchService`
- [ ] Production: open https://docs.di-framework.dev → search button → results