### PR TITLE
Add EventBridge implementation and memory transport adapter with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ npm i @di-framework/core
 - `packages/di-framework-core` - core container
 - `packages/di-framework-repo` - data access
 - `packages/di-framework-http` - http handling
+- `packages/di-framework-graphql` - GraphQL schema from domain objects
+- `packages/di-framework-events` - bridge container events to Kafka / NATS / memory
 - `packages/di-framework-cli` - `di-framework-core` cli (build, test, typecheck, publish)
 - `examples` - usage examples
 

--- a/bun.lock
+++ b/bun.lock
@@ -64,6 +64,14 @@
         "wrangler": "latest",
       },
     },
+    "examples/packages/events": {
+      "name": "di-events-example",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@di-framework/core": "workspace:*",
+        "@di-framework/events": "workspace:*",
+      },
+    },
     "examples/packages/graphql": {
       "name": "@di-framework/graphql-example",
       "version": "0.0.0",
@@ -97,7 +105,7 @@
     },
     "packages/di-framework-cli": {
       "name": "@di-framework/cli",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "bin": {
         "di-framework": "./main.ts",
       },
@@ -113,7 +121,7 @@
     },
     "packages/di-framework-core": {
       "name": "@di-framework/core",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "devDependencies": {
         "typescript": "^5",
       },
@@ -121,9 +129,29 @@
         "typescript": "^5",
       },
     },
+    "packages/di-framework-events": {
+      "name": "@di-framework/events",
+      "version": "4.0.1",
+      "devDependencies": {
+        "@types/bun": "latest",
+        "kafkajs": "^2.2.4",
+        "nats": "^2.29.3",
+        "typescript": "^5",
+      },
+      "peerDependencies": {
+        "@di-framework/core": "workspace:^",
+        "kafkajs": "^2.2.0",
+        "nats": "^2.28.0",
+        "typescript": "^5",
+      },
+      "optionalPeers": [
+        "kafkajs",
+        "nats",
+      ],
+    },
     "packages/di-framework-graphql": {
       "name": "@di-framework/graphql",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "devDependencies": {
         "@types/bun": "latest",
         "graphql": "^17.0.2",
@@ -140,7 +168,7 @@
     },
     "packages/di-framework-http": {
       "name": "@di-framework/http",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "bin": {
         "di-framework-http": "./dist/src/cli.js",
       },
@@ -158,7 +186,7 @@
     },
     "packages/di-framework-repo": {
       "name": "@di-framework/repo",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "peerDependencies": {
         "@di-framework/core": "workspace:^",
         "typescript": "^5",
@@ -207,6 +235,8 @@
     "@di-framework/core": ["@di-framework/core@workspace:packages/di-framework-core"],
 
     "@di-framework/docs-search-example": ["@di-framework/docs-search-example@workspace:examples/packages/docs-search"],
+
+    "@di-framework/events": ["@di-framework/events@workspace:packages/di-framework-events"],
 
     "@di-framework/graphql": ["@di-framework/graphql@workspace:packages/di-framework-graphql"],
 
@@ -436,6 +466,8 @@
 
     "di-basic-example": ["di-basic-example@workspace:examples/packages/basic"],
 
+    "di-events-example": ["di-events-example@workspace:examples/packages/events"],
+
     "di-http-router-example": ["di-http-router-example@workspace:examples/packages/http-router"],
 
     "di-services-example": ["di-services-example@workspace:examples/packages/services"],
@@ -462,9 +494,15 @@
 
     "jose": ["jose@6.2.7", "", {}, "sha512-hq1OB1bALKfydZNoViyg6hPVGV4i93ny9Op+n4zP5RSf7SCZEXa/TsG2O3IEr7+WlHRTPnpqDmHfMH6qXAD60w=="],
 
+    "kafkajs": ["kafkajs@2.2.4", "", {}, "sha512-j/YeapB1vfPT2iOIUn/vxdyKEuhuY2PxMBvf5JWux6iSaukAccrMtXEY/Lb7OvavDhOWME589bpLrEdnVHjfjA=="],
+
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "miniflare": ["miniflare@5.20260730.0-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.28.0", "workerd": "1.20260730.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-8/dspSXDshP6nSkCpjKO7BYc2qZoYSXm7iM+QxY7qJyJpAB3onnQSaiu0cvKJlfuMGwULl55hG69FJCcCMXU1Q=="],
+
+    "nats": ["nats@2.29.3", "", { "dependencies": { "nkeys.js": "1.1.0" } }, "sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA=="],
+
+    "nkeys.js": ["nkeys.js@1.1.0", "", { "dependencies": { "tweetnacl": "1.0.3" } }, "sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg=="],
 
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
@@ -477,6 +515,8 @@
     "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/examples/packages/basic/index.test.ts
+++ b/examples/packages/basic/index.test.ts
@@ -1,6 +1,18 @@
-import { expect, test } from 'bun:test';
+import { beforeEach, expect, test } from 'bun:test';
 import { useContainer } from '@di-framework/core';
 import { ApplicationContext } from '../services/ApplicationContext';
+import { DatabaseService } from '../services/DatabaseService';
+import { LoggerService } from '../services/LoggerService';
+import { UserService } from '../services/UserService';
+
+beforeEach(() => {
+  const container = useContainer();
+  if (!container.has(DatabaseService)) container.register(DatabaseService, { singleton: true });
+  if (!container.has(LoggerService)) container.register(LoggerService, { singleton: true });
+  if (!container.has(UserService)) container.register(UserService, { singleton: true });
+  if (!container.has(ApplicationContext))
+    container.register(ApplicationContext, { singleton: true });
+});
 
 test('basic example resolves ApplicationContext', () => {
   const container = useContainer();

--- a/examples/packages/events/index.test.ts
+++ b/examples/packages/events/index.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { useContainer } from '@di-framework/core/container';
+import { Container, Publisher, Subscriber } from '@di-framework/core/decorators';
+import { createEventBridge, memoryTransport } from '@di-framework/events';
+
+beforeEach(() => {
+  useContainer().clear();
+});
+
+describe('events example', () => {
+  it('bridges publisher output to a topic and inbound payments to subscribers', async () => {
+    const placed: unknown[] = [];
+    const paid: unknown[] = [];
+    const topicOrders: unknown[] = [];
+
+    @Container()
+    class Orders {
+      @Publisher('order.placed')
+      place(id: string) {
+        return { id };
+      }
+    }
+
+    @Container()
+    class Listeners {
+      @Subscriber('order.placed')
+      onPlaced(p: unknown) {
+        const envelope = p as { result?: unknown };
+        placed.push(envelope.result ?? p);
+      }
+      @Subscriber('payment.captured')
+      onPaid(p: unknown) {
+        paid.push(p);
+      }
+    }
+
+    const transport = memoryTransport();
+    await transport.start?.();
+    await transport.subscribe('orders', async (msg, ack) => {
+      topicOrders.push(msg.payload);
+      ack.ack();
+    });
+
+    const bridge = createEventBridge({
+      transport,
+      routes: {
+        outbound: [{ event: 'order.placed', topic: 'orders' }],
+        inbound: [{ topic: 'payments.captured', event: 'payment.captured' }],
+      },
+    });
+    await bridge.start();
+
+    const c = useContainer();
+    c.resolve(Listeners);
+    c.resolve(Orders).place('o1');
+    await Bun.sleep(20);
+
+    expect(placed).toEqual([{ id: 'o1' }]);
+    expect(topicOrders).toEqual([{ id: 'o1' }]);
+
+    await transport.publish({
+      id: 'p1',
+      topic: 'payments.captured',
+      payload: { orderId: 'o1' },
+    });
+    await Bun.sleep(20);
+
+    expect(paid).toEqual([{ orderId: 'o1' }]);
+    await bridge.stop();
+  });
+});

--- a/examples/packages/events/index.ts
+++ b/examples/packages/events/index.ts
@@ -1,0 +1,78 @@
+/**
+ * @di-framework/events example
+ *
+ * Domain services use core @Publisher / @Subscriber.
+ * An EventBridge + memoryTransport maps those events onto topics.
+ */
+
+import { useContainer } from '@di-framework/core/container';
+import { Container, Publisher, Subscriber } from '@di-framework/core/decorators';
+import { EventBridge, Inbound, memoryTransport, Outbound } from '@di-framework/events';
+
+const transport = memoryTransport();
+
+@EventBridge({ transport: () => transport })
+class OrderEvents {
+  @Outbound('order.placed', {
+    topic: 'orders',
+    key: (p: unknown) => {
+      if (p && typeof p === 'object' && 'result' in p) {
+        const result = (p as { result?: { id?: string } }).result;
+        return result?.id;
+      }
+      return undefined;
+    },
+  })
+  outboundOrders!: undefined;
+
+  @Inbound({ topic: 'payments.captured', event: 'payment.captured' })
+  inboundPayments!: undefined;
+}
+
+@Container()
+class OrderService {
+  @Publisher('order.placed')
+  place(id: string, total: number) {
+    return { id, total };
+  }
+}
+
+@Container()
+class FulfillmentService {
+  @Subscriber('order.placed')
+  onPlaced(payload: unknown) {
+    const envelope = payload as { result?: { id: string; total: number } };
+    const order = envelope.result ?? (payload as { id: string; total: number });
+    console.log(`[fulfillment] order ${order.id} total=${order.total}`);
+  }
+
+  @Subscriber('payment.captured')
+  onPaid(payload: unknown) {
+    console.log(`[fulfillment] payment captured`, payload);
+  }
+}
+
+const container = useContainer();
+container.resolve(OrderEvents);
+container.resolve(FulfillmentService);
+const orders = container.resolve(OrderService);
+
+// Wait for autoStart microtask
+await Bun.sleep(20);
+
+console.log('--- place order (local subscriber + outbound topic) ---');
+orders.place('o-100', 42);
+
+await Bun.sleep(20);
+
+console.log('--- simulate remote payment on topic payments.captured ---');
+await transport.publish({
+  id: crypto.randomUUID(),
+  topic: 'payments.captured',
+  payload: { orderId: 'o-100', amount: 42 },
+});
+
+await Bun.sleep(20);
+
+console.log('done');
+container.clear();

--- a/examples/packages/events/package.json
+++ b/examples/packages/events/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "di-events-example",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "start": "bun run index.ts",
+    "test": "bun test"
+  },
+  "devDependencies": {
+    "@di-framework/core": "workspace:*",
+    "@di-framework/events": "workspace:*"
+  }
+}

--- a/examples/packages/events/tsconfig.json
+++ b/examples/packages/events/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/examples/packages/services/services.test.ts
+++ b/examples/packages/services/services.test.ts
@@ -1,8 +1,19 @@
-import { describe, expect, test } from 'bun:test';
+import { beforeEach, describe, expect, test } from 'bun:test';
 import { useContainer } from '@di-framework/core';
+import { ApplicationContext } from './ApplicationContext';
 import { DatabaseService } from './DatabaseService';
 import { LoggerService } from './LoggerService';
 import { UserService } from './UserService';
+
+beforeEach(() => {
+  const container = useContainer();
+  // Re-register after other suites call clear() — @Container() only runs once at import time.
+  if (!container.has(DatabaseService)) container.register(DatabaseService, { singleton: true });
+  if (!container.has(LoggerService)) container.register(LoggerService, { singleton: true });
+  if (!container.has(UserService)) container.register(UserService, { singleton: true });
+  if (!container.has(ApplicationContext))
+    container.register(ApplicationContext, { singleton: true });
+});
 
 describe('services example', () => {
   test('DatabaseService connects and queries', () => {
@@ -45,8 +56,7 @@ describe('services example', () => {
   });
 
   test('ApplicationContext manages environment and context', () => {
-    const { ApplicationContext } = require('./ApplicationContext');
-    const appCtx: any = useContainer().resolve(ApplicationContext);
+    const appCtx = useContainer().resolve(ApplicationContext);
 
     appCtx.setEnv({ FOO: 'bar' });
     expect(appCtx.getEnv()).toEqual({ FOO: 'bar' });

--- a/packages/di-framework-cli/cmd/build.ts
+++ b/packages/di-framework-cli/cmd/build.ts
@@ -7,6 +7,7 @@ export const PACKAGES = [
   'packages/di-framework-repo',
   'packages/di-framework-http',
   'packages/di-framework-graphql',
+  'packages/di-framework-events',
   'packages/di-framework-cli',
 ];
 

--- a/packages/di-framework-cli/cmd/publish.ts
+++ b/packages/di-framework-cli/cmd/publish.ts
@@ -6,6 +6,7 @@ export const PACKAGES = [
   'packages/di-framework-repo',
   'packages/di-framework-http',
   'packages/di-framework-graphql',
+  'packages/di-framework-events',
   'packages/di-framework-cli',
 ];
 

--- a/packages/di-framework-cli/tests/build.test.ts
+++ b/packages/di-framework-cli/tests/build.test.ts
@@ -75,6 +75,7 @@ describe('build command', () => {
       expect(PACKAGES).toContain('packages/di-framework-repo');
       expect(PACKAGES).toContain('packages/di-framework-http');
       expect(PACKAGES).toContain('packages/di-framework-graphql');
+      expect(PACKAGES).toContain('packages/di-framework-events');
       expect(PACKAGES).toContain('packages/di-framework-cli');
     });
 

--- a/packages/di-framework-cli/tests/publish.test.ts
+++ b/packages/di-framework-cli/tests/publish.test.ts
@@ -114,6 +114,7 @@ describe('publish command', () => {
       expect(PACKAGES).toContain('packages/di-framework-repo');
       expect(PACKAGES).toContain('packages/di-framework-http');
       expect(PACKAGES).toContain('packages/di-framework-graphql');
+      expect(PACKAGES).toContain('packages/di-framework-events');
       expect(PACKAGES).toContain('packages/di-framework-cli');
     });
 

--- a/packages/di-framework-events/README.md
+++ b/packages/di-framework-events/README.md
@@ -1,0 +1,167 @@
+# @di-framework/events
+
+Bridge the core in-process `@Publisher` / `@Subscriber` bus to external brokers (Kafka, NATS) through a pluggable `EventTransport`. Domain services stay on `@di-framework/core`; this package is the wire.
+
+## Features
+
+- **Same bus, external brokers**: outbound routes publish container events to topics; inbound routes emit broker messages back onto the container (so `@Subscriber` and GraphQL subscriptions keep working).
+- **Decorator routes**: `@EventBridge`, `@Outbound`, `@Inbound` declare the map in code.
+- **Imperative API**: `createEventBridge({ transport, routes })` for tests and scripts.
+- **In-memory transport**: always available, no peers — used in unit tests and local runs.
+- **Optional peers**: `kafkajs` and `nats` behind `@di-framework/events/kafka` and `@di-framework/events/nats`.
+- **At-least-once**: adapters expose `ack` / `nack`; durability details are broker-specific.
+
+## Installation
+
+```bash
+bun add @di-framework/events @di-framework/core
+# optional brokers
+bun add kafkajs   # for @di-framework/events/kafka
+bun add nats      # for @di-framework/events/nats
+```
+
+## Quick start (in-memory)
+
+```typescript
+import { Container, Publisher, Subscriber } from '@di-framework/core/decorators';
+import { useContainer } from '@di-framework/core/container';
+import {
+  createEventBridge,
+  memoryTransport,
+} from '@di-framework/events';
+
+@Container()
+class OrderService {
+  @Publisher('order.placed')
+  place(id: string) {
+    return { id };
+  }
+}
+
+@Container()
+class FulfillmentService {
+  @Subscriber('order.placed')
+  onPlaced(payload: any) {
+    console.log('order', payload.result ?? payload);
+  }
+}
+
+const transport = memoryTransport();
+const bridge = createEventBridge({
+  transport,
+  routes: {
+    outbound: [{ event: 'order.placed', topic: 'orders' }],
+    inbound: [{ topic: 'payments', event: 'payment.captured' }],
+  },
+});
+
+await bridge.start();
+
+const orders = useContainer().resolve(OrderService);
+useContainer().resolve(FulfillmentService);
+orders.place('o1'); // local subscriber + outbound publish to "orders"
+
+await bridge.stop();
+```
+
+Outbound payloads default to unwrapping the `@Publisher` envelope (`result`), matching GraphQL subscriptions. Inbound emits the decoded payload as-is.
+
+## Decorator routes
+
+```typescript
+import { EventBridge, Outbound, Inbound, memoryTransport } from '@di-framework/events';
+
+@EventBridge({ transport: () => memoryTransport() })
+class OrderEvents {
+  @Outbound('order.placed', {
+    topic: 'orders',
+    key: (p: any) => p.result?.id,
+  })
+  outboundOrders!: void;
+
+  @Inbound({ topic: 'payments.captured', event: 'payment.captured' })
+  inboundPayments!: void;
+}
+
+// autoStart (default) starts the bridge on resolve:
+useContainer().resolve(OrderEvents);
+
+// or disable autoStart and call:
+// await startEventBridges();
+```
+
+Inject a shared transport instead of passing one in options:
+
+```typescript
+container.registerFactory('EventTransport', () => memoryTransport(), { singleton: true });
+
+@EventBridge() // resolves token "EventTransport"
+class OrderEvents { /* ... */ }
+```
+
+## Kafka
+
+```typescript
+import { createEventBridge } from '@di-framework/events';
+import { kafkaTransport } from '@di-framework/events/kafka';
+
+const transport = kafkaTransport({
+  client: { clientId: 'my-app', brokers: ['localhost:9092'] },
+  groupId: 'my-app-consumers',
+});
+
+const bridge = createEventBridge({
+  transport,
+  routes: {
+    outbound: [{ event: 'order.placed', topic: 'orders' }],
+    inbound: [{ topic: 'orders', event: 'order.placed' }],
+  },
+});
+await bridge.start();
+```
+
+Topic creation is left to operators. Delivery is at-least-once via the consumer group.
+
+## NATS
+
+```typescript
+import { natsTransport } from '@di-framework/events/nats';
+
+const transport = natsTransport({
+  servers: 'nats://127.0.0.1:4222',
+  // jetstream: true,
+  // durable: 'my-consumer',
+});
+```
+
+Core NATS is the default. Set `jetstream: true` (and usually `durable`) for durable consumers.
+
+## Loop suppression
+
+When the same process both publishes and consumes the same event/topic pair, inbound emits temporarily suppress outbound republishing so a single-process echo cannot spin forever. Local `@Subscriber` handlers still see the original `@Publisher` event; a remote echo would arrive as a second emit in a multi-process deployment.
+
+## Lifecycle
+
+- `bridge.start()` connects the transport and attaches routes.
+- `bridge.stop()` and `container.clear()` tear the bridge down (same idea as `@Cron`).
+- Optional `onError` receives `{ direction, topic, event, error }`.
+
+## API
+
+| Export | |
+| --- | --- |
+| `createEventBridge` | Imperative bridge |
+| `memoryTransport` | In-process transport |
+| `JsonCodec` | Default JSON codec |
+| `EventBridge` / `Outbound` / `Inbound` | Route decorators |
+| `startEventBridges` | Resolve + start all registered bridges |
+| `@di-framework/events/kafka` | `kafkaTransport` |
+| `@di-framework/events/nats` | `natsTransport` |
+
+## Non-goals (v1)
+
+Transactional outbox/inbox, schema registry / Avro, request-reply, and additional brokers (Redis Streams, SQS, …). The `EventTransport` interface is the extension point.
+
+## License
+
+MIT

--- a/packages/di-framework-events/index.ts
+++ b/packages/di-framework-events/index.ts
@@ -1,0 +1,37 @@
+export { type MemoryTransportOptions, memoryTransport } from './src/adapters/memory.ts';
+export { createEventBridge, unwrapPublisherPayload } from './src/bridge.ts';
+export { bytesFromCodecOutput, JsonCodec, stringFromCodecOutput } from './src/codec.ts';
+export {
+  EventBridge,
+  Inbound,
+  Outbound,
+  startEventBridges,
+} from './src/decorators.ts';
+export {
+  default as registry,
+  EventBridgeRegistry,
+  getRegistry,
+  setRegistry,
+} from './src/registry.ts';
+export type {
+  Ack,
+  CreateEventBridgeOptions,
+  EventBridgeContainer,
+  EventBridgeDecoratorOptions,
+  EventBridgeErrorContext,
+  EventBridgeHandle,
+  EventBridgeRoutes,
+  EventCodec,
+  EventMessage,
+  EventTransport,
+  InboundDecoratorOptions,
+  InboundFilterFn,
+  InboundMapFn,
+  InboundRoute,
+  OutboundDecoratorOptions,
+  OutboundFilterFn,
+  OutboundKeyFn,
+  OutboundMapFn,
+  OutboundRoute,
+  Unsubscribe,
+} from './src/types.ts';

--- a/packages/di-framework-events/kafka.ts
+++ b/packages/di-framework-events/kafka.ts
@@ -1,0 +1,5 @@
+export {
+  type KafkaJsLike,
+  type KafkaTransportOptions,
+  kafkaTransport,
+} from './src/adapters/kafka.ts';

--- a/packages/di-framework-events/memory.ts
+++ b/packages/di-framework-events/memory.ts
@@ -1,0 +1,4 @@
+export {
+  type MemoryTransportOptions,
+  memoryTransport,
+} from './src/adapters/memory.ts';

--- a/packages/di-framework-events/nats.ts
+++ b/packages/di-framework-events/nats.ts
@@ -1,0 +1,6 @@
+export {
+  type NatsConnectionLike,
+  type NatsLike,
+  type NatsTransportOptions,
+  natsTransport,
+} from './src/adapters/nats.ts';

--- a/packages/di-framework-events/package.json
+++ b/packages/di-framework-events/package.json
@@ -1,0 +1,86 @@
+{
+  "name": "@di-framework/events",
+  "version": "4.0.1",
+  "description": "Bridge di-framework container events to external brokers (Kafka, NATS) via pluggable transports.",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "private": false,
+  "exports": {
+    ".": {
+      "bun": "./index.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./memory": {
+      "bun": "./memory.ts",
+      "import": "./dist/memory.js",
+      "default": "./dist/memory.js"
+    },
+    "./kafka": {
+      "bun": "./kafka.ts",
+      "import": "./dist/kafka.js",
+      "default": "./dist/kafka.js"
+    },
+    "./nats": {
+      "bun": "./nats.ts",
+      "import": "./dist/nats.js",
+      "default": "./dist/nats.js"
+    }
+  },
+  "author": "@di-framework Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/di-framework/di-framework",
+    "directory": "packages/di-framework-events"
+  },
+  "bugs": {
+    "url": "https://github.com/di-framework/di-framework/issues"
+  },
+  "homepage": "https://github.com/di-framework/di-framework#readme",
+  "keywords": [
+    "events",
+    "kafka",
+    "nats",
+    "messaging",
+    "dependency-injection",
+    "decorators",
+    "typescript"
+  ],
+  "type": "module",
+  "files": [
+    "dist",
+    "README.md",
+    "index.ts",
+    "memory.ts",
+    "kafka.ts",
+    "nats.ts",
+    "src"
+  ],
+  "scripts": {
+    "build": "rm -rf dist && bun build ./index.ts ./memory.ts ./kafka.ts ./nats.ts --outdir ./dist --target node --external @di-framework/core --external kafkajs --external nats && tsc --emitDeclarationOnly --declaration --outDir dist",
+    "prepublishOnly": "bun run build",
+    "test": "bun test"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "kafkajs": "^2.2.4",
+    "nats": "^2.29.3",
+    "typescript": "^5"
+  },
+  "peerDependencies": {
+    "@di-framework/core": "workspace:^",
+    "kafkajs": "^2.2.0",
+    "nats": "^2.28.0",
+    "typescript": "^5"
+  },
+  "peerDependenciesMeta": {
+    "kafkajs": {
+      "optional": true
+    },
+    "nats": {
+      "optional": true
+    }
+  }
+}

--- a/packages/di-framework-events/src/adapters/kafka.ts
+++ b/packages/di-framework-events/src/adapters/kafka.ts
@@ -1,0 +1,235 @@
+import { JsonCodec, stringFromCodecOutput } from '../codec.ts';
+import type { Ack, EventCodec, EventMessage, EventTransport, Unsubscribe } from '../types.ts';
+
+export interface KafkaTransportOptions {
+  /** KafkaJS client config (brokers, clientId, ssl, sasl, …). */
+  client: {
+    clientId: string;
+    brokers: string[];
+    [key: string]: unknown;
+  };
+  /** Consumer group id. Required for subscribe(). */
+  groupId?: string;
+  /** Topic → fromBeginning override. Defaults to false. */
+  fromBeginning?: boolean;
+  codec?: EventCodec;
+  /** Injected KafkaJS module for tests. Defaults to dynamic `import('kafkajs')`. */
+  kafkajs?: KafkaJsLike;
+}
+
+interface KafkaProducer {
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  send(record: {
+    topic: string;
+    messages: Array<{
+      key?: string | null;
+      value: string | Buffer | null;
+      headers?: Record<string, string>;
+    }>;
+  }): Promise<unknown>;
+}
+
+interface KafkaConsumer {
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  subscribe(opts: { topic: string; fromBeginning?: boolean }): Promise<void>;
+  run(config: {
+    eachMessage: (payload: {
+      topic: string;
+      partition: number;
+      message: {
+        key: Buffer | null;
+        value: Buffer | null;
+        headers?: Record<string, Buffer | string | undefined>;
+        timestamp: string;
+      };
+    }) => Promise<void>;
+  }): Promise<void>;
+}
+
+interface KafkaClient {
+  producer(config?: unknown): KafkaProducer;
+  consumer(config: { groupId: string }): KafkaConsumer;
+}
+
+/** Minimal KafkaJS surface we depend on (keeps types soft without a hard dep). */
+export interface KafkaJsLike {
+  Kafka: new (config: Record<string, unknown>) => KafkaClient;
+}
+
+/**
+ * Kafka transport backed by optional peer dependency `kafkajs`.
+ * Topic creation is left to operators.
+ */
+export function kafkaTransport(options: KafkaTransportOptions): EventTransport {
+  const codec = options.codec ?? JsonCodec;
+  let kafkaModule: KafkaJsLike | undefined = options.kafkajs;
+  let producer: KafkaProducer | undefined;
+  let consumer: KafkaConsumer | undefined;
+  let started = false;
+  const pendingSubscribes: Array<{
+    topic: string;
+    handler: (msg: EventMessage, ack: Ack) => Promise<void>;
+  }> = [];
+  const handlers = new Map<string, Set<(msg: EventMessage, ack: Ack) => Promise<void>>>();
+
+  async function loadKafka(): Promise<KafkaJsLike> {
+    if (kafkaModule) return kafkaModule;
+    try {
+      kafkaModule = (await import('kafkajs')) as unknown as KafkaJsLike;
+      return kafkaModule;
+    } catch (err) {
+      throw new Error(
+        '@di-framework/events/kafka requires the optional peer dependency "kafkajs". Install it with: bun add kafkajs',
+        { cause: err },
+      );
+    }
+  }
+
+  return {
+    async start() {
+      if (started) return;
+      const mod = await loadKafka();
+      const kafka = new mod.Kafka(options.client);
+      producer = kafka.producer();
+      await producer.connect();
+
+      if (options.groupId) {
+        consumer = kafka.consumer({ groupId: options.groupId });
+        await consumer.connect();
+
+        for (const pending of pendingSubscribes) {
+          let set = handlers.get(pending.topic);
+          if (!set) {
+            set = new Set();
+            handlers.set(pending.topic, set);
+          }
+          set.add(pending.handler);
+          await consumer.subscribe({
+            topic: pending.topic,
+            fromBeginning: options.fromBeginning ?? false,
+          });
+        }
+        pendingSubscribes.length = 0;
+
+        await consumer.run({
+          eachMessage: async ({ topic, message }) => {
+            const set = handlers.get(topic);
+            if (!set || set.size === 0) return;
+
+            const headers: Record<string, string> = {};
+            if (message.headers) {
+              for (const [k, v] of Object.entries(message.headers)) {
+                if (v == null) continue;
+                headers[k] = typeof v === 'string' ? v : Buffer.from(v as Buffer).toString('utf8');
+              }
+            }
+
+            const raw = message.value
+              ? typeof message.value === 'string'
+                ? message.value
+                : new Uint8Array(message.value)
+              : '';
+            const payload = codec.decode(raw || 'null');
+
+            const eventMessage: EventMessage = {
+              id: headers['x-event-id'] ?? crypto.randomUUID(),
+              topic,
+              key: message.key ? message.key.toString('utf8') : undefined,
+              headers,
+              payload,
+              timestamp: message.timestamp ? Number(message.timestamp) : Date.now(),
+            };
+
+            for (const handler of set) {
+              let settled = false;
+              const ack: Ack = {
+                ack() {
+                  settled = true;
+                },
+                nack() {
+                  settled = true;
+                  throw new Error('nack');
+                },
+              };
+              try {
+                await handler(eventMessage, ack);
+                if (!settled) ack.ack();
+              } catch (err) {
+                if (!settled) throw err;
+              }
+            }
+          },
+        });
+      }
+
+      started = true;
+    },
+
+    async stop() {
+      await consumer?.disconnect?.();
+      await producer?.disconnect?.();
+      consumer = undefined;
+      producer = undefined;
+      handlers.clear();
+      started = false;
+    },
+
+    async publish(message: EventMessage) {
+      if (!started || !producer) {
+        throw new Error('Kafka transport is not started. Call start() before publish().');
+      }
+      const value = stringFromCodecOutput(codec.encode(message.payload));
+      const headers: Record<string, string> = {
+        ...(message.headers ?? {}),
+        'x-event-id': message.id,
+      };
+      await producer.send({
+        topic: message.topic,
+        messages: [
+          {
+            key: message.key ?? null,
+            value,
+            headers,
+          },
+        ],
+      });
+    },
+
+    async subscribe(
+      topic: string,
+      handler: (msg: EventMessage, ack: Ack) => Promise<void>,
+    ): Promise<Unsubscribe> {
+      if (!options.groupId) {
+        throw new Error('kafkaTransport requires groupId to subscribe');
+      }
+
+      if (!started) {
+        pendingSubscribes.push({ topic, handler });
+        return async () => {
+          const idx = pendingSubscribes.findIndex(
+            (p) => p.topic === topic && p.handler === handler,
+          );
+          if (idx >= 0) pendingSubscribes.splice(idx, 1);
+          handlers.get(topic)?.delete(handler);
+        };
+      }
+
+      let set = handlers.get(topic);
+      if (!set) {
+        set = new Set();
+        handlers.set(topic, set);
+      }
+      set.add(handler);
+      await consumer?.subscribe({
+        topic,
+        fromBeginning: options.fromBeginning ?? false,
+      });
+
+      return async () => {
+        handlers.get(topic)?.delete(handler);
+      };
+    },
+  };
+}

--- a/packages/di-framework-events/src/adapters/memory.ts
+++ b/packages/di-framework-events/src/adapters/memory.ts
@@ -1,0 +1,78 @@
+import type { Ack, EventMessage, EventTransport, Unsubscribe } from '../types.ts';
+
+type Handler = (msg: EventMessage, ack: Ack) => Promise<void>;
+
+export interface MemoryTransportOptions {
+  /** Simulate async delivery delay in ms. Defaults to 0. */
+  delayMs?: number;
+}
+
+/**
+ * In-process transport for tests and local development.
+ * Messages are delivered to all active subscribers of a topic.
+ */
+export function memoryTransport(options: MemoryTransportOptions = {}): EventTransport {
+  const delayMs = options.delayMs ?? 0;
+  const subscribers = new Map<string, Set<Handler>>();
+  let started = false;
+  const queue: EventMessage[] = [];
+
+  const deliver = async (message: EventMessage): Promise<void> => {
+    const handlers = subscribers.get(message.topic);
+    if (!handlers || handlers.size === 0) return;
+
+    if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
+
+    await Promise.all(
+      [...handlers].map(async (handler) => {
+        let settled = false;
+        const ack: Ack = {
+          ack() {
+            settled = true;
+          },
+          nack() {
+            settled = true;
+          },
+        };
+        try {
+          await handler(message, ack);
+          if (!settled) ack.ack();
+        } catch {
+          if (!settled) ack.nack({ requeue: false });
+        }
+      }),
+    );
+  };
+
+  return {
+    async start() {
+      started = true;
+      while (queue.length > 0) {
+        const msg = queue.shift();
+        if (msg) await deliver(msg);
+      }
+    },
+
+    async stop() {
+      started = false;
+      subscribers.clear();
+      queue.length = 0;
+    },
+
+    async publish(message: EventMessage) {
+      if (!started) {
+        queue.push(message);
+        return;
+      }
+      await deliver(message);
+    },
+
+    async subscribe(topic: string, handler: Handler): Promise<Unsubscribe> {
+      if (!subscribers.has(topic)) subscribers.set(topic, new Set());
+      subscribers.get(topic)?.add(handler);
+      return () => {
+        subscribers.get(topic)?.delete(handler);
+      };
+    },
+  };
+}

--- a/packages/di-framework-events/src/adapters/nats.ts
+++ b/packages/di-framework-events/src/adapters/nats.ts
@@ -1,0 +1,228 @@
+import { JsonCodec, stringFromCodecOutput } from '../codec.ts';
+import type { Ack, EventCodec, EventMessage, EventTransport, Unsubscribe } from '../types.ts';
+
+export interface NatsTransportOptions {
+  /** NATS server URL(s). Defaults to `nats://127.0.0.1:4222`. */
+  servers?: string | string[];
+  /** Use JetStream for durable publish/subscribe when true. */
+  jetstream?: boolean;
+  /** JetStream durable consumer name (required when jetstream + subscribe). */
+  durable?: string;
+  /** Extra connect options forwarded to `nats.connect`. */
+  connect?: Record<string, unknown>;
+  codec?: EventCodec;
+  /** Injected nats module for tests. */
+  nats?: NatsLike;
+}
+
+export interface NatsLike {
+  connect(opts?: Record<string, unknown>): Promise<NatsConnectionLike>;
+  StringCodec?: () => { encode(s: string): Uint8Array; decode(b: Uint8Array): string };
+  headers?: () => NatsHeadersLike;
+}
+
+export interface NatsHeadersLike {
+  set(key: string, value: string): void;
+  keys(): Iterable<string>;
+  get(key: string): string;
+}
+
+export interface NatsConnectionLike {
+  publish(subject: string, data?: Uint8Array, opts?: { headers?: NatsHeadersLike }): void;
+  subscribe(
+    subject: string,
+    opts?: { callback?: (err: Error | null, msg: NatsMsgLike) => void },
+  ): NatsSubscriptionLike;
+  jetstream?: () => NatsJetStreamLike;
+  jetstreamManager?: () => Promise<unknown>;
+  drain(): Promise<void>;
+  close(): Promise<void>;
+  isClosed(): boolean;
+}
+
+export interface NatsMsgLike {
+  subject: string;
+  data: Uint8Array;
+  headers?: NatsHeadersLike;
+  respond?: (data?: Uint8Array) => boolean;
+  ack?: () => void;
+  nak?: (millis?: number) => void;
+}
+
+export interface NatsSubscriptionLike {
+  unsubscribe(): void;
+  getSubject?(): string;
+  [Symbol.asyncIterator]?: () => AsyncIterator<NatsMsgLike>;
+}
+
+export interface NatsJetStreamLike {
+  publish(
+    subject: string,
+    data: Uint8Array,
+    opts?: { headers?: NatsHeadersLike },
+  ): Promise<unknown>;
+  subscribe(
+    subject: string,
+    opts?: { config?: { durable_name?: string } },
+  ): Promise<AsyncIterable<NatsMsgLike> & { unsubscribe(): void }>;
+}
+
+/**
+ * NATS transport backed by optional peer dependency `nats`.
+ * Set `jetstream: true` for durable streams; otherwise uses core NATS pub/sub.
+ */
+export function natsTransport(options: NatsTransportOptions = {}): EventTransport {
+  const codec = options.codec ?? JsonCodec;
+  let natsModule: NatsLike | undefined = options.nats;
+  let nc: NatsConnectionLike | undefined;
+  let started = false;
+  const unsubs: Array<() => void> = [];
+
+  async function loadNats(): Promise<NatsLike> {
+    if (natsModule) return natsModule;
+    try {
+      natsModule = (await import('nats')) as unknown as NatsLike;
+      return natsModule;
+    } catch (err) {
+      throw new Error(
+        '@di-framework/events/nats requires the optional peer dependency "nats". Install it with: bun add nats',
+        { cause: err },
+      );
+    }
+  }
+
+  function encodePayload(payload: unknown): Uint8Array {
+    return new TextEncoder().encode(stringFromCodecOutput(codec.encode(payload)));
+  }
+
+  function decodePayload(data: Uint8Array): unknown {
+    return codec.decode(data);
+  }
+
+  function headersToRecord(h?: NatsHeadersLike): Record<string, string> | undefined {
+    if (!h) return undefined;
+    const out: Record<string, string> = {};
+    for (const key of h.keys()) {
+      out[key] = h.get(key);
+    }
+    return out;
+  }
+
+  return {
+    async start() {
+      if (started) return;
+      const mod = await loadNats();
+      nc = await mod.connect({
+        servers: options.servers ?? 'nats://127.0.0.1:4222',
+        ...(options.connect ?? {}),
+      });
+      started = true;
+    },
+
+    async stop() {
+      for (const u of unsubs) u();
+      unsubs.length = 0;
+      if (nc && !nc.isClosed()) {
+        await nc.drain();
+        await nc.close();
+      }
+      nc = undefined;
+      started = false;
+    },
+
+    async publish(message: EventMessage) {
+      if (!started || !nc) {
+        throw new Error('NATS transport is not started. Call start() before publish().');
+      }
+      const data = encodePayload(message.payload);
+      const mod = await loadNats();
+      let hdrs: NatsHeadersLike | undefined;
+      if (mod.headers) {
+        hdrs = mod.headers();
+        hdrs.set('x-event-id', message.id);
+        if (message.key) hdrs.set('x-event-key', message.key);
+        if (message.headers) {
+          for (const [k, v] of Object.entries(message.headers)) hdrs.set(k, v);
+        }
+      }
+
+      if (options.jetstream) {
+        const js = nc.jetstream?.();
+        if (!js) throw new Error('Connected NATS server does not expose JetStream');
+        await js.publish(message.topic, data, hdrs ? { headers: hdrs } : undefined);
+      } else {
+        nc.publish(message.topic, data, hdrs ? { headers: hdrs } : undefined);
+      }
+    },
+
+    async subscribe(
+      topic: string,
+      handler: (msg: EventMessage, ack: Ack) => Promise<void>,
+    ): Promise<Unsubscribe> {
+      if (!started || !nc) {
+        throw new Error('NATS transport is not started. Call start() before subscribe().');
+      }
+
+      const handleMsg = async (m: NatsMsgLike) => {
+        const headers = headersToRecord(m.headers);
+        const eventMessage: EventMessage = {
+          id: headers?.['x-event-id'] ?? crypto.randomUUID(),
+          topic: m.subject,
+          key: headers?.['x-event-key'],
+          headers,
+          payload: decodePayload(m.data),
+          timestamp: Date.now(),
+        };
+
+        let settled = false;
+        const ack: Ack = {
+          ack() {
+            settled = true;
+            m.ack?.();
+          },
+          nack(opts) {
+            settled = true;
+            if (m.nak) m.nak(opts?.requeue === false ? 0 : undefined);
+          },
+        };
+
+        try {
+          await handler(eventMessage, ack);
+          if (!settled) ack.ack();
+        } catch {
+          if (!settled) ack.nack({ requeue: true });
+        }
+      };
+
+      if (options.jetstream) {
+        const js = nc.jetstream?.();
+        if (!js) throw new Error('Connected NATS server does not expose JetStream');
+        const sub = await js.subscribe(topic, {
+          config: options.durable ? { durable_name: options.durable } : undefined,
+        });
+        const iter = (async () => {
+          for await (const m of sub) {
+            await handleMsg(m);
+          }
+        })();
+        void iter;
+        const unsub = () => sub.unsubscribe();
+        unsubs.push(unsub);
+        return async () => unsub();
+      }
+
+      const sub = nc.subscribe(topic, {
+        callback: (err, msg) => {
+          if (err) {
+            console.error('[natsTransport] subscription error', err);
+            return;
+          }
+          void handleMsg(msg);
+        },
+      });
+      const unsub = () => sub.unsubscribe();
+      unsubs.push(unsub);
+      return async () => unsub();
+    },
+  };
+}

--- a/packages/di-framework-events/src/bridge.ts
+++ b/packages/di-framework-events/src/bridge.ts
@@ -1,0 +1,152 @@
+import { useContainer } from '@di-framework/core/container';
+import type {
+  CreateEventBridgeOptions,
+  EventBridgeContainer,
+  EventBridgeHandle,
+  EventMessage,
+  InboundRoute,
+  OutboundRoute,
+} from './types.ts';
+
+/**
+ * Unwrap the core `@Publisher` envelope to its `result`, matching GraphQL
+ * subscription behaviour. Non-envelope payloads pass through unchanged.
+ */
+export function unwrapPublisherPayload(payload: unknown): unknown {
+  if (
+    payload &&
+    typeof payload === 'object' &&
+    'className' in payload &&
+    'methodName' in payload &&
+    'result' in payload
+  ) {
+    return (payload as { result: unknown }).result;
+  }
+  return payload;
+}
+
+function newMessageId(): string {
+  return crypto.randomUUID();
+}
+
+/**
+ * Bridge a DI container event bus to an {@link EventTransport}.
+ *
+ * Outbound: container emit → topic publish.
+ * Inbound: broker message → container emit (feeds `@Subscriber` / GraphQL).
+ *
+ * Outbound publishing is suppressed while handling inbound emits so a
+ * single-process echo of the same event/topic pair cannot loop forever.
+ */
+export function createEventBridge(options: CreateEventBridgeOptions): EventBridgeHandle {
+  const container: EventBridgeContainer = options.container ?? useContainer();
+  const transport = options.transport;
+  const outbound = options.routes.outbound ?? [];
+  const inbound = options.routes.inbound ?? [];
+  const onError =
+    options.onError ??
+    ((ctx) => {
+      console.error(`[EventBridge] ${ctx.direction} ${ctx.event}↔${ctx.topic} failed`, ctx.error);
+    });
+  void options.codec; // reserved for bridge-level encoding hooks; adapters use their own codec
+
+  let started = false;
+  let inboundDepth = 0;
+  const unsubscribers: Array<() => void | Promise<void>> = [];
+  let clearUnsub: (() => void) | undefined;
+
+  const publishOutbound = async (route: OutboundRoute, payload: unknown) => {
+    if (inboundDepth > 0) return;
+    if (route.filter && !route.filter(payload)) return;
+
+    const mapped = route.map ? route.map(payload) : unwrapPublisherPayload(payload);
+    const key = route.key?.(payload);
+    const headers = route.headers?.(payload);
+
+    const message: EventMessage = {
+      id: newMessageId(),
+      topic: route.topic,
+      key,
+      headers,
+      payload: mapped,
+      timestamp: Date.now(),
+    };
+
+    try {
+      await transport.publish(message);
+    } catch (error) {
+      onError({ direction: 'outbound', topic: route.topic, event: route.event, error });
+    }
+  };
+
+  const attachOutbound = (route: OutboundRoute) => {
+    const off = container.on(route.event, (payload: unknown) => {
+      void publishOutbound(route, payload);
+    });
+    unsubscribers.push(off);
+  };
+
+  const attachInbound = async (route: InboundRoute) => {
+    const unsub = await transport.subscribe(route.topic, async (msg, ack) => {
+      try {
+        if (route.filter && !route.filter(msg.payload, msg)) {
+          await ack.ack();
+          return;
+        }
+        const mapped = route.map ? route.map(msg.payload, msg) : msg.payload;
+        inboundDepth += 1;
+        try {
+          container.emit(route.event, mapped);
+        } finally {
+          inboundDepth -= 1;
+        }
+        await ack.ack();
+      } catch (error) {
+        onError({ direction: 'inbound', topic: route.topic, event: route.event, error });
+        try {
+          await ack.nack({ requeue: false });
+        } catch (nackErr) {
+          onError({ direction: 'inbound', topic: route.topic, event: route.event, error: nackErr });
+        }
+      }
+    });
+    unsubscribers.push(unsub);
+  };
+
+  const handle: EventBridgeHandle = {
+    get started() {
+      return started;
+    },
+
+    async start() {
+      if (started) return;
+      await transport.start?.();
+
+      for (const route of outbound) attachOutbound(route);
+      for (const route of inbound) await attachInbound(route);
+
+      // Tear down when the container is cleared (same lifecycle idea as @Cron).
+      clearUnsub = container.on('cleared', () => {
+        void handle.stop();
+      });
+
+      started = true;
+    },
+
+    async stop() {
+      if (!started && unsubscribers.length === 0) return;
+      clearUnsub?.();
+      clearUnsub = undefined;
+
+      const pending = [...unsubscribers];
+      unsubscribers.length = 0;
+      for (const unsub of pending) {
+        await unsub();
+      }
+      await transport.stop?.();
+      started = false;
+    },
+  };
+
+  return handle;
+}

--- a/packages/di-framework-events/src/codec.ts
+++ b/packages/di-framework-events/src/codec.ts
@@ -1,0 +1,23 @@
+import type { EventCodec } from './types.ts';
+
+/** UTF-8 JSON codec — the default for all transports. */
+export const JsonCodec: EventCodec = {
+  encode(payload: unknown): string {
+    return JSON.stringify(payload === undefined ? null : payload);
+  },
+  decode(data: Uint8Array | string): unknown {
+    const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+    if (text.length === 0) return null;
+    return JSON.parse(text);
+  },
+};
+
+export function bytesFromCodecOutput(encoded: Uint8Array | string): Uint8Array {
+  if (typeof encoded === 'string') return new TextEncoder().encode(encoded);
+  return encoded;
+}
+
+export function stringFromCodecOutput(encoded: Uint8Array | string): string {
+  if (typeof encoded === 'string') return encoded;
+  return new TextDecoder().decode(encoded);
+}

--- a/packages/di-framework-events/src/decorators.ts
+++ b/packages/di-framework-events/src/decorators.ts
@@ -1,0 +1,247 @@
+import { useContainer } from '@di-framework/core/container';
+import { Container as ContainerDecorator } from '@di-framework/core/decorators';
+import { createEventBridge } from './bridge.ts';
+import registry, { type EventBridgeTarget } from './registry.ts';
+import type {
+  EventBridgeContainer,
+  EventBridgeDecoratorOptions,
+  EventBridgeHandle,
+  EventTransport,
+  InboundDecoratorOptions,
+  OutboundDecoratorOptions,
+} from './types.ts';
+
+const BRIDGE_HANDLE = Symbol.for('di-framework.events.bridge-handle');
+const SOURCE_KEY = '__diEventsSource';
+const PATCHED_KEY = '__diEventsBridgePatched';
+
+type Ctor = EventBridgeTarget;
+
+interface BridgeHost {
+  transport?: EventTransport;
+  $startBridge?: () => Promise<EventBridgeHandle>;
+  $stopBridge?: () => Promise<void>;
+  [BRIDGE_HANDLE]?: EventBridgeHandle;
+  [PATCHED_KEY]?: boolean;
+  [SOURCE_KEY]?: Ctor;
+}
+
+function asHost(value: unknown): BridgeHost {
+  return value as BridgeHost;
+}
+
+function asContainer(value: unknown): EventBridgeContainer {
+  return (value ?? useContainer()) as EventBridgeContainer;
+}
+
+function resolveTransport(
+  instance: BridgeHost,
+  options: EventBridgeDecoratorOptions,
+  container: EventBridgeContainer,
+): EventTransport {
+  if (typeof options.transport === 'function') return options.transport();
+  if (options.transport) return options.transport;
+
+  if (instance.transport && typeof instance.transport.publish === 'function') {
+    return instance.transport;
+  }
+
+  const token = options.transportToken ?? 'EventTransport';
+  return container.resolve?.(token) as EventTransport;
+}
+
+function attachBridgeMethods(ctor: Ctor, options: EventBridgeDecoratorOptions): void {
+  const proto = asHost(ctor.prototype);
+  if (proto[PATCHED_KEY]) return;
+  proto[PATCHED_KEY] = true;
+
+  proto.$startBridge = async function $startBridge(this: BridgeHost): Promise<EventBridgeHandle> {
+    const existing = this[BRIDGE_HANDLE];
+    if (existing?.started) return existing;
+
+    const container = asContainer(options.container);
+    const transport = resolveTransport(this, options, container);
+    const entry = registry.get(ctor);
+    const handle = createEventBridge({
+      container,
+      transport,
+      routes: {
+        outbound: entry?.outbound ?? [],
+        inbound: entry?.inbound ?? [],
+      },
+      codec: options.codec,
+      onError: options.onError,
+    });
+    await handle.start();
+    this[BRIDGE_HANDLE] = handle;
+    return handle;
+  };
+
+  proto.$stopBridge = async function $stopBridge(this: BridgeHost): Promise<void> {
+    const handle = this[BRIDGE_HANDLE];
+    if (handle) await handle.stop();
+    this[BRIDGE_HANDLE] = undefined;
+  };
+}
+
+function registerWithContainer(target: Ctor, options: EventBridgeDecoratorOptions): void {
+  ContainerDecorator({
+    singleton: options.singleton,
+    container: options.container as never,
+  })(target);
+}
+
+/**
+ * Marks a class as an event bridge definition and registers it with the DI container.
+ * Collect `@Outbound` / `@Inbound` routes from the class. Call `$startBridge()` on the
+ * resolved instance, or `startEventBridges()`, to connect the transport.
+ *
+ * When `autoStart` is true (default), the bridge starts on the next microtask after
+ * the instance is constructed (via a subclass wrapper).
+ */
+export function EventBridge(options: EventBridgeDecoratorOptions = {}) {
+  return <T extends Ctor>(target: T): T => {
+    registry.addTarget(target);
+    attachBridgeMethods(target, options);
+
+    const autoStart = options.autoStart !== false;
+
+    if (!autoStart) {
+      registerWithContainer(target, options);
+      return target;
+    }
+
+    // Subclass so construction can kick off the bridge without hooking Container internals.
+    const BridgeClass = class extends target {
+      // biome-ignore lint/suspicious/noExplicitAny: mirrors decorated class arity
+      constructor(...args: any[]) {
+        super(...args);
+        queueMicrotask(() => {
+          void asHost(this)
+            .$startBridge?.()
+            .catch((err: unknown) => {
+              console.error(`[EventBridge] failed to start ${target.name}`, err);
+            });
+        });
+      }
+    } as T;
+
+    Object.defineProperty(BridgeClass, 'name', { value: target.name });
+    attachBridgeMethods(BridgeClass, options);
+
+    // Point registry entries at the class the container will resolve.
+    const prior = registry.get(target);
+    const slot = registry.addTarget(BridgeClass);
+    if (prior) {
+      slot.outbound.push(...prior.outbound);
+      slot.inbound.push(...prior.inbound);
+    }
+
+    // Keep original key too so startEventBridges(registry) can find either.
+    asHost(BridgeClass)[SOURCE_KEY] = target;
+
+    registerWithContainer(BridgeClass, options);
+
+    return BridgeClass;
+  };
+}
+
+function ctorFromDecoratorTarget(target: object | Ctor): Ctor {
+  if (typeof target === 'function') return target as Ctor;
+  return (target as { constructor: Ctor }).constructor;
+}
+
+/**
+ * Declares an outbound route: container `event` → broker `topic`.
+ * May decorate a property or method (body unused; options carry map/key/filter).
+ */
+export function Outbound(event: string, options: OutboundDecoratorOptions) {
+  return (target: object, _propertyKey: string | symbol) => {
+    registry.addOutbound(ctorFromDecoratorTarget(target), {
+      event,
+      topic: options.topic,
+      map: options.map,
+      key: options.key,
+      filter: options.filter,
+      headers: options.headers,
+    });
+  };
+}
+
+/**
+ * Declares an inbound route: broker `topic` → container `event`.
+ */
+export function Inbound(options: InboundDecoratorOptions) {
+  return (target: object, _propertyKey: string | symbol) => {
+    registry.addInbound(ctorFromDecoratorTarget(target), {
+      topic: options.topic,
+      event: options.event,
+      map: options.map,
+      filter: options.filter,
+    });
+  };
+}
+
+/**
+ * Resolve every `@EventBridge` class and start its transport bridge.
+ * Prefer this in bootstrap when `autoStart` was disabled or after `container.clear()`.
+ */
+export async function startEventBridges(
+  options: {
+    container?: EventBridgeContainer;
+    transport?: EventTransport | (() => EventTransport);
+  } = {},
+): Promise<EventBridgeHandle[]> {
+  const container = options.container ?? useContainer();
+  const handles: EventBridgeHandle[] = [];
+  const seen = new Set<Ctor>();
+
+  for (const entry of registry.getAll()) {
+    const source = asHost(entry.target)[SOURCE_KEY];
+    if (source && seen.has(source)) continue;
+    if (seen.has(entry.target)) continue;
+    seen.add(entry.target);
+    if (source) seen.add(source);
+
+    // Prefer the container-registered subclass when present.
+    let ctor = entry.target;
+    if (!container.has?.(ctor) && source && container.has?.(source)) {
+      ctor = source;
+    } else if (source) {
+      for (const other of registry.getAll()) {
+        if (asHost(other.target)[SOURCE_KEY] === source || other.target === entry.target) {
+          if (container.has?.(other.target)) {
+            ctor = other.target;
+            break;
+          }
+        }
+      }
+    }
+
+    const resolvable = container.has?.(ctor) ? ctor : entry.target;
+    if (!container.has?.(resolvable)) {
+      container.register?.(resolvable, { singleton: true });
+    }
+
+    const instance = asHost(container.resolve?.(resolvable));
+
+    if (typeof instance.$startBridge === 'function') {
+      if (options.transport) {
+        const transport =
+          typeof options.transport === 'function' ? options.transport() : options.transport;
+        const handle = createEventBridge({
+          container,
+          transport,
+          routes: { outbound: entry.outbound, inbound: entry.inbound },
+        });
+        await handle.start();
+        instance[BRIDGE_HANDLE] = handle;
+        handles.push(handle);
+      } else {
+        handles.push(await instance.$startBridge());
+      }
+    }
+  }
+
+  return handles;
+}

--- a/packages/di-framework-events/src/registry.ts
+++ b/packages/di-framework-events/src/registry.ts
@@ -1,0 +1,70 @@
+import type { InboundRoute, OutboundRoute } from './types.ts';
+
+// Decorator targets have heterogeneous constructors; matches GraphQL `Ctor`.
+// biome-ignore lint/suspicious/noExplicitAny: see above
+export type EventBridgeTarget = new (...args: any[]) => any;
+
+export interface RegisteredEventBridge {
+  target: EventBridgeTarget;
+  outbound: OutboundRoute[];
+  inbound: InboundRoute[];
+}
+
+/**
+ * Collects classes decorated with `@EventBridge` and their `@Outbound` /
+ * `@Inbound` routes. Import-time registration, same idea as HTTP/GraphQL registries.
+ */
+export class EventBridgeRegistry {
+  private targets = new Map<EventBridgeTarget, RegisteredEventBridge>();
+
+  addTarget(target: EventBridgeTarget): RegisteredEventBridge {
+    let entry = this.targets.get(target);
+    if (!entry) {
+      entry = { target, outbound: [], inbound: [] };
+      this.targets.set(target, entry);
+    }
+    return entry;
+  }
+
+  addOutbound(target: EventBridgeTarget, route: OutboundRoute): void {
+    this.addTarget(target).outbound.push(route);
+  }
+
+  addInbound(target: EventBridgeTarget, route: InboundRoute): void {
+    this.addTarget(target).inbound.push(route);
+  }
+
+  getTargets(): EventBridgeTarget[] {
+    return [...this.targets.keys()];
+  }
+
+  get(target: EventBridgeTarget): RegisteredEventBridge | undefined {
+    return this.targets.get(target);
+  }
+
+  getAll(): RegisteredEventBridge[] {
+    return [...this.targets.values()];
+  }
+
+  clear(): void {
+    this.targets.clear();
+  }
+}
+
+const globalRegistry = new EventBridgeRegistry();
+
+export function getRegistry(): EventBridgeRegistry {
+  return globalRegistry;
+}
+
+export function setRegistry(registry: EventBridgeRegistry): void {
+  // Replace contents of the shared singleton so existing imports keep working.
+  globalRegistry.clear();
+  for (const entry of registry.getAll()) {
+    const slot = globalRegistry.addTarget(entry.target);
+    slot.outbound.push(...entry.outbound);
+    slot.inbound.push(...entry.inbound);
+  }
+}
+
+export default globalRegistry;

--- a/packages/di-framework-events/src/types.ts
+++ b/packages/di-framework-events/src/types.ts
@@ -1,0 +1,131 @@
+/**
+ * Wire-format message exchanged with an {@link EventTransport}.
+ */
+export interface EventMessage<T = unknown> {
+  id: string;
+  topic: string;
+  key?: string;
+  headers?: Record<string, string>;
+  payload: T;
+  timestamp?: number;
+}
+
+/** Acknowledgement handle passed to inbound transport handlers. */
+export interface Ack {
+  ack(): Promise<void> | void;
+  nack(options?: { requeue?: boolean }): Promise<void> | void;
+}
+
+export type Unsubscribe = () => void | Promise<void>;
+
+/**
+ * Broker-agnostic transport. Kafka, NATS, and in-memory adapters implement this.
+ * Delivery is at-least-once; adapters document durability specifics.
+ */
+export interface EventTransport {
+  publish(message: EventMessage): Promise<void>;
+  subscribe(
+    topic: string,
+    handler: (msg: EventMessage, ack: Ack) => Promise<void>,
+  ): Promise<Unsubscribe>;
+  start?(): Promise<void>;
+  stop?(): Promise<void>;
+}
+
+/** Encode / decode payloads for the wire. */
+export interface EventCodec {
+  encode(payload: unknown): Uint8Array | string;
+  decode(data: Uint8Array | string): unknown;
+}
+
+export type OutboundMapFn = (payload: unknown) => unknown;
+export type OutboundKeyFn = (payload: unknown) => string | undefined;
+export type OutboundFilterFn = (payload: unknown) => boolean;
+export type InboundMapFn = (payload: unknown, message: EventMessage) => unknown;
+export type InboundFilterFn = (payload: unknown, message: EventMessage) => boolean;
+
+export interface OutboundRoute {
+  event: string;
+  topic: string;
+  /** Defaults to unwrapping the @Publisher envelope (`result`). */
+  map?: OutboundMapFn;
+  key?: OutboundKeyFn;
+  filter?: OutboundFilterFn;
+  headers?: (payload: unknown) => Record<string, string> | undefined;
+}
+
+export interface InboundRoute {
+  topic: string;
+  event: string;
+  map?: InboundMapFn;
+  filter?: InboundFilterFn;
+}
+
+export interface EventBridgeRoutes {
+  outbound?: OutboundRoute[];
+  inbound?: InboundRoute[];
+}
+
+export type EventBridgeErrorContext = {
+  direction: 'inbound' | 'outbound';
+  topic: string;
+  event: string;
+  error: unknown;
+};
+
+export interface CreateEventBridgeOptions {
+  /** DI container whose bus is bridged. Defaults to `useContainer()`. */
+  container?: EventBridgeContainer;
+  transport: EventTransport;
+  routes: EventBridgeRoutes;
+  codec?: EventCodec;
+  /** Called when publish/consume handling fails. Defaults to console.error + nack. */
+  onError?: (ctx: EventBridgeErrorContext) => void;
+}
+
+/** Minimal container surface used by the bridge (avoids tight coupling). */
+export interface EventBridgeContainer {
+  on(event: string, listener: (payload: unknown) => void): () => void;
+  emit(event: string, payload: unknown): void;
+  clear?: () => void;
+  has?(serviceClass: unknown): boolean;
+  register?(serviceClass: unknown, options?: { singleton?: boolean }): void;
+  resolve?(serviceClass: unknown): unknown;
+}
+
+export interface EventBridgeHandle {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  readonly started: boolean;
+}
+
+export interface OutboundDecoratorOptions {
+  topic: string;
+  map?: OutboundMapFn;
+  key?: OutboundKeyFn;
+  filter?: OutboundFilterFn;
+  headers?: (payload: unknown) => Record<string, string> | undefined;
+}
+
+export interface InboundDecoratorOptions {
+  topic: string;
+  event: string;
+  map?: InboundMapFn;
+  filter?: InboundFilterFn;
+}
+
+export type EventTransportConstructor = abstract new () => EventTransport;
+
+export interface EventBridgeDecoratorOptions {
+  singleton?: boolean;
+  /** DI container instance. Defaults to the global container. */
+  container?: unknown;
+  /** Transport instance or factory. Resolved from DI token when omitted. */
+  transport?: EventTransport | (() => EventTransport);
+  /** DI token used when `transport` is omitted. Defaults to `'EventTransport'`. */
+  transportToken?: string | EventTransportConstructor;
+  codec?: EventCodec;
+  onError?: (ctx: EventBridgeErrorContext) => void;
+  /** Start the bridge when the class is resolved. Defaults to `true`. */
+  autoStart?: boolean;
+}

--- a/packages/di-framework-events/tests/bridge.test.ts
+++ b/packages/di-framework-events/tests/bridge.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { useContainer } from '@di-framework/core/container';
+import { Container, Publisher, Subscriber } from '@di-framework/core/decorators';
+import { memoryTransport } from '../src/adapters/memory.ts';
+import { createEventBridge, unwrapPublisherPayload } from '../src/bridge.ts';
+import { JsonCodec } from '../src/codec.ts';
+import type { Ack, EventMessage } from '../src/types.ts';
+
+beforeEach(() => {
+  useContainer().clear();
+});
+
+describe('unwrapPublisherPayload', () => {
+  it('unwraps @Publisher envelopes to result', () => {
+    expect(
+      unwrapPublisherPayload({
+        className: 'S',
+        methodName: 'm',
+        result: { id: 1 },
+      }),
+    ).toEqual({ id: 1 });
+  });
+
+  it('passes through plain payloads', () => {
+    expect(unwrapPublisherPayload({ id: 2 })).toEqual({ id: 2 });
+    expect(unwrapPublisherPayload('x')).toBe('x');
+  });
+});
+
+describe('JsonCodec', () => {
+  it('round-trips values', () => {
+    expect(JsonCodec.decode(JsonCodec.encode({ a: 1 }))).toEqual({ a: 1 });
+    expect(JsonCodec.decode(JsonCodec.encode(null))).toBeNull();
+  });
+});
+
+describe('createEventBridge + memoryTransport', () => {
+  it('publishes outbound container events to the transport topic', async () => {
+    const transport = memoryTransport();
+    const seen: unknown[] = [];
+
+    await transport.start?.();
+    await transport.subscribe('orders', async (msg, ack) => {
+      seen.push(msg.payload);
+      await ack.ack();
+    });
+
+    const bridge = createEventBridge({
+      transport,
+      routes: {
+        outbound: [{ event: 'order.placed', topic: 'orders' }],
+      },
+    });
+    await bridge.start();
+
+    useContainer().emit('order.placed', {
+      className: 'OrderService',
+      methodName: 'place',
+      result: { id: 'o1' },
+    });
+
+    // outbound publish is async
+    await Bun.sleep(10);
+
+    expect(seen).toEqual([{ id: 'o1' }]);
+    await bridge.stop();
+  });
+
+  it('emits inbound transport messages onto the container bus', async () => {
+    const transport = memoryTransport();
+    const received: unknown[] = [];
+
+    useContainer().on('payment.captured', (payload) => {
+      received.push(payload);
+    });
+
+    const bridge = createEventBridge({
+      transport,
+      routes: {
+        inbound: [{ topic: 'payments', event: 'payment.captured' }],
+      },
+    });
+    await bridge.start();
+
+    await transport.publish({
+      id: '1',
+      topic: 'payments',
+      payload: { amount: 42 },
+    });
+
+    await Bun.sleep(10);
+    expect(received).toEqual([{ amount: 42 }]);
+    await bridge.stop();
+  });
+
+  it('does not loop when outbound and inbound share the same event/topic', async () => {
+    const transport = memoryTransport();
+    let publishes = 0;
+
+    const counting = {
+      ...transport,
+      async publish(msg: EventMessage) {
+        publishes += 1;
+        return transport.publish(msg);
+      },
+      async subscribe(topic: string, handler: (msg: EventMessage, ack: Ack) => Promise<void>) {
+        return transport.subscribe(topic, handler);
+      },
+      start: () => transport.start?.() ?? Promise.resolve(),
+      stop: () => transport.stop?.() ?? Promise.resolve(),
+    };
+
+    const bridge = createEventBridge({
+      transport: counting,
+      routes: {
+        outbound: [{ event: 'echo', topic: 'echo' }],
+        inbound: [{ topic: 'echo', event: 'echo' }],
+      },
+    });
+    await bridge.start();
+
+    useContainer().emit('echo', { className: 'T', methodName: 'm', result: { n: 1 } });
+    await Bun.sleep(20);
+
+    expect(publishes).toBe(1);
+    await bridge.stop();
+  });
+
+  it('stops on container.clear()', async () => {
+    const transport = memoryTransport();
+    const bridge = createEventBridge({
+      transport,
+      routes: { outbound: [{ event: 'x', topic: 'x' }] },
+    });
+    await bridge.start();
+    expect(bridge.started).toBe(true);
+
+    useContainer().clear();
+    await Bun.sleep(10);
+    expect(bridge.started).toBe(false);
+  });
+
+  it('end-to-end with @Publisher and @Subscriber', async () => {
+    const received: unknown[] = [];
+
+    @Container()
+    class Audit {
+      @Subscriber('order.placed')
+      onPlaced(payload: unknown) {
+        received.push(payload);
+      }
+    }
+
+    @Container()
+    class Orders {
+      @Publisher('order.placed')
+      place(id: string) {
+        return { id };
+      }
+    }
+
+    const transport = memoryTransport();
+    const remote: unknown[] = [];
+    await transport.start?.();
+    await transport.subscribe('orders', async (msg, ack) => {
+      remote.push(msg.payload);
+      await ack.ack();
+    });
+
+    const bridge = createEventBridge({
+      transport,
+      routes: {
+        outbound: [{ event: 'order.placed', topic: 'orders' }],
+      },
+    });
+    await bridge.start();
+
+    const c = useContainer();
+    c.resolve(Audit);
+    const orders = c.resolve(Orders);
+    orders.place('o9');
+
+    await Bun.sleep(20);
+
+    expect(received.length).toBe(1);
+    expect((received[0] as { result: unknown }).result).toEqual({ id: 'o9' });
+    expect(remote).toEqual([{ id: 'o9' }]);
+
+    await bridge.stop();
+  });
+});

--- a/packages/di-framework-events/tests/decorators.test.ts
+++ b/packages/di-framework-events/tests/decorators.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { useContainer } from '@di-framework/core/container';
+import { memoryTransport } from '../src/adapters/memory.ts';
+import { EventBridge, Inbound, Outbound, startEventBridges } from '../src/decorators.ts';
+import registry from '../src/registry.ts';
+
+beforeEach(() => {
+  useContainer().clear();
+  registry.clear();
+});
+
+describe('@EventBridge / @Outbound / @Inbound', () => {
+  it('registers routes on the registry', () => {
+    @EventBridge({ transport: () => memoryTransport(), autoStart: false })
+    class OrderEvents {
+      @Outbound('order.placed', { topic: 'orders' })
+      outboundOrders!: undefined;
+
+      @Inbound({ topic: 'payments', event: 'payment.captured' })
+      inboundPayments!: undefined;
+    }
+
+    void OrderEvents;
+    const entries = registry.getAll();
+    expect(entries.length).toBeGreaterThanOrEqual(1);
+    const entry = entries.find((e) => e.outbound.length > 0 || e.inbound.length > 0);
+    expect(entry).toBeDefined();
+    expect(entry?.outbound).toEqual([
+      expect.objectContaining({ event: 'order.placed', topic: 'orders' }),
+    ]);
+    expect(entry?.inbound).toEqual([
+      expect.objectContaining({ topic: 'payments', event: 'payment.captured' }),
+    ]);
+  });
+
+  it('starts via startEventBridges and bridges outbound', async () => {
+    const transport = memoryTransport();
+    const seen: unknown[] = [];
+
+    @EventBridge({ transport: () => transport, autoStart: false })
+    class Wire {
+      @Outbound('tick', { topic: 'ticks' })
+      out!: undefined;
+    }
+
+    void Wire;
+
+    await transport.start?.();
+    await transport.subscribe('ticks', async (msg, ack) => {
+      seen.push(msg.payload);
+      ack.ack();
+    });
+
+    await startEventBridges();
+    useContainer().emit('tick', { className: 'A', methodName: 'b', result: 7 });
+    await Bun.sleep(20);
+
+    expect(seen).toEqual([7]);
+  });
+
+  it('auto-starts on resolve when autoStart is true', async () => {
+    const transport = memoryTransport();
+    const seen: unknown[] = [];
+
+    @EventBridge({ transport: () => transport })
+    class AutoWire {
+      @Outbound('ping', { topic: 'pings' })
+      out!: undefined;
+    }
+
+    await transport.start?.();
+    await transport.subscribe('pings', async (msg, ack) => {
+      seen.push(msg.payload);
+      ack.ack();
+    });
+
+    useContainer().resolve(AutoWire);
+    await Bun.sleep(30);
+
+    useContainer().emit('ping', { className: 'A', methodName: 'b', result: 'pong' });
+    await Bun.sleep(20);
+
+    expect(seen).toEqual(['pong']);
+  });
+});

--- a/packages/di-framework-events/tests/memory.test.ts
+++ b/packages/di-framework-events/tests/memory.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'bun:test';
+import { type KafkaJsLike, kafkaTransport } from '../src/adapters/kafka.ts';
+import { memoryTransport } from '../src/adapters/memory.ts';
+import { type NatsConnectionLike, natsTransport } from '../src/adapters/nats.ts';
+import type { EventMessage } from '../src/types.ts';
+
+describe('memoryTransport', () => {
+  it('delivers published messages to subscribers', async () => {
+    const transport = memoryTransport();
+    const seen: unknown[] = [];
+    await transport.start?.();
+    await transport.subscribe('t', async (msg, ack) => {
+      seen.push(msg.payload);
+      ack.ack();
+    });
+    await transport.publish({ id: '1', topic: 't', payload: { x: 1 } });
+    expect(seen).toEqual([{ x: 1 }]);
+    await transport.stop?.();
+  });
+});
+
+describe('kafkaTransport', () => {
+  it('publishes through an injected KafkaJS mock', async () => {
+    const sent: Array<{
+      topic: string;
+      messages: Array<{ key: string | null; value: string }>;
+    }> = [];
+    const producer = {
+      async connect() {},
+      async disconnect() {},
+      async send(record: {
+        topic: string;
+        messages: Array<{ key: string | null; value: string }>;
+      }) {
+        sent.push(record);
+      },
+    };
+    const mock: KafkaJsLike = {
+      Kafka: class {
+        producer() {
+          return producer;
+        }
+        consumer() {
+          return {
+            async connect() {},
+            async disconnect() {},
+            async subscribe() {},
+            async run() {},
+          };
+        }
+      },
+    };
+
+    const transport = kafkaTransport({
+      client: { clientId: 'test', brokers: ['localhost:9092'] },
+      groupId: 'g1',
+      kafkajs: mock,
+    });
+
+    await transport.start?.();
+    await transport.publish({
+      id: 'm1',
+      topic: 'orders',
+      key: 'k1',
+      payload: { ok: true },
+    });
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.topic).toBe('orders');
+    expect(sent[0]?.messages[0]?.key).toBe('k1');
+    expect(JSON.parse(sent[0]?.messages[0]?.value ?? 'null')).toEqual({ ok: true });
+    await transport.stop?.();
+  });
+
+  it('requires groupId to subscribe', async () => {
+    const transport = kafkaTransport({
+      client: { clientId: 'test', brokers: ['localhost:9092'] },
+      kafkajs: {
+        Kafka: class {
+          producer() {
+            return {
+              async connect() {},
+              async disconnect() {},
+              async send() {},
+            };
+          }
+          consumer() {
+            return {
+              async connect() {},
+              async disconnect() {},
+              async subscribe() {},
+              async run() {},
+            };
+          }
+        },
+      },
+    });
+    await expect(transport.subscribe('t', async () => {})).rejects.toThrow(/groupId/);
+  });
+});
+
+describe('natsTransport', () => {
+  it('publishes through an injected nats mock', async () => {
+    const published: Array<{ subject: string; data: Uint8Array }> = [];
+    const headersFactory = () => {
+      const map = new Map<string, string>();
+      return {
+        set(k: string, v: string) {
+          map.set(k, v);
+        },
+        keys() {
+          return map.keys();
+        },
+        get(k: string) {
+          return map.get(k) ?? '';
+        },
+      };
+    };
+
+    const nc: NatsConnectionLike = {
+      publish(subject: string, data?: Uint8Array) {
+        published.push({ subject, data: data ?? new Uint8Array() });
+      },
+      subscribe() {
+        return { unsubscribe() {} };
+      },
+      async drain() {},
+      async close() {},
+      isClosed() {
+        return false;
+      },
+    };
+
+    const transport = natsTransport({
+      nats: {
+        async connect() {
+          return nc;
+        },
+        headers: headersFactory,
+      },
+    });
+
+    await transport.start?.();
+    const msg: EventMessage = { id: '1', topic: 'events.x', payload: { a: 1 } };
+    await transport.publish(msg);
+
+    expect(published).toHaveLength(1);
+    expect(published[0]?.subject).toBe('events.x');
+    expect(JSON.parse(new TextDecoder().decode(published[0]?.data))).toEqual({ a: 1 });
+    await transport.stop?.();
+  });
+});

--- a/packages/di-framework-events/tsconfig.json
+++ b/packages/di-framework-events/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "allowJs": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": false,
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false,
+    "experimentalDecorators": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "index.ts", "memory.ts", "kafka.ts", "nats.ts"],
+  "exclude": ["**/*.test.ts", "tests/**/*", "node_modules", "dist"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,7 +39,9 @@
       "@di-framework/repo": ["packages/di-framework-repo/src/index.ts"],
       "@di-framework/repo/*": ["packages/di-framework-repo/src/*"],
       "@di-framework/graphql": ["packages/di-framework-graphql/index.ts"],
-      "@di-framework/graphql/*": ["packages/di-framework-graphql/*"]
+      "@di-framework/graphql/*": ["packages/di-framework-graphql/*"],
+      "@di-framework/events": ["packages/di-framework-events/index.ts"],
+      "@di-framework/events/*": ["packages/di-framework-events/*"]
     }
   },
   "exclude": [


### PR DESCRIPTION
Introduced `createEventBridge` for bridging container events to transport topics and vice versa. Added `memoryTransport` as a lightweight in-memory adapter. Implemented utility functions like `unwrapPublisherPayload` and codecs like `JsonCodec` for payload handling. Extended the test suite to cover EventBridge functionality, decorators, and end-to-end examples.