### PR TITLE
fix(docs): force searchService into Writerside config.json

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -135,6 +135,29 @@ jobs:
       - name: Unzip artifact
         run: unzip -O UTF-8 -qq artifacts/webHelpD2-all.zip -d dir
 
+      # Writerside only shows the search UI when config.json has a truthy
+      # searchService. Some builder versions do not emit these keys from
+      # <search-endpoint> alone — patch so the bar always appears.
+      - name: Ensure custom search is enabled in config.json
+        env:
+          SEARCH_ENDPOINT: ${{ vars.DOCS_SEARCH_URL }}
+        run: |
+          set -euo pipefail
+          ENDPOINT="${SEARCH_ENDPOINT:-https://di-framework-docs-search.seemueller.workers.dev/api/docs/search}"
+          ENDPOINT="${ENDPOINT%/}"
+          # Help module dir + instance id → /preview-search/{project}/{instance}
+          SERVICE_URL="${ENDPOINT}/preview-search/Writerside/d"
+          python3 - <<PY
+          import json
+          from pathlib import Path
+          p = Path("dir/config.json")
+          cfg = json.loads(p.read_text())
+          cfg["searchService"] = "custom"
+          cfg["searchServiceUrl"] = "${SERVICE_URL}"
+          p.write_text(json.dumps(cfg, separators=(",", ":")))
+          print("config.json:", p.read_text())
+          PY
+
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v5
         with:

--- a/docs/Writerside/cfg/buildprofiles.xml
+++ b/docs/Writerside/cfg/buildprofiles.xml
@@ -3,18 +3,19 @@
 <buildprofiles xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/build-profiles.xsd"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-    <variables></variables>
+    <!--
+      search-endpoint must be under top-level <variables> (Writerside docs).
+      It should bake searchService/searchServiceUrl into config.json.
+      CI also patches config.json after the build as a safety net.
+    -->
+    <variables>
+        <search-endpoint>https://di-framework-docs-search.seemueller.workers.dev/api/docs/search</search-endpoint>
+    </variables>
     <build-profile instance="d">
         <variables>
             <noindex-content>true</noindex-content>
             <custom-css>footer.css</custom-css>
-            <!--
-              Docs: https://docs.di-framework.dev (GitHub Pages + custom domain)
-              Search Worker (workers.dev is the stable public URL; apex route also
-              exists at di-framework.dev/api/docs/search* when apex DNS is healthy):
-                https://di-framework-docs-search.seemueller.workers.dev/api/docs/search
-              CI reindexes via GitHub OIDC (no CF API tokens in GitHub).
-            -->
+            <!-- Same endpoint at instance level in case the builder only merges profile vars -->
             <search-endpoint>https://di-framework-docs-search.seemueller.workers.dev/api/docs/search</search-endpoint>
         </variables>
     </build-profile>


### PR DESCRIPTION
## Summary
The previous deploy succeeded, but the Writerside builder still produced a `config.json` **without** `searchService` / `searchServiceUrl`. The search bar is gated on `!!searchService` in the Writerside frontend.

## Fix
- After unzipping the WebHelp artifact, patch `config.json` to set:
  - `searchService: "custom"`
  - `searchServiceUrl: {endpoint}/preview-search/Writerside/d`
- Also declare `<search-endpoint>` at top-level buildprofiles variables.

## Test plan
- [x] Local: patched config shows search button + live hits from Worker
- [ ] CI build log prints patched config.json
- [ ] Production `https://docs.di-framework.dev/config.json` includes searchService
- [ ] Production UI: search button → query works