### PR TITLE
Add `@di-framework/config` package with sources, validation, and DI d…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ npm i @di-framework/core
 - `packages/di-framework-http` - http handling
 - `packages/di-framework-graphql` - GraphQL schema from domain objects
 - `packages/di-framework-events` - bridge container events to Kafka / NATS / memory
+- `packages/di-framework-config` - typed config from env/files, validated and injected via DI
 - `packages/di-framework-cli` - `di-framework-core` cli (build, test, typecheck, publish)
 - `examples` - usage examples
 

--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,14 @@
         "wrangler": "latest",
       },
     },
+    "examples/packages/config": {
+      "name": "di-config-example",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@di-framework/config": "workspace:*",
+        "@di-framework/core": "workspace:*",
+      },
+    },
     "examples/packages/docs-search": {
       "name": "@di-framework/docs-search-example",
       "version": "0.0.0",
@@ -118,6 +126,23 @@
       "peerDependencies": {
         "typescript": "^5",
       },
+    },
+    "packages/di-framework-config": {
+      "name": "@di-framework/config",
+      "version": "4.0.1",
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5",
+        "zod": "^3.24.0",
+      },
+      "peerDependencies": {
+        "@di-framework/core": "workspace:^",
+        "typescript": "^5",
+        "zod": "^3.22.0",
+      },
+      "optionalPeers": [
+        "zod",
+      ],
     },
     "packages/di-framework-core": {
       "name": "@di-framework/core",
@@ -231,6 +256,8 @@
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
     "@di-framework/cli": ["@di-framework/cli@workspace:packages/di-framework-cli"],
+
+    "@di-framework/config": ["@di-framework/config@workspace:packages/di-framework-config"],
 
     "@di-framework/core": ["@di-framework/core@workspace:packages/di-framework-core"],
 
@@ -466,6 +493,8 @@
 
     "di-basic-example": ["di-basic-example@workspace:examples/packages/basic"],
 
+    "di-config-example": ["di-config-example@workspace:examples/packages/config"],
+
     "di-events-example": ["di-events-example@workspace:examples/packages/events"],
 
     "di-http-router-example": ["di-http-router-example@workspace:examples/packages/http-router"],
@@ -537,6 +566,8 @@
     "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
 
     "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "di-worker-example/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
   }

--- a/examples/packages/config/index.test.ts
+++ b/examples/packages/config/index.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { Configuration, envSource, objectSource, Value } from '@di-framework/config';
+import { useContainer } from '@di-framework/core/container';
+import { Container } from '@di-framework/core/decorators';
+
+describe('config example', () => {
+  beforeEach(() => {
+    useContainer().clear();
+  });
+
+  it('injects env-backed config into a service', () => {
+    @Configuration({
+      sources: [
+        objectSource({ port: 3000 }),
+        envSource({
+          prefix: 'APP_',
+          env: {
+            APP_PORT: '9090',
+            APP_DATABASE__HOST: 'db.test',
+          },
+        }),
+      ],
+    })
+    class AppConfig {
+      port = 1;
+      database = { host: 'localhost' };
+    }
+
+    @Container()
+    class Api {
+      @Value('database.host')
+      dbHost!: string;
+
+      constructor(@Value('port') public port: number) {}
+    }
+
+    const api = useContainer().resolve(Api);
+    expect(api.port).toBe(9090);
+    expect(api.dbHost).toBe('db.test');
+    expect(useContainer().resolve(AppConfig).port).toBe(9090);
+  });
+});

--- a/examples/packages/config/index.ts
+++ b/examples/packages/config/index.ts
@@ -1,0 +1,51 @@
+/**
+ * @di-framework/config example
+ *
+ * Load AppConfig from defaults + env, inject nested values into a service.
+ */
+
+import { Configuration, envSource, Value } from '@di-framework/config';
+import { useContainer } from '@di-framework/core/container';
+import { Container } from '@di-framework/core/decorators';
+
+@Configuration({
+  sources: [
+    envSource({
+      prefix: 'APP_',
+      env: {
+        APP_PORT: '8080',
+        APP_DATABASE__HOST: 'db.example',
+        APP_DATABASE__PORT: '5432',
+      },
+    }),
+  ],
+})
+class AppConfig {
+  host = 'localhost';
+  port = 3000;
+  database = { host: 'localhost', port: 5432 };
+}
+
+@Container()
+class DatabaseService {
+  @Value('database.host')
+  host!: string;
+
+  @Value('database.port')
+  port!: number;
+
+  constructor(@Value('host') public listenHost: string) {}
+
+  describe() {
+    return `${this.listenHost} → ${this.host}:${this.port}`;
+  }
+}
+
+const container = useContainer();
+const cfg = container.resolve(AppConfig);
+const db = container.resolve(DatabaseService);
+
+console.log('config.port =', cfg.port);
+console.log('database    =', db.describe());
+
+container.clear();

--- a/examples/packages/config/package.json
+++ b/examples/packages/config/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "di-config-example",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "start": "bun run index.ts",
+    "test": "bun test"
+  },
+  "devDependencies": {
+    "@di-framework/config": "workspace:*",
+    "@di-framework/core": "workspace:*"
+  }
+}

--- a/examples/packages/config/tsconfig.json
+++ b/examples/packages/config/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/di-framework-cli/cmd/build.ts
+++ b/packages/di-framework-cli/cmd/build.ts
@@ -8,6 +8,7 @@ export const PACKAGES = [
   'packages/di-framework-http',
   'packages/di-framework-graphql',
   'packages/di-framework-events',
+  'packages/di-framework-config',
   'packages/di-framework-cli',
 ];
 

--- a/packages/di-framework-cli/cmd/publish.ts
+++ b/packages/di-framework-cli/cmd/publish.ts
@@ -7,6 +7,7 @@ export const PACKAGES = [
   'packages/di-framework-http',
   'packages/di-framework-graphql',
   'packages/di-framework-events',
+  'packages/di-framework-config',
   'packages/di-framework-cli',
 ];
 

--- a/packages/di-framework-cli/tests/build.test.ts
+++ b/packages/di-framework-cli/tests/build.test.ts
@@ -76,6 +76,7 @@ describe('build command', () => {
       expect(PACKAGES).toContain('packages/di-framework-http');
       expect(PACKAGES).toContain('packages/di-framework-graphql');
       expect(PACKAGES).toContain('packages/di-framework-events');
+      expect(PACKAGES).toContain('packages/di-framework-config');
       expect(PACKAGES).toContain('packages/di-framework-cli');
     });
 

--- a/packages/di-framework-cli/tests/publish.test.ts
+++ b/packages/di-framework-cli/tests/publish.test.ts
@@ -115,6 +115,7 @@ describe('publish command', () => {
       expect(PACKAGES).toContain('packages/di-framework-http');
       expect(PACKAGES).toContain('packages/di-framework-graphql');
       expect(PACKAGES).toContain('packages/di-framework-events');
+      expect(PACKAGES).toContain('packages/di-framework-config');
       expect(PACKAGES).toContain('packages/di-framework-cli');
     });
 

--- a/packages/di-framework-config/README.md
+++ b/packages/di-framework-config/README.md
@@ -1,0 +1,128 @@
+# @di-framework/config
+
+Load, validate, and inject application configuration through the DI container. Domain services stay on `@di-framework/core`; this package is the typed config layer.
+
+## Features
+
+- **Sources**: `envSource`, `objectSource`, `jsonFileSource` (deep-merged left → right).
+- **Validation**: pluggable `ConfigSchema` — optional Zod adapter at `@di-framework/config/zod`.
+- **DI registration**: `registerConfig` exposes the root object plus flattened dotted paths.
+- **Decorators**: `@Configuration` / `@Value` match the rest of the framework.
+- **Imperative API**: `loadConfig` / `loadAndRegisterConfig` for scripts and tests.
+
+## Installation
+
+```bash
+bun add @di-framework/config @di-framework/core
+# optional validation
+bun add zod   # for @di-framework/config/zod
+```
+
+## Quick start
+
+```typescript
+import { Container } from '@di-framework/core/decorators';
+import { useContainer } from '@di-framework/core/container';
+import {
+  Configuration,
+  Value,
+  envSource,
+} from '@di-framework/config';
+
+@Configuration({
+  sources: [envSource({ prefix: 'APP_' })],
+})
+class AppConfig {
+  host = 'localhost';
+  port = 3000;
+  database = { host: 'localhost', port: 5432 };
+}
+
+@Container()
+class DatabaseService {
+  @Value('database.host')
+  host!: string;
+
+  constructor(@Value('port') public port: number) {}
+}
+
+const db = useContainer().resolve(DatabaseService);
+```
+
+With `APP_PORT=8080` and `APP_DATABASE__HOST=db.internal`, `db.port` is `8080` and `db.host` is `db.internal`.
+
+## Imperative API
+
+```typescript
+import {
+  loadAndRegisterConfig,
+  envSource,
+  objectSource,
+  jsonFileSource,
+} from '@di-framework/config';
+import { useContainer } from '@di-framework/core/container';
+
+const config = await loadAndRegisterConfig({
+  defaults: { port: 3000 },
+  sources: [
+    jsonFileSource('./config.json', { optional: true }),
+    envSource({ prefix: 'APP_' }),
+    objectSource({ /* test overrides */ }),
+  ],
+  token: 'config', // default
+  flatten: true,   // default — registers config.port, config.db.host, …
+});
+
+useContainer().resolve('config.port'); // number
+```
+
+## Zod
+
+```typescript
+import { z } from 'zod';
+import { loadConfigSync, objectSource } from '@di-framework/config';
+import { zodSchema } from '@di-framework/config/zod';
+
+const schema = zodSchema(
+  z.object({
+    port: z.coerce.number().default(3000),
+    apiKey: z.string().min(1),
+  }),
+);
+
+const config = loadConfigSync({
+  sources: [objectSource({ apiKey: 'k', port: '4000' })],
+  schema,
+});
+```
+
+## Env mapping
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `prefix` | `''` | Only keys with this prefix; prefix is stripped |
+| `separator` | `'__'` | Nesting delimiter after strip |
+| `keyCase` | `'camel'` | Segment transform (`DATABASE_HOST` → `databaseHost`) |
+| `coerce` | `true` | Parse booleans, numbers, JSON literals |
+
+`APP_DB__HOST=localhost` → `{ db: { host: 'localhost' } }`.
+
+## API
+
+| Export | |
+| --- | --- |
+| `loadConfig` / `loadConfigSync` | Merge defaults + sources (+ schema) |
+| `registerConfig` | Put config (and paths) on the container |
+| `loadAndRegisterConfig` | Both of the above |
+| `envSource` / `objectSource` / `jsonFileSource` | Built-in sources |
+| `Configuration` / `Value` | Decorators |
+| `schemaFromParse` / `identitySchema` | Schema helpers |
+| `@di-framework/config/zod` | `zodSchema` |
+
+## Non-goals (v1)
+
+YAML/TOML loaders, remote config providers, live reload / watch, and secret managers. Implement `ConfigSource` / `ConfigSchema` for those.
+
+## License
+
+MIT

--- a/packages/di-framework-config/index.ts
+++ b/packages/di-framework-config/index.ts
@@ -1,0 +1,24 @@
+export {
+  type LoadAndRegisterOptions,
+  loadAndRegisterConfig,
+  loadAndRegisterConfigSync,
+} from './src/bootstrap.ts';
+export { coerceEnvValue, toCamelCase, transformKeySegment } from './src/coerce.ts';
+export { Configuration, Value } from './src/decorators.ts';
+export { loadConfig, loadConfigSync } from './src/load.ts';
+export { deepMerge, flattenEntries, getByPath, setByPath } from './src/path.ts';
+export { registerConfig } from './src/register.ts';
+export { identitySchema, schemaFromParse } from './src/schema.ts';
+export { type EnvSourceOptions, envSource } from './src/sources/env.ts';
+export { type JsonFileSourceOptions, jsonFileSource } from './src/sources/json-file.ts';
+export { objectSource } from './src/sources/object.ts';
+export type {
+  ConfigContainer,
+  ConfigKeyCase,
+  ConfigSchema,
+  ConfigSource,
+  ConfigurationDecoratorOptions,
+  LoadConfigOptions,
+  RegisterConfigOptions,
+  ValueDecoratorOptions,
+} from './src/types.ts';

--- a/packages/di-framework-config/package.json
+++ b/packages/di-framework-config/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@di-framework/config",
+  "version": "4.0.1",
+  "description": "Typed, validated configuration for di-framework — load from env/files, validate, and inject via DI.",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "private": false,
+  "exports": {
+    ".": {
+      "bun": "./index.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./zod": {
+      "bun": "./zod.ts",
+      "import": "./dist/zod.js",
+      "default": "./dist/zod.js"
+    }
+  },
+  "author": "@di-framework Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/di-framework/di-framework",
+    "directory": "packages/di-framework-config"
+  },
+  "bugs": {
+    "url": "https://github.com/di-framework/di-framework/issues"
+  },
+  "homepage": "https://github.com/di-framework/di-framework#readme",
+  "keywords": [
+    "config",
+    "configuration",
+    "environment",
+    "dependency-injection",
+    "decorators",
+    "typescript",
+    "zod"
+  ],
+  "type": "module",
+  "files": [
+    "dist",
+    "README.md",
+    "index.ts",
+    "zod.ts",
+    "src"
+  ],
+  "scripts": {
+    "build": "rm -rf dist && bun build ./index.ts ./zod.ts --outdir ./dist --target node --external @di-framework/core --external zod && tsc --emitDeclarationOnly --declaration --outDir dist",
+    "prepublishOnly": "bun run build",
+    "test": "bun test"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5",
+    "zod": "^3.24.0"
+  },
+  "peerDependencies": {
+    "@di-framework/core": "workspace:^",
+    "typescript": "^5",
+    "zod": "^3.22.0"
+  },
+  "peerDependenciesMeta": {
+    "zod": {
+      "optional": true
+    }
+  }
+}

--- a/packages/di-framework-config/src/adapters/zod.ts
+++ b/packages/di-framework-config/src/adapters/zod.ts
@@ -1,0 +1,23 @@
+import type { ConfigSchema } from '../types.ts';
+
+/** Minimal Zod-like surface so we don't hard-depend on Zod types at compile time. */
+export interface ZodTypeLike<T = unknown> {
+  parse(input: unknown): T;
+}
+
+/**
+ * Adapt a Zod schema to {@link ConfigSchema}.
+ *
+ * @example
+ * import { z } from 'zod';
+ * import { zodSchema } from '@di-framework/config/zod';
+ *
+ * const schema = zodSchema(z.object({ port: z.number().default(3000) }));
+ */
+export function zodSchema<T>(zod: ZodTypeLike<T>): ConfigSchema<T> {
+  return {
+    parse(input: unknown) {
+      return zod.parse(input);
+    },
+  };
+}

--- a/packages/di-framework-config/src/bootstrap.ts
+++ b/packages/di-framework-config/src/bootstrap.ts
@@ -1,0 +1,28 @@
+import { loadConfig, loadConfigSync } from './load.ts';
+import { registerConfig } from './register.ts';
+import type { LoadConfigOptions, RegisterConfigOptions } from './types.ts';
+
+export type LoadAndRegisterOptions<T = Record<string, unknown>> = LoadConfigOptions<T> &
+  RegisterConfigOptions;
+
+/**
+ * `loadConfig` then `registerConfig`.
+ */
+export async function loadAndRegisterConfig<T = Record<string, unknown>>(
+  options: LoadAndRegisterOptions<T> = {},
+): Promise<T> {
+  const { token, flatten, container, ...loadOpts } = options;
+  const config = await loadConfig<T>(loadOpts);
+  return registerConfig(config, { token, flatten, container });
+}
+
+/**
+ * Sync variant of {@link loadAndRegisterConfig}.
+ */
+export function loadAndRegisterConfigSync<T = Record<string, unknown>>(
+  options: LoadAndRegisterOptions<T> = {},
+): T {
+  const { token, flatten, container, ...loadOpts } = options;
+  const config = loadConfigSync<T>(loadOpts);
+  return registerConfig(config, { token, flatten, container });
+}

--- a/packages/di-framework-config/src/coerce.ts
+++ b/packages/di-framework-config/src/coerce.ts
@@ -1,0 +1,40 @@
+import type { ConfigKeyCase } from './types.ts';
+
+/**
+ * `DATABASE_HOST` → `databaseHost`, `host` → `host`.
+ */
+export function toCamelCase(segment: string): string {
+  const lower = segment.toLowerCase();
+  return lower.replace(/_([a-z0-9])/g, (_, c: string) => c.toUpperCase());
+}
+
+export function transformKeySegment(segment: string, keyCase: ConfigKeyCase): string {
+  if (keyCase === 'preserve') return segment;
+  if (keyCase === 'lower') return segment.toLowerCase();
+  return toCamelCase(segment);
+}
+
+/**
+ * Coerce common env string forms: booleans, integers, floats. Empty string stays `''`.
+ */
+export function coerceEnvValue(raw: string): unknown {
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  if (raw === 'null') return null;
+  if (raw === 'undefined') return undefined;
+
+  if (raw !== '' && !Number.isNaN(Number(raw)) && /^-?\d+(\.\d+)?$/.test(raw)) {
+    return Number(raw);
+  }
+
+  // JSON object/array literals
+  if ((raw.startsWith('{') && raw.endsWith('}')) || (raw.startsWith('[') && raw.endsWith(']'))) {
+    try {
+      return JSON.parse(raw) as unknown;
+    } catch {
+      return raw;
+    }
+  }
+
+  return raw;
+}

--- a/packages/di-framework-config/src/decorators.ts
+++ b/packages/di-framework-config/src/decorators.ts
@@ -1,0 +1,109 @@
+import { Component, Container as ContainerDecorator } from '@di-framework/core/decorators';
+import { loadConfigSync } from './load.ts';
+import { registerConfig } from './register.ts';
+import type { ConfigurationDecoratorOptions, ValueDecoratorOptions } from './types.ts';
+
+// biome-ignore lint/suspicious/noExplicitAny: decorator targets are heterogeneous class constructors
+type Ctor = new (...args: any[]) => any;
+
+function defaultsFromClass(ctor: Ctor): Record<string, unknown> {
+  try {
+    const instance = new ctor();
+    if (instance === null || typeof instance !== 'object') return {};
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(instance as Record<string, unknown>)) {
+      if (value !== undefined) out[key] = value;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Marks a class as a configuration definition.
+ *
+ * 1. Builds defaults from property initializers on a fresh instance
+ * 2. Loads + merges sources (sync) and optional schema
+ * 3. Registers the result under `token` (default `'config'`) with flattened paths
+ * 4. Optionally registers the class itself as a singleton holding the loaded values
+ *
+ * Prefer sync sources (`envSource`, `objectSource`, `jsonFileSource`) with this decorator.
+ * For async sources, use `loadAndRegisterConfig` instead.
+ *
+ * @example
+ * @Configuration({
+ *   sources: [envSource({ prefix: 'APP_' })],
+ *   defaults: { port: 3000 },
+ * })
+ * class AppConfig {
+ *   host = 'localhost';
+ *   port = 3000;
+ * }
+ */
+export function Configuration<T = Record<string, unknown>>(
+  options: ConfigurationDecoratorOptions<T> = {},
+) {
+  return <C extends Ctor>(target: C): C => {
+    const classDefaults = defaultsFromClass(target);
+    const defaults = {
+      ...classDefaults,
+      ...(options.defaults ?? {}),
+    };
+
+    const config = loadConfigSync<T>({
+      sources: options.sources,
+      defaults,
+      schema: options.schema,
+    });
+
+    registerConfig(config, {
+      token: options.token ?? 'config',
+      flatten: options.flatten,
+      container: options.container,
+    });
+
+    const registerClass = options.registerClass !== false;
+    if (!registerClass) return target;
+
+    const singleton = options.singleton ?? true;
+
+    // Subclass so construction applies the loaded snapshot (same idea as @EventBridge autoStart).
+    const ConfigClass = class extends target {
+      // biome-ignore lint/suspicious/noExplicitAny: mirrors decorated class arity
+      constructor(...args: any[]) {
+        super(...args);
+        Object.assign(this, config as object);
+      }
+    };
+
+    Object.defineProperty(ConfigClass, 'name', { value: target.name });
+
+    ContainerDecorator({
+      singleton,
+      container: options.container as never,
+    })(ConfigClass);
+
+    return ConfigClass as C;
+  };
+}
+
+/**
+ * Inject a nested config value by dotted path under the root config token.
+ *
+ * Equivalent to `@Component('config.<path>')` when flatten registration is enabled.
+ *
+ * @example
+ * @Container()
+ * class DatabaseService {
+ *   @Value('database.host')
+ *   host!: string;
+ *
+ *   constructor(@Value('database.port') port: number) {}
+ * }
+ */
+export function Value(path: string, options: ValueDecoratorOptions = {}) {
+  const token = options.token ?? 'config';
+  const full = path ? `${token}.${path}` : token;
+  return Component(full);
+}

--- a/packages/di-framework-config/src/load.ts
+++ b/packages/di-framework-config/src/load.ts
@@ -1,0 +1,55 @@
+import { deepMerge } from './path.ts';
+import type { LoadConfigOptions } from './types.ts';
+
+/**
+ * Load configuration by deep-merging defaults + sources (left → right),
+ * then optionally validating with a schema.
+ *
+ * Sources may be sync or async; this always returns a Promise.
+ */
+export async function loadConfig<T = Record<string, unknown>>(
+  options: LoadConfigOptions<T> = {},
+): Promise<T> {
+  let merged: Record<string, unknown> = { ...(options.defaults ?? {}) };
+
+  for (const source of options.sources ?? []) {
+    const label = source.name ?? 'source';
+    try {
+      const loaded = await Promise.resolve(source.load());
+      merged = deepMerge(merged, loaded);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to load config from ${label}: ${message}`, { cause: err });
+    }
+  }
+
+  if (options.schema) {
+    return options.schema.parse(merged);
+  }
+
+  return merged as T;
+}
+
+/**
+ * Synchronous variant — all sources must return plain objects (not Promises).
+ */
+export function loadConfigSync<T = Record<string, unknown>>(options: LoadConfigOptions<T> = {}): T {
+  let merged: Record<string, unknown> = { ...(options.defaults ?? {}) };
+
+  for (const source of options.sources ?? []) {
+    const label = source.name ?? 'source';
+    const loaded = source.load();
+    if (loaded instanceof Promise) {
+      throw new Error(
+        `Config source "${label}" is async; use loadConfig() instead of loadConfigSync()`,
+      );
+    }
+    merged = deepMerge(merged, loaded);
+  }
+
+  if (options.schema) {
+    return options.schema.parse(merged);
+  }
+
+  return merged as T;
+}

--- a/packages/di-framework-config/src/path.ts
+++ b/packages/di-framework-config/src/path.ts
@@ -1,0 +1,79 @@
+/**
+ * Read a dotted path from a nested object.
+ */
+export function getByPath(obj: unknown, path: string): unknown {
+  if (!path) return obj;
+  const parts = path.split('.').filter(Boolean);
+  let cur: unknown = obj;
+  for (const part of parts) {
+    if (cur === null || cur === undefined || typeof cur !== 'object') return undefined;
+    cur = (cur as Record<string, unknown>)[part];
+  }
+  return cur;
+}
+
+/**
+ * Write a dotted path into a nested object (mutates `target`).
+ */
+export function setByPath(target: Record<string, unknown>, path: string, value: unknown): void {
+  const parts = path.split('.').filter(Boolean);
+  if (parts.length === 0) return;
+
+  let cur: Record<string, unknown> = target;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const key = parts[i];
+    if (key === undefined) continue;
+    const next = cur[key];
+    if (next === null || next === undefined || typeof next !== 'object' || Array.isArray(next)) {
+      cur[key] = {};
+    }
+    cur = cur[key] as Record<string, unknown>;
+  }
+  const last = parts[parts.length - 1];
+  if (last !== undefined) cur[last] = value;
+}
+
+/**
+ * Deep-merge plain objects. Arrays and non-objects from `source` replace.
+ * Later source wins for conflicting keys.
+ */
+export function deepMerge(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...target };
+  for (const [key, value] of Object.entries(source)) {
+    const existing = out[key];
+    if (
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      existing !== null &&
+      typeof existing === 'object' &&
+      !Array.isArray(existing)
+    ) {
+      out[key] = deepMerge(existing as Record<string, unknown>, value as Record<string, unknown>);
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+/**
+ * Walk a nested object and yield `[dottedPath, value]` for every leaf and intermediate object.
+ */
+export function flattenEntries(
+  obj: Record<string, unknown>,
+  prefix = '',
+): Array<[string, unknown]> {
+  const entries: Array<[string, unknown]> = [];
+  for (const [key, value] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    entries.push([path, value]);
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      entries.push(...flattenEntries(value as Record<string, unknown>, path));
+    }
+  }
+  return entries;
+}

--- a/packages/di-framework-config/src/register.ts
+++ b/packages/di-framework-config/src/register.ts
@@ -1,0 +1,33 @@
+import { useContainer } from '@di-framework/core/container';
+import { flattenEntries } from './path.ts';
+import type { ConfigContainer, RegisterConfigOptions } from './types.ts';
+
+function asContainer(value: unknown): ConfigContainer {
+  return (value ?? useContainer()) as ConfigContainer;
+}
+
+/**
+ * Register a config object on the DI container under `token` (default `'config'`).
+ * When `flatten` is true (default), also registers every dotted path as its own factory
+ * so `@Component('config.db.host')` / `@Value('db.host')` work.
+ */
+export function registerConfig<T>(config: T, options: RegisterConfigOptions = {}): T {
+  const token = options.token ?? 'config';
+  const flatten = options.flatten !== false;
+  const container = asContainer(options.container);
+
+  if (!container.registerFactory) {
+    throw new Error('Container does not support registerFactory');
+  }
+
+  container.registerFactory(token, () => config, { singleton: true });
+
+  if (flatten && config !== null && typeof config === 'object' && !Array.isArray(config)) {
+    for (const [path, value] of flattenEntries(config as Record<string, unknown>)) {
+      const childToken = `${token}.${path}`;
+      container.registerFactory(childToken, () => value, { singleton: true });
+    }
+  }
+
+  return config;
+}

--- a/packages/di-framework-config/src/schema.ts
+++ b/packages/di-framework-config/src/schema.ts
@@ -1,0 +1,19 @@
+import type { ConfigSchema } from './types.ts';
+
+/**
+ * Wrap a parse function as a {@link ConfigSchema}.
+ */
+export function schemaFromParse<T>(parse: (input: unknown) => T): ConfigSchema<T> {
+  return { parse };
+}
+
+/**
+ * Identity schema — useful when you only want typed defaults without validation.
+ */
+export function identitySchema<T>(): ConfigSchema<T> {
+  return {
+    parse(input: unknown) {
+      return input as T;
+    },
+  };
+}

--- a/packages/di-framework-config/src/sources/env.ts
+++ b/packages/di-framework-config/src/sources/env.ts
@@ -1,0 +1,62 @@
+import { coerceEnvValue, transformKeySegment } from '../coerce.ts';
+import { setByPath } from '../path.ts';
+import type { ConfigKeyCase, ConfigSource } from '../types.ts';
+
+export interface EnvSourceOptions {
+  /** Only include keys starting with this prefix (stripped from the result). */
+  prefix?: string;
+  /**
+   * Split remaining key on this separator for nesting.
+   * Default `'__'` so `APP_DB__HOST` → `{ db: { host } }` after prefix strip + keyCase.
+   */
+  separator?: string;
+  /** How to transform each path segment. Default `'camel'`. */
+  keyCase?: ConfigKeyCase;
+  /** Coerce string values to number/boolean/JSON. Default `true`. */
+  coerce?: boolean;
+  /** Env bag to read. Defaults to `process.env`. */
+  env?: Record<string, string | undefined>;
+}
+
+/**
+ * Load configuration from environment variables.
+ *
+ * @example
+ * // APP_PORT=3000 APP_DB__HOST=localhost
+ * envSource({ prefix: 'APP_' })
+ * // → { port: 3000, db: { host: 'localhost' } }
+ */
+export function envSource(options: EnvSourceOptions = {}): ConfigSource {
+  const prefix = options.prefix ?? '';
+  const separator = options.separator ?? '__';
+  const keyCase = options.keyCase ?? 'camel';
+  const coerce = options.coerce !== false;
+
+  return {
+    name: 'env',
+    load() {
+      const bag = options.env ?? (typeof process !== 'undefined' ? process.env : {});
+      const out: Record<string, unknown> = {};
+
+      for (const [rawKey, rawValue] of Object.entries(bag)) {
+        if (rawValue === undefined) continue;
+        if (prefix && !rawKey.startsWith(prefix)) continue;
+
+        const stripped = prefix ? rawKey.slice(prefix.length) : rawKey;
+        if (!stripped) continue;
+
+        const segments = stripped
+          .split(separator)
+          .filter(Boolean)
+          .map((s) => transformKeySegment(s, keyCase));
+        if (segments.length === 0) continue;
+
+        const path = segments.join('.');
+        const value = coerce ? coerceEnvValue(rawValue) : rawValue;
+        setByPath(out, path, value);
+      }
+
+      return out;
+    },
+  };
+}

--- a/packages/di-framework-config/src/sources/json-file.ts
+++ b/packages/di-framework-config/src/sources/json-file.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import type { ConfigSource } from '../types.ts';
+
+export interface JsonFileSourceOptions {
+  /** When true, missing files yield `{}` instead of throwing. Default `false`. */
+  optional?: boolean;
+}
+
+/**
+ * Load a JSON file as a config object.
+ */
+export function jsonFileSource(path: string, options: JsonFileSourceOptions = {}): ConfigSource {
+  return {
+    name: `json:${path}`,
+    load() {
+      try {
+        const text = readFileSync(path, 'utf8');
+        const parsed: unknown = JSON.parse(text);
+        if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+          throw new Error(`JSON config at ${path} must be an object`);
+        }
+        return parsed as Record<string, unknown>;
+      } catch (err) {
+        if (options.optional && isNotFound(err)) return {};
+        throw err;
+      }
+    },
+  };
+}
+
+function isNotFound(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code?: string }).code === 'ENOENT'
+  );
+}

--- a/packages/di-framework-config/src/sources/object.ts
+++ b/packages/di-framework-config/src/sources/object.ts
@@ -1,0 +1,13 @@
+import type { ConfigSource } from '../types.ts';
+
+/**
+ * Static object source — useful for defaults, tests, and programmatic overrides.
+ */
+export function objectSource(value: Record<string, unknown>, name = 'object'): ConfigSource {
+  return {
+    name,
+    load() {
+      return { ...value };
+    },
+  };
+}

--- a/packages/di-framework-config/src/types.ts
+++ b/packages/di-framework-config/src/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Loads a flat or nested configuration object from a backing store.
+ */
+export interface ConfigSource {
+  /** Optional label used in error messages. */
+  name?: string;
+  load(): Record<string, unknown> | Promise<Record<string, unknown>>;
+}
+
+/**
+ * Validates / transforms a merged config object into a typed result.
+ * Adapters (e.g. Zod) implement this interface.
+ */
+export interface ConfigSchema<T = unknown> {
+  parse(input: unknown): T;
+}
+
+export type ConfigKeyCase = 'camel' | 'lower' | 'preserve';
+
+export interface LoadConfigOptions<T = Record<string, unknown>> {
+  /** Sources are deep-merged left → right (later wins). */
+  sources?: ConfigSource[];
+  /** Base values applied before sources. */
+  defaults?: Record<string, unknown>;
+  /** Optional schema; when set, return type is `T`. */
+  schema?: ConfigSchema<T>;
+}
+
+export interface ConfigContainer {
+  registerFactory?<T>(name: string, factory: () => T, options?: { singleton?: boolean }): unknown;
+  resolve?<T>(token: string | (abstract new (...args: never[]) => T)): T;
+  has?(token: string | (abstract new (...args: never[]) => unknown)): boolean;
+}
+
+export interface RegisterConfigOptions {
+  /** DI token for the root config object. Defaults to `'config'`. */
+  token?: string;
+  /**
+   * Also register dotted paths as factories (`config.db.host` → token `'config.db.host'`).
+   * Defaults to `true`.
+   */
+  flatten?: boolean;
+  container?: unknown;
+}
+
+export interface ConfigurationDecoratorOptions<T = Record<string, unknown>>
+  extends LoadConfigOptions<T>,
+    RegisterConfigOptions {
+  /**
+   * When true (default), also register the decorated class as a singleton
+   * whose instance is `Object.assign(new Ctor(), loaded)`.
+   */
+  registerClass?: boolean;
+  singleton?: boolean;
+}
+
+export interface ValueDecoratorOptions {
+  /** Root config token. Defaults to `'config'`. */
+  token?: string;
+}

--- a/packages/di-framework-config/tests/decorators.test.ts
+++ b/packages/di-framework-config/tests/decorators.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { useContainer } from '@di-framework/core/container';
+import { Container } from '@di-framework/core/decorators';
+import { z } from 'zod';
+import { zodSchema } from '../src/adapters/zod.ts';
+import { Configuration, Value } from '../src/decorators.ts';
+import { envSource } from '../src/sources/env.ts';
+import { objectSource } from '../src/sources/object.ts';
+
+describe('Configuration / Value', () => {
+  beforeEach(() => {
+    useContainer().clear();
+  });
+
+  it('loads sources, registers token, and injects via @Value', () => {
+    @Configuration({
+      sources: [
+        objectSource({
+          database: { host: 'db.local', port: 5432 },
+          apiKey: 'secret',
+        }),
+      ],
+    })
+    class AppConfig {
+      database = { host: 'localhost', port: 5432 };
+      apiKey = '';
+    }
+
+    @Container()
+    class DatabaseService {
+      @Value('database.host')
+      host!: string;
+
+      @Value('database.port')
+      port!: number;
+
+      constructor(@Value('apiKey') public apiKey: string) {}
+    }
+
+    const c = useContainer();
+    const cfg = c.resolve(AppConfig);
+    expect(cfg.database.host).toBe('db.local');
+    expect(c.resolve<string>('config.apiKey')).toBe('secret');
+
+    const db = c.resolve(DatabaseService);
+    expect(db.host).toBe('db.local');
+    expect(db.port).toBe(5432);
+    expect(db.apiKey).toBe('secret');
+  });
+
+  it('merges env over class defaults', () => {
+    @Configuration({
+      sources: [
+        envSource({
+          prefix: 'APP_',
+          env: { APP_PORT: '8080', APP_HOST: '0.0.0.0' },
+        }),
+      ],
+    })
+    class AppConfig {
+      host = '127.0.0.1';
+      port = 3000;
+    }
+
+    const cfg = useContainer().resolve(AppConfig);
+    expect(cfg.host).toBe('0.0.0.0');
+    expect(cfg.port).toBe(8080);
+  });
+
+  it('supports zod schema via adapter', () => {
+    const schema = zodSchema(
+      z.object({
+        port: z.number().int().positive(),
+        name: z.string().default('app'),
+      }),
+    );
+
+    @Configuration({
+      sources: [objectSource({ port: 9 })],
+      schema,
+    })
+    class AppConfig {
+      port!: number;
+      name!: string;
+    }
+
+    const cfg = useContainer().resolve(AppConfig);
+    expect(cfg.port).toBe(9);
+    expect(cfg.name).toBe('app');
+  });
+});

--- a/packages/di-framework-config/tests/load.test.ts
+++ b/packages/di-framework-config/tests/load.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { useContainer } from '@di-framework/core/container';
+import { coerceEnvValue, toCamelCase } from '../src/coerce.ts';
+import { loadConfig, loadConfigSync } from '../src/load.ts';
+import { deepMerge, flattenEntries, getByPath, setByPath } from '../src/path.ts';
+import { registerConfig } from '../src/register.ts';
+import { schemaFromParse } from '../src/schema.ts';
+import { envSource } from '../src/sources/env.ts';
+import { jsonFileSource } from '../src/sources/json-file.ts';
+import { objectSource } from '../src/sources/object.ts';
+
+describe('path helpers', () => {
+  it('getByPath / setByPath', () => {
+    const obj: Record<string, unknown> = {};
+    setByPath(obj, 'a.b.c', 1);
+    expect(obj).toEqual({ a: { b: { c: 1 } } });
+    expect(getByPath(obj, 'a.b.c')).toBe(1);
+    expect(getByPath(obj, 'a.x')).toBeUndefined();
+  });
+
+  it('deepMerge prefers later source', () => {
+    expect(deepMerge({ a: 1, b: { x: 1, y: 1 } }, { b: { y: 2 }, c: 3 })).toEqual({
+      a: 1,
+      b: { x: 1, y: 2 },
+      c: 3,
+    });
+  });
+
+  it('flattenEntries includes nested paths', () => {
+    const entries = flattenEntries({ a: 1, b: { c: 2 } });
+    expect(entries).toContainEqual(['a', 1]);
+    expect(entries).toContainEqual(['b', { c: 2 }]);
+    expect(entries).toContainEqual(['b.c', 2]);
+  });
+});
+
+describe('coerce', () => {
+  it('coerces booleans, numbers, json', () => {
+    expect(coerceEnvValue('true')).toBe(true);
+    expect(coerceEnvValue('false')).toBe(false);
+    expect(coerceEnvValue('42')).toBe(42);
+    expect(coerceEnvValue('3.5')).toBe(3.5);
+    expect(coerceEnvValue('{"a":1}')).toEqual({ a: 1 });
+    expect(coerceEnvValue('hello')).toBe('hello');
+  });
+
+  it('toCamelCase', () => {
+    expect(toCamelCase('DATABASE_HOST')).toBe('databaseHost');
+    expect(toCamelCase('port')).toBe('port');
+  });
+});
+
+describe('sources', () => {
+  it('envSource strips prefix, nests on __, camelCases', () => {
+    const src = envSource({
+      prefix: 'APP_',
+      env: {
+        APP_PORT: '3000',
+        APP_DB__HOST: 'localhost',
+        APP_DB__PORT: '5432',
+        OTHER: 'ignored',
+      },
+    });
+    expect(src.load()).toEqual({
+      port: 3000,
+      db: { host: 'localhost', port: 5432 },
+    });
+  });
+
+  it('objectSource returns a shallow copy', () => {
+    const value = { a: 1 };
+    const loaded = objectSource(value).load() as Record<string, unknown>;
+    expect(loaded).toEqual({ a: 1 });
+    expect(loaded).not.toBe(value);
+  });
+
+  it('jsonFileSource reads JSON objects', () => {
+    const dir = join(import.meta.dir, '.tmp-config');
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, 'cfg.json');
+    writeFileSync(file, JSON.stringify({ host: 'h', nested: { n: 1 } }));
+    try {
+      expect(jsonFileSource(file).load()).toEqual({ host: 'h', nested: { n: 1 } });
+      expect(jsonFileSource(join(dir, 'missing.json'), { optional: true }).load()).toEqual({});
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('loadConfig', () => {
+  it('merges defaults and sources left-to-right', async () => {
+    const config = await loadConfig({
+      defaults: { a: 1, b: { x: 1 } },
+      sources: [objectSource({ b: { y: 2 }, c: 3 }), objectSource({ c: 4 })],
+    });
+    expect(config).toEqual({ a: 1, b: { x: 1, y: 2 }, c: 4 });
+  });
+
+  it('applies schema', () => {
+    const config = loadConfigSync({
+      sources: [objectSource({ port: '3000' })],
+      schema: schemaFromParse((input) => {
+        const obj = input as { port: string };
+        return { port: Number(obj.port) };
+      }),
+    });
+    expect(config).toEqual({ port: 3000 });
+  });
+});
+
+describe('registerConfig', () => {
+  beforeEach(() => {
+    useContainer().clear();
+  });
+
+  it('registers root and flattened tokens', () => {
+    const c = useContainer();
+    registerConfig({ db: { host: 'localhost' }, port: 1 });
+    expect(c.resolve<{ db: { host: string }; port: number }>('config')).toEqual({
+      db: { host: 'localhost' },
+      port: 1,
+    });
+    expect(c.resolve<number>('config.port')).toBe(1);
+    expect(c.resolve<{ host: string }>('config.db')).toEqual({ host: 'localhost' });
+    expect(c.resolve<string>('config.db.host')).toBe('localhost');
+  });
+});

--- a/packages/di-framework-config/tests/zod.test.ts
+++ b/packages/di-framework-config/tests/zod.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'bun:test';
+import { z } from 'zod';
+import { zodSchema } from '../src/adapters/zod.ts';
+import { loadConfigSync } from '../src/load.ts';
+import { objectSource } from '../src/sources/object.ts';
+
+describe('zodSchema', () => {
+  it('parses and applies defaults', () => {
+    const schema = zodSchema(
+      z.object({
+        port: z.coerce.number().default(3000),
+        debug: z.boolean().default(false),
+      }),
+    );
+
+    const config = loadConfigSync({
+      sources: [objectSource({ port: '4000' })],
+      schema,
+    });
+
+    expect(config).toEqual({ port: 4000, debug: false });
+  });
+
+  it('throws on invalid input', () => {
+    const schema = zodSchema(z.object({ port: z.number() }));
+    expect(() =>
+      loadConfigSync({
+        sources: [objectSource({ port: 'nope' })],
+        schema,
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/di-framework-config/tsconfig.json
+++ b/packages/di-framework-config/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "allowJs": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": false,
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false,
+    "experimentalDecorators": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "index.ts", "zod.ts"],
+  "exclude": ["**/*.test.ts", "tests/**/*", "node_modules", "dist"]
+}

--- a/packages/di-framework-config/zod.ts
+++ b/packages/di-framework-config/zod.ts
@@ -1,0 +1,1 @@
+export { type ZodTypeLike, zodSchema } from './src/adapters/zod.ts';

--- a/packages/di-framework-events/bunfig.toml
+++ b/packages/di-framework-events/bunfig.toml
@@ -1,0 +1,1 @@
+telemetry = false

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,7 +41,9 @@
       "@di-framework/graphql": ["packages/di-framework-graphql/index.ts"],
       "@di-framework/graphql/*": ["packages/di-framework-graphql/*"],
       "@di-framework/events": ["packages/di-framework-events/index.ts"],
-      "@di-framework/events/*": ["packages/di-framework-events/*"]
+      "@di-framework/events/*": ["packages/di-framework-events/*"],
+      "@di-framework/config": ["packages/di-framework-config/index.ts"],
+      "@di-framework/config/*": ["packages/di-framework-config/*"]
     }
   },
   "exclude": [


### PR DESCRIPTION
Introduced a new package for typed configuration in the `@di-framework` ecosystem. Added support for env, JSON file, and object sources. Included utilities for validation (Zod-supported), DI registration, and flattened path resolution. Expanded test coverage with decorators, imperative APIs, and integration examples. Updated workspace dependencies and metadata.