### PR TITLE
feat(ai): platform capabilities and ingestion tooling

### DIFF
--- a/packages/di-framework-ai/src/chat/client/advisor/index.ts
+++ b/packages/di-framework-ai/src/chat/client/advisor/index.ts
@@ -31,6 +31,8 @@ export {
   type SimpleLoggerAdvisorOptions,
 } from './simple-logger-advisor.ts';
 export { augmentWithFormatInstructions } from './structured-output-format.ts';
+export type { RetryAdvisorOptions } from './retry-advisor.ts';
+export { RetryAdvisor, retryAdvisor } from './retry-advisor.ts';
 export {
   StructuredOutputValidationAdvisor,
   type StructuredOutputValidationAdvisorOptions,

--- a/packages/di-framework-ai/src/chat/client/advisor/index.ts
+++ b/packages/di-framework-ai/src/chat/client/advisor/index.ts
@@ -26,13 +26,13 @@ export {
   HIGHEST_PRECEDENCE,
   LOWEST_PRECEDENCE,
 } from './ordered.ts';
+export type { RetryAdvisorOptions } from './retry-advisor.ts';
+export { RetryAdvisor, retryAdvisor } from './retry-advisor.ts';
 export {
   SimpleLoggerAdvisor,
   type SimpleLoggerAdvisorOptions,
 } from './simple-logger-advisor.ts';
 export { augmentWithFormatInstructions } from './structured-output-format.ts';
-export type { RetryAdvisorOptions } from './retry-advisor.ts';
-export { RetryAdvisor, retryAdvisor } from './retry-advisor.ts';
 export {
   StructuredOutputValidationAdvisor,
   type StructuredOutputValidationAdvisorOptions,

--- a/packages/di-framework-ai/src/chat/client/advisor/retry-advisor.ts
+++ b/packages/di-framework-ai/src/chat/client/advisor/retry-advisor.ts
@@ -1,6 +1,11 @@
 import type { ChatClientRequest } from '../chat-client-request.ts';
 import type { ChatClientResponse } from '../chat-client-response.ts';
-import type { CallAdvisor, CallAdvisorChain, StreamAdvisor, StreamAdvisorChain } from './advisor.ts';
+import type {
+  CallAdvisor,
+  CallAdvisorChain,
+  StreamAdvisor,
+  StreamAdvisorChain,
+} from './advisor.ts';
 
 export interface RetryAdvisorOptions {
   readonly maxAttempts?: number;
@@ -14,35 +19,60 @@ export interface RetryAdvisorOptions {
 
 const defaultRetry = (error: unknown): boolean => {
   const details = (error as { details?: { retryable?: boolean } } | null)?.details;
-  return details?.retryable === true || (error instanceof TypeError);
+  return details?.retryable === true || error instanceof TypeError;
 };
 
 export class RetryAdvisor implements CallAdvisor, StreamAdvisor {
   readonly name = 'RetryAdvisor';
   readonly order: number;
-  private readonly options: Required<Pick<RetryAdvisorOptions, 'maxAttempts' | 'backoffMs' | 'maxBackoffMs' | 'jitter'>> & RetryAdvisorOptions;
+  private readonly options: Required<
+    Pick<RetryAdvisorOptions, 'maxAttempts' | 'backoffMs' | 'maxBackoffMs' | 'jitter'>
+  > &
+    RetryAdvisorOptions;
   constructor(options: RetryAdvisorOptions = {}) {
     this.order = options.order ?? 0;
-    this.options = { maxAttempts: Math.max(1, options.maxAttempts ?? 3), backoffMs: Math.max(0, options.backoffMs ?? 100), maxBackoffMs: Math.max(0, options.maxBackoffMs ?? 10_000), jitter: Math.max(0, options.jitter ?? 0.2), ...options };
+    this.options = {
+      maxAttempts: Math.max(1, options.maxAttempts ?? 3),
+      backoffMs: Math.max(0, options.backoffMs ?? 100),
+      maxBackoffMs: Math.max(0, options.maxBackoffMs ?? 10_000),
+      jitter: Math.max(0, options.jitter ?? 0.2),
+      ...options,
+    };
   }
-  async adviseCall(request: ChatClientRequest, chain: CallAdvisorChain): Promise<ChatClientResponse> {
+  async adviseCall(
+    request: ChatClientRequest,
+    chain: CallAdvisorChain,
+  ): Promise<ChatClientResponse> {
     let attempt = 1;
     for (;;) {
-      try { return await chain.nextCall(request); } catch (error) {
-        if (attempt >= this.options.maxAttempts || !(await (this.options.shouldRetry ?? defaultRetry)(error, attempt))) throw error;
+      try {
+        return await chain.nextCall(request);
+      } catch (error) {
+        if (
+          attempt >= this.options.maxAttempts ||
+          !(await (this.options.shouldRetry ?? defaultRetry)(error, attempt))
+        )
+          throw error;
         await this.delay(attempt);
         attempt++;
       }
     }
   }
-  async *adviseStream(request: ChatClientRequest, chain: StreamAdvisorChain): AsyncIterable<ChatClientResponse> {
+  async *adviseStream(
+    request: ChatClientRequest,
+    chain: StreamAdvisorChain,
+  ): AsyncIterable<ChatClientResponse> {
     let attempt = 1;
     for (;;) {
       try {
         yield* chain.nextStream(request);
         return;
       } catch (error) {
-        if (attempt >= this.options.maxAttempts || !(await (this.options.shouldRetry ?? defaultRetry)(error, attempt))) throw error;
+        if (
+          attempt >= this.options.maxAttempts ||
+          !(await (this.options.shouldRetry ?? defaultRetry)(error, attempt))
+        )
+          throw error;
         await this.delay(attempt);
         attempt++;
       }
@@ -54,11 +84,20 @@ export class RetryAdvisor implements CallAdvisor, StreamAdvisor {
     const ms = Math.max(0, Math.round(base * factor));
     if (!ms) return;
     await new Promise<void>((resolve, reject) => {
-      if (this.options.signal?.aborted) return reject(this.options.signal.reason ?? new Error('Aborted'));
+      if (this.options.signal?.aborted)
+        return reject(this.options.signal.reason ?? new Error('Aborted'));
       const timer = setTimeout(resolve, ms);
-      this.options.signal?.addEventListener('abort', () => { clearTimeout(timer); reject(this.options.signal?.reason ?? new Error('Aborted')); }, { once: true });
+      this.options.signal?.addEventListener(
+        'abort',
+        () => {
+          clearTimeout(timer);
+          reject(this.options.signal?.reason ?? new Error('Aborted'));
+        },
+        { once: true },
+      );
     });
   }
 }
 
-export const retryAdvisor = (options?: RetryAdvisorOptions): RetryAdvisor => new RetryAdvisor(options);
+export const retryAdvisor = (options?: RetryAdvisorOptions): RetryAdvisor =>
+  new RetryAdvisor(options);

--- a/packages/di-framework-ai/src/chat/client/advisor/retry-advisor.ts
+++ b/packages/di-framework-ai/src/chat/client/advisor/retry-advisor.ts
@@ -1,0 +1,64 @@
+import type { ChatClientRequest } from '../chat-client-request.ts';
+import type { ChatClientResponse } from '../chat-client-response.ts';
+import type { CallAdvisor, CallAdvisorChain, StreamAdvisor, StreamAdvisorChain } from './advisor.ts';
+
+export interface RetryAdvisorOptions {
+  readonly maxAttempts?: number;
+  readonly backoffMs?: number;
+  readonly maxBackoffMs?: number;
+  readonly jitter?: number;
+  readonly shouldRetry?: (error: unknown, attempt: number) => boolean | Promise<boolean>;
+  readonly signal?: AbortSignal;
+  readonly order?: number;
+}
+
+const defaultRetry = (error: unknown): boolean => {
+  const details = (error as { details?: { retryable?: boolean } } | null)?.details;
+  return details?.retryable === true || (error instanceof TypeError);
+};
+
+export class RetryAdvisor implements CallAdvisor, StreamAdvisor {
+  readonly name = 'RetryAdvisor';
+  readonly order: number;
+  private readonly options: Required<Pick<RetryAdvisorOptions, 'maxAttempts' | 'backoffMs' | 'maxBackoffMs' | 'jitter'>> & RetryAdvisorOptions;
+  constructor(options: RetryAdvisorOptions = {}) {
+    this.order = options.order ?? 0;
+    this.options = { maxAttempts: Math.max(1, options.maxAttempts ?? 3), backoffMs: Math.max(0, options.backoffMs ?? 100), maxBackoffMs: Math.max(0, options.maxBackoffMs ?? 10_000), jitter: Math.max(0, options.jitter ?? 0.2), ...options };
+  }
+  async adviseCall(request: ChatClientRequest, chain: CallAdvisorChain): Promise<ChatClientResponse> {
+    let attempt = 1;
+    for (;;) {
+      try { return await chain.nextCall(request); } catch (error) {
+        if (attempt >= this.options.maxAttempts || !(await (this.options.shouldRetry ?? defaultRetry)(error, attempt))) throw error;
+        await this.delay(attempt);
+        attempt++;
+      }
+    }
+  }
+  async *adviseStream(request: ChatClientRequest, chain: StreamAdvisorChain): AsyncIterable<ChatClientResponse> {
+    let attempt = 1;
+    for (;;) {
+      try {
+        yield* chain.nextStream(request);
+        return;
+      } catch (error) {
+        if (attempt >= this.options.maxAttempts || !(await (this.options.shouldRetry ?? defaultRetry)(error, attempt))) throw error;
+        await this.delay(attempt);
+        attempt++;
+      }
+    }
+  }
+  private async delay(attempt: number): Promise<void> {
+    const base = Math.min(this.options.maxBackoffMs, this.options.backoffMs * 2 ** (attempt - 1));
+    const factor = this.options.jitter ? 1 + (Math.random() * 2 - 1) * this.options.jitter : 1;
+    const ms = Math.max(0, Math.round(base * factor));
+    if (!ms) return;
+    await new Promise<void>((resolve, reject) => {
+      if (this.options.signal?.aborted) return reject(this.options.signal.reason ?? new Error('Aborted'));
+      const timer = setTimeout(resolve, ms);
+      this.options.signal?.addEventListener('abort', () => { clearTimeout(timer); reject(this.options.signal?.reason ?? new Error('Aborted')); }, { once: true });
+    });
+  }
+}
+
+export const retryAdvisor = (options?: RetryAdvisorOptions): RetryAdvisor => new RetryAdvisor(options);

--- a/packages/di-framework-ai/src/converter/index.ts
+++ b/packages/di-framework-ai/src/converter/index.ts
@@ -21,10 +21,19 @@ export {
   SchemaOutputConverter,
   schemaOutputConverter,
 } from './schema-output-converter.ts';
+export type {
+  StandardSchemaIssue,
+  StandardSchemaOutputConverterOptions,
+  StandardSchemaV1,
+} from './standard-schema.ts';
+export {
+  isStandardSchema,
+  parseStandardSchema,
+  StandardSchemaOutputConverter,
+  standardSchemaOutputConverter,
+} from './standard-schema.ts';
 export type { StructuredOutputConverter } from './structured-output-converter.ts';
 export {
   isStructuredOutputConverter,
   NO_JSON_SCHEMA,
 } from './structured-output-converter.ts';
-export type { StandardSchemaV1, StandardSchemaIssue, StandardSchemaOutputConverterOptions } from './standard-schema.ts';
-export { isStandardSchema, parseStandardSchema, StandardSchemaOutputConverter, standardSchemaOutputConverter } from './standard-schema.ts';

--- a/packages/di-framework-ai/src/converter/index.ts
+++ b/packages/di-framework-ai/src/converter/index.ts
@@ -26,3 +26,5 @@ export {
   isStructuredOutputConverter,
   NO_JSON_SCHEMA,
 } from './structured-output-converter.ts';
+export type { StandardSchemaV1, StandardSchemaIssue, StandardSchemaOutputConverterOptions } from './standard-schema.ts';
+export { isStandardSchema, parseStandardSchema, StandardSchemaOutputConverter, standardSchemaOutputConverter } from './standard-schema.ts';

--- a/packages/di-framework-ai/src/converter/standard-schema.ts
+++ b/packages/di-framework-ai/src/converter/standard-schema.ts
@@ -1,32 +1,59 @@
 import { AiError } from '../model/errors.ts';
-import { SchemaOutputConverter, type SchemaOutputConverterOptions } from './schema-output-converter.ts';
+import {
+  SchemaOutputConverter,
+  type SchemaOutputConverterOptions,
+} from './schema-output-converter.ts';
 
 /** Minimal structural representation of Standard Schema v1. */
 export interface StandardSchemaV1<TInput = unknown, TOutput = TInput> {
   readonly '~standard': {
     readonly version: 1;
     readonly vendor: string;
-    readonly validate: (value: TInput) => TOutput | Promise<TOutput> | { readonly issues: readonly StandardSchemaIssue[] } | Promise<{ readonly issues: readonly StandardSchemaIssue[] }>;
-    readonly jsonSchema?: (options?: { target?: string }) => Record<string, unknown> | Promise<Record<string, unknown>>;
+    readonly validate: (
+      value: TInput,
+    ) =>
+      | TOutput
+      | Promise<TOutput>
+      | { readonly issues: readonly StandardSchemaIssue[] }
+      | Promise<{ readonly issues: readonly StandardSchemaIssue[] }>;
+    readonly jsonSchema?: (options?: {
+      target?: string;
+    }) => Record<string, unknown> | Promise<Record<string, unknown>>;
   };
 }
-export interface StandardSchemaIssue { readonly message: string; readonly path?: readonly (string | number)[]; }
+export interface StandardSchemaIssue {
+  readonly message: string;
+  readonly path?: readonly (string | number)[];
+}
 
 export function isStandardSchema(value: unknown): value is StandardSchemaV1 {
   const standard = (value as { '~standard'?: unknown } | null)?.['~standard'];
-  return !!standard && typeof standard === 'object' && (standard as { version?: unknown }).version === 1 && typeof (standard as { validate?: unknown }).validate === 'function';
+  return (
+    !!standard &&
+    typeof standard === 'object' &&
+    (standard as { version?: unknown }).version === 1 &&
+    typeof (standard as { validate?: unknown }).validate === 'function'
+  );
 }
 
-export async function parseStandardSchema<T>(schema: StandardSchemaV1<unknown, T>, value: unknown): Promise<T> {
+export async function parseStandardSchema<T>(
+  schema: StandardSchemaV1<unknown, T>,
+  value: unknown,
+): Promise<T> {
   const result = await schema['~standard'].validate(value);
   if (result && typeof result === 'object' && 'issues' in result) {
     const issues = (result as { issues: readonly StandardSchemaIssue[] }).issues;
-    throw new AiError(`Standard Schema validation failed: ${issues.map((i) => i.message).join('; ')}`, 'output-validation', { retryable: false });
+    throw new AiError(
+      `Standard Schema validation failed: ${issues.map((i) => i.message).join('; ')}`,
+      'output-validation',
+      { retryable: false },
+    );
   }
   return result as T;
 }
 
-export interface StandardSchemaOutputConverterOptions<T> extends Omit<SchemaOutputConverterOptions<T>, 'schema' | 'map'> {
+export interface StandardSchemaOutputConverterOptions<T>
+  extends Omit<SchemaOutputConverterOptions<T>, 'schema' | 'map'> {
   readonly schema: StandardSchemaV1<unknown, T>;
 }
 
@@ -37,7 +64,12 @@ export class StandardSchemaOutputConverter<T> extends SchemaOutputConverter<T> {
     let jsonSchema: Record<string, unknown> | undefined;
     const candidate = options.schema['~standard'].jsonSchema;
     if (candidate) {
-      try { jsonSchema = candidate instanceof Function ? undefined : candidate as Record<string, unknown>; } catch { /* optional */ }
+      try {
+        jsonSchema =
+          candidate instanceof Function ? undefined : (candidate as Record<string, unknown>);
+      } catch {
+        /* optional */
+      }
     }
     super({ ...options, schema: jsonSchema, map: (value) => value as T });
     this.standardSchema = options.schema;
@@ -48,6 +80,8 @@ export class StandardSchemaOutputConverter<T> extends SchemaOutputConverter<T> {
   }
 }
 
-export function standardSchemaOutputConverter<T>(options: StandardSchemaOutputConverterOptions<T>): StandardSchemaOutputConverter<T> {
+export function standardSchemaOutputConverter<T>(
+  options: StandardSchemaOutputConverterOptions<T>,
+): StandardSchemaOutputConverter<T> {
   return new StandardSchemaOutputConverter(options);
 }

--- a/packages/di-framework-ai/src/converter/standard-schema.ts
+++ b/packages/di-framework-ai/src/converter/standard-schema.ts
@@ -1,0 +1,53 @@
+import { AiError } from '../model/errors.ts';
+import { SchemaOutputConverter, type SchemaOutputConverterOptions } from './schema-output-converter.ts';
+
+/** Minimal structural representation of Standard Schema v1. */
+export interface StandardSchemaV1<TInput = unknown, TOutput = TInput> {
+  readonly '~standard': {
+    readonly version: 1;
+    readonly vendor: string;
+    readonly validate: (value: TInput) => TOutput | Promise<TOutput> | { readonly issues: readonly StandardSchemaIssue[] } | Promise<{ readonly issues: readonly StandardSchemaIssue[] }>;
+    readonly jsonSchema?: (options?: { target?: string }) => Record<string, unknown> | Promise<Record<string, unknown>>;
+  };
+}
+export interface StandardSchemaIssue { readonly message: string; readonly path?: readonly (string | number)[]; }
+
+export function isStandardSchema(value: unknown): value is StandardSchemaV1 {
+  const standard = (value as { '~standard'?: unknown } | null)?.['~standard'];
+  return !!standard && typeof standard === 'object' && (standard as { version?: unknown }).version === 1 && typeof (standard as { validate?: unknown }).validate === 'function';
+}
+
+export async function parseStandardSchema<T>(schema: StandardSchemaV1<unknown, T>, value: unknown): Promise<T> {
+  const result = await schema['~standard'].validate(value);
+  if (result && typeof result === 'object' && 'issues' in result) {
+    const issues = (result as { issues: readonly StandardSchemaIssue[] }).issues;
+    throw new AiError(`Standard Schema validation failed: ${issues.map((i) => i.message).join('; ')}`, 'output-validation', { retryable: false });
+  }
+  return result as T;
+}
+
+export interface StandardSchemaOutputConverterOptions<T> extends Omit<SchemaOutputConverterOptions<T>, 'schema' | 'map'> {
+  readonly schema: StandardSchemaV1<unknown, T>;
+}
+
+/** Structured-output converter backed by any Standard Schema implementation (Zod, Valibot, ArkType, ...). */
+export class StandardSchemaOutputConverter<T> extends SchemaOutputConverter<T> {
+  private readonly standardSchema: StandardSchemaV1<unknown, T>;
+  constructor(options: StandardSchemaOutputConverterOptions<T>) {
+    let jsonSchema: Record<string, unknown> | undefined;
+    const candidate = options.schema['~standard'].jsonSchema;
+    if (candidate) {
+      try { jsonSchema = candidate instanceof Function ? undefined : candidate as Record<string, unknown>; } catch { /* optional */ }
+    }
+    super({ ...options, schema: jsonSchema, map: (value) => value as T });
+    this.standardSchema = options.schema;
+  }
+  async convertAsync(text: string): Promise<T> {
+    const value = super.convert(text);
+    return parseStandardSchema(this.standardSchema, value);
+  }
+}
+
+export function standardSchemaOutputConverter<T>(options: StandardSchemaOutputConverterOptions<T>): StandardSchemaOutputConverter<T> {
+  return new StandardSchemaOutputConverter(options);
+}

--- a/packages/di-framework-ai/src/document/index.ts
+++ b/packages/di-framework-ai/src/document/index.ts
@@ -7,4 +7,9 @@ export {
   withDocumentScore,
 } from './document.ts';
 export type { DocumentLoader, TextDocumentLoaderOptions } from './loaders.ts';
-export { htmlDocumentLoader, loadDocuments, pdfDocumentLoader, textDocumentLoader } from './loaders.ts';
+export {
+  htmlDocumentLoader,
+  loadDocuments,
+  pdfDocumentLoader,
+  textDocumentLoader,
+} from './loaders.ts';

--- a/packages/di-framework-ai/src/document/index.ts
+++ b/packages/di-framework-ai/src/document/index.ts
@@ -6,3 +6,5 @@ export {
   textDocument,
   withDocumentScore,
 } from './document.ts';
+export type { DocumentLoader, TextDocumentLoaderOptions } from './loaders.ts';
+export { htmlDocumentLoader, loadDocuments, pdfDocumentLoader, textDocumentLoader } from './loaders.ts';

--- a/packages/di-framework-ai/src/document/loaders.ts
+++ b/packages/di-framework-ai/src/document/loaders.ts
@@ -18,12 +18,85 @@ export function textDocumentLoader(
     },
   };
 }
+const RAW_TEXT_ELEMENTS = new Set(['script', 'style']);
+function isTagNameChar(char: string): boolean {
+  return (
+    (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || (char >= '0' && char <= '9')
+  );
+}
+function readTagName(input: string, start: number): { name: string; end: number } {
+  let end = start;
+  while (end < input.length && isTagNameChar(input[end] as string)) end += 1;
+  return { name: input.slice(start, end).toLowerCase(), end };
+}
+function skipAttributes(input: string, start: number): number {
+  let cursor = start;
+  while (cursor < input.length) {
+    const char = input[cursor] as string;
+    if (char === '"' || char === "'") {
+      const close = input.indexOf(char, cursor + 1);
+      cursor = close < 0 ? input.length : close + 1;
+      continue;
+    }
+    if (char === '>') return cursor + 1;
+    cursor += 1;
+  }
+  return input.length;
+}
+function skipRawTextElement(input: string, start: number, name: string): number {
+  let cursor = start;
+  while (cursor < input.length) {
+    const open = input.indexOf('</', cursor);
+    if (open < 0) return input.length;
+    const { name: closing, end } = readTagName(input, open + 2);
+    if (closing === name) return skipAttributes(input, end);
+    cursor = open + 2;
+  }
+  return input.length;
+}
+function stripHtmlMarkup(input: string): string {
+  let text = '';
+  let cursor = 0;
+  while (cursor < input.length) {
+    const open = input.indexOf('<', cursor);
+    if (open < 0) {
+      text += input.slice(cursor);
+      break;
+    }
+    text += input.slice(cursor, open);
+    const next = input[open + 1];
+    if (next === '!') {
+      if (input.startsWith('<!--', open)) {
+        const close = input.indexOf('-->', open + 4);
+        cursor = close < 0 ? input.length : close + 3;
+      } else {
+        const close = input.indexOf('>', open + 2);
+        cursor = close < 0 ? input.length : close + 1;
+      }
+      text += ' ';
+      continue;
+    }
+    const closing = next === '/';
+    const { name, end } = readTagName(input, open + (closing ? 2 : 1));
+    if (name === '') {
+      text += '<';
+      cursor = open + 1;
+      continue;
+    }
+    const afterTag = skipAttributes(input, end);
+    const selfClosing = input[afterTag - 2] === '/';
+    cursor =
+      !closing && !selfClosing && RAW_TEXT_ELEMENTS.has(name)
+        ? skipRawTextElement(input, afterTag, name)
+        : afterTag;
+    text += ' ';
+  }
+  return text;
+}
 export function htmlDocumentLoader(): DocumentLoader<string> {
   return {
     async load(input, options = {}) {
-      const text = input
-        .replace(/<script[\s\S]*?<\/script>|<style[\s\S]*?<\/style>/gi, '')
-        .replace(/<[^>]+>/g, ' ')
+      const text = stripHtmlMarkup(input)
         .replace(/&nbsp;/gi, ' ')
         .replace(/\s+/g, ' ')
         .trim();

--- a/packages/di-framework-ai/src/document/loaders.ts
+++ b/packages/di-framework-ai/src/document/loaders.ts
@@ -1,0 +1,7 @@
+import { document, type Document } from './document.ts';
+export interface DocumentLoader<T = unknown> { load(input: T, options?: { id?: string; metadata?: Readonly<Record<string, unknown>> }): Promise<readonly Document[]>; }
+export interface TextDocumentLoaderOptions { readonly encoding?: string; }
+export function textDocumentLoader(_options: TextDocumentLoaderOptions = {}): DocumentLoader<string | Uint8Array> { return { async load(input, options = {}) { const text = typeof input === 'string' ? input : new TextDecoder().decode(input); return [document({ ...options, text })]; } }; }
+export function htmlDocumentLoader(): DocumentLoader<string> { return { async load(input, options = {}) { const text = input.replace(/<script[\s\S]*?<\/script>|<style[\s\S]*?<\/style>/gi, '').replace(/<[^>]+>/g, ' ').replace(/&nbsp;/gi, ' ').replace(/\s+/g, ' ').trim(); return [document({ ...options, text, metadata: { ...options.metadata, format: 'html' } })]; } }; }
+export function pdfDocumentLoader(extractText: (input: Uint8Array) => string | Promise<string>): DocumentLoader<Uint8Array> { return { async load(input, options = {}) { return [document({ ...options, text: await extractText(input), metadata: { ...options.metadata, format: 'pdf' } })]; } }; }
+export async function loadDocuments<T>(loader: DocumentLoader<T>, inputs: readonly T[], options?: { metadata?: Readonly<Record<string, unknown>> }): Promise<Document[]> { const loaded = await Promise.all(inputs.map((input) => loader.load(input, options))); return loaded.flat(); }

--- a/packages/di-framework-ai/src/document/loaders.ts
+++ b/packages/di-framework-ai/src/document/loaders.ts
@@ -1,7 +1,56 @@
-import { document, type Document } from './document.ts';
-export interface DocumentLoader<T = unknown> { load(input: T, options?: { id?: string; metadata?: Readonly<Record<string, unknown>> }): Promise<readonly Document[]>; }
-export interface TextDocumentLoaderOptions { readonly encoding?: string; }
-export function textDocumentLoader(_options: TextDocumentLoaderOptions = {}): DocumentLoader<string | Uint8Array> { return { async load(input, options = {}) { const text = typeof input === 'string' ? input : new TextDecoder().decode(input); return [document({ ...options, text })]; } }; }
-export function htmlDocumentLoader(): DocumentLoader<string> { return { async load(input, options = {}) { const text = input.replace(/<script[\s\S]*?<\/script>|<style[\s\S]*?<\/style>/gi, '').replace(/<[^>]+>/g, ' ').replace(/&nbsp;/gi, ' ').replace(/\s+/g, ' ').trim(); return [document({ ...options, text, metadata: { ...options.metadata, format: 'html' } })]; } }; }
-export function pdfDocumentLoader(extractText: (input: Uint8Array) => string | Promise<string>): DocumentLoader<Uint8Array> { return { async load(input, options = {}) { return [document({ ...options, text: await extractText(input), metadata: { ...options.metadata, format: 'pdf' } })]; } }; }
-export async function loadDocuments<T>(loader: DocumentLoader<T>, inputs: readonly T[], options?: { metadata?: Readonly<Record<string, unknown>> }): Promise<Document[]> { const loaded = await Promise.all(inputs.map((input) => loader.load(input, options))); return loaded.flat(); }
+import { type Document, document } from './document.ts';
+export interface DocumentLoader<T = unknown> {
+  load(
+    input: T,
+    options?: { id?: string; metadata?: Readonly<Record<string, unknown>> },
+  ): Promise<readonly Document[]>;
+}
+export interface TextDocumentLoaderOptions {
+  readonly encoding?: string;
+}
+export function textDocumentLoader(
+  _options: TextDocumentLoaderOptions = {},
+): DocumentLoader<string | Uint8Array> {
+  return {
+    async load(input, options = {}) {
+      const text = typeof input === 'string' ? input : new TextDecoder().decode(input);
+      return [document({ ...options, text })];
+    },
+  };
+}
+export function htmlDocumentLoader(): DocumentLoader<string> {
+  return {
+    async load(input, options = {}) {
+      const text = input
+        .replace(/<script[\s\S]*?<\/script>|<style[\s\S]*?<\/style>/gi, '')
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/&nbsp;/gi, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+      return [document({ ...options, text, metadata: { ...options.metadata, format: 'html' } })];
+    },
+  };
+}
+export function pdfDocumentLoader(
+  extractText: (input: Uint8Array) => string | Promise<string>,
+): DocumentLoader<Uint8Array> {
+  return {
+    async load(input, options = {}) {
+      return [
+        document({
+          ...options,
+          text: await extractText(input),
+          metadata: { ...options.metadata, format: 'pdf' },
+        }),
+      ];
+    },
+  };
+}
+export async function loadDocuments<T>(
+  loader: DocumentLoader<T>,
+  inputs: readonly T[],
+  options?: { metadata?: Readonly<Record<string, unknown>> },
+): Promise<Document[]> {
+  const loaded = await Promise.all(inputs.map((input) => loader.load(input, options)));
+  return loaded.flat();
+}

--- a/packages/di-framework-ai/src/index.ts
+++ b/packages/di-framework-ai/src/index.ts
@@ -30,6 +30,7 @@ export type {
   EntityParamSpec,
   EntityResponse,
   MessageChatMemoryAdvisorOptions,
+  RetryAdvisorOptions,
   SimpleLoggerAdvisorOptions,
   StreamAdvisor,
   StreamAdvisorChain,
@@ -38,7 +39,6 @@ export type {
   ToolAdvisor,
   ToolCallingAdvisorOptions,
   ToolSource,
-  RetryAdvisorOptions,
 } from './chat/client/index.ts';
 // ChatClient + advisors
 export {
@@ -63,14 +63,14 @@ export {
   LOWEST_PRECEDENCE,
   MessageChatMemoryAdvisor,
   MessageChatMemoryAdvisorBuilder,
+  RetryAdvisor,
   renderTemplate,
+  retryAdvisor,
   SimpleLoggerAdvisor,
   StructuredOutputValidationAdvisor,
   TOOL_CALLING_ADVISOR_AUTO_REGISTER,
   ToolCallingAdvisor,
   ToolCallingAdvisorBuilder,
-  RetryAdvisor,
-  retryAdvisor,
 } from './chat/client/index.ts';
 export {
   assistantMessage,
@@ -187,27 +187,27 @@ export type {
   ResponseTextCleaner,
   SchemaOutputConverterOptions,
   SchemaValidationResult,
-  StructuredOutputConverter,
-  StandardSchemaV1,
   StandardSchemaIssue,
   StandardSchemaOutputConverterOptions,
+  StandardSchemaV1,
+  StructuredOutputConverter,
 } from './converter/index.ts';
 export {
   compositeResponseTextCleaner,
   defaultResponseTextCleaner,
+  isStandardSchema,
   isStructuredOutputConverter,
   listOutputConverter,
   mapOutputConverter,
   markdownCodeBlockCleaner,
   NO_JSON_SCHEMA,
-  SchemaOutputConverter,
-  schemaOutputConverter,
-  isStandardSchema,
   parseStandardSchema,
+  SchemaOutputConverter,
   StandardSchemaOutputConverter,
-  standardSchemaOutputConverter,
+  schemaOutputConverter,
   schemaValidationFailed,
   schemaValidationOk,
+  standardSchemaOutputConverter,
   thinkingTagCleaner,
   validateAgainstJsonSchema,
   whitespaceCleaner,
@@ -330,18 +330,22 @@ export {
   Worker,
 } from './di/index.ts';
 // Document
-export type { Document, DocumentOptions } from './document/index.ts';
+export type {
+  Document,
+  DocumentLoader,
+  DocumentOptions,
+  TextDocumentLoaderOptions,
+} from './document/index.ts';
 export {
   document,
-  isTextDocument,
-  textDocument,
-  withDocumentScore,
   htmlDocumentLoader,
+  isTextDocument,
   loadDocuments,
   pdfDocumentLoader,
+  textDocument,
   textDocumentLoader,
+  withDocumentScore,
 } from './document/index.ts';
-export type { DocumentLoader, TextDocumentLoaderOptions } from './document/index.ts';
 // Embedding
 export type { EmbeddingModel, FakeEmbeddingModelOptions } from './embedding/index.ts';
 export {
@@ -365,9 +369,9 @@ export type {
   McpToolDescriptor,
   McpToolFilter,
   McpToolHandler,
+  McpToolNamePrefixGenerator,
   McpToolServer,
   McpToolServerOptions,
-  McpToolNamePrefixGenerator,
   SdkMcpClientLike,
   ToolContextToMcpMetaConverter,
 } from './mcp/index.ts';

--- a/packages/di-framework-ai/src/index.ts
+++ b/packages/di-framework-ai/src/index.ts
@@ -38,6 +38,7 @@ export type {
   ToolAdvisor,
   ToolCallingAdvisorOptions,
   ToolSource,
+  RetryAdvisorOptions,
 } from './chat/client/index.ts';
 // ChatClient + advisors
 export {
@@ -68,6 +69,8 @@ export {
   TOOL_CALLING_ADVISOR_AUTO_REGISTER,
   ToolCallingAdvisor,
   ToolCallingAdvisorBuilder,
+  RetryAdvisor,
+  retryAdvisor,
 } from './chat/client/index.ts';
 export {
   assistantMessage,
@@ -185,6 +188,9 @@ export type {
   SchemaOutputConverterOptions,
   SchemaValidationResult,
   StructuredOutputConverter,
+  StandardSchemaV1,
+  StandardSchemaIssue,
+  StandardSchemaOutputConverterOptions,
 } from './converter/index.ts';
 export {
   compositeResponseTextCleaner,
@@ -196,6 +202,10 @@ export {
   NO_JSON_SCHEMA,
   SchemaOutputConverter,
   schemaOutputConverter,
+  isStandardSchema,
+  parseStandardSchema,
+  StandardSchemaOutputConverter,
+  standardSchemaOutputConverter,
   schemaValidationFailed,
   schemaValidationOk,
   thinkingTagCleaner,
@@ -326,7 +336,12 @@ export {
   isTextDocument,
   textDocument,
   withDocumentScore,
+  htmlDocumentLoader,
+  loadDocuments,
+  pdfDocumentLoader,
+  textDocumentLoader,
 } from './document/index.ts';
+export type { DocumentLoader, TextDocumentLoaderOptions } from './document/index.ts';
 // Embedding
 export type { EmbeddingModel, FakeEmbeddingModelOptions } from './embedding/index.ts';
 export {
@@ -350,6 +365,8 @@ export type {
   McpToolDescriptor,
   McpToolFilter,
   McpToolHandler,
+  McpToolServer,
+  McpToolServerOptions,
   McpToolNamePrefixGenerator,
   SdkMcpClientLike,
   ToolContextToMcpMetaConverter,
@@ -358,6 +375,7 @@ export {
   adaptSdkClient,
   contentBlocksToString,
   createMcpToolCallbackProvider,
+  createMcpToolServer,
   createToolDefinitionFromMcp,
   defaultMcpToolNamePrefixGenerator,
   defaultToolContextToMcpMetaConverter,

--- a/packages/di-framework-ai/src/mcp/index.ts
+++ b/packages/di-framework-ai/src/mcp/index.ts
@@ -26,6 +26,8 @@ export {
   TOOL_CONTEXT_MCP_EXCHANGE_KEY,
 } from './mcp-tool-utils.ts';
 export type { McpToolHandler } from './tool-callback-as-mcp.ts';
+export type { McpToolServer, McpToolServerOptions } from './mcp-tool-server.ts';
+export { createMcpToolServer } from './mcp-tool-server.ts';
 export {
   toolCallbackAsMcpTool,
   toolCallbackToMcpDescriptor,

--- a/packages/di-framework-ai/src/mcp/index.ts
+++ b/packages/di-framework-ai/src/mcp/index.ts
@@ -13,6 +13,8 @@ export {
   McpToolCallbackProvider,
   mcpToolCallbacks,
 } from './mcp-tool-callback-provider.ts';
+export type { McpToolServer, McpToolServerOptions } from './mcp-tool-server.ts';
+export { createMcpToolServer } from './mcp-tool-server.ts';
 export {
   contentBlocksToString,
   createToolDefinitionFromMcp,
@@ -26,8 +28,6 @@ export {
   TOOL_CONTEXT_MCP_EXCHANGE_KEY,
 } from './mcp-tool-utils.ts';
 export type { McpToolHandler } from './tool-callback-as-mcp.ts';
-export type { McpToolServer, McpToolServerOptions } from './mcp-tool-server.ts';
-export { createMcpToolServer } from './mcp-tool-server.ts';
 export {
   toolCallbackAsMcpTool,
   toolCallbackToMcpDescriptor,

--- a/packages/di-framework-ai/src/mcp/mcp-tool-server.ts
+++ b/packages/di-framework-ai/src/mcp/mcp-tool-server.ts
@@ -1,11 +1,39 @@
 import type { ToolCallback } from '../tool/tool-callback.ts';
-import { toolCallbackAsMcpTool, type McpToolHandler } from './tool-callback-as-mcp.ts';
+import { type McpToolHandler, toolCallbackAsMcpTool } from './tool-callback-as-mcp.ts';
 import type { McpCallToolResult, McpToolDescriptor } from './types.ts';
-export interface McpToolServerOptions { readonly name?: string; readonly version?: string; readonly tools?: readonly ToolCallback[]; }
-export interface McpToolServer { readonly name: string; readonly version: string; listTools(): readonly McpToolDescriptor[]; callTool(name: string, args?: Record<string, unknown>): Promise<McpCallToolResult>; addTool(tool: ToolCallback): void; removeTool(name: string): boolean; }
+export interface McpToolServerOptions {
+  readonly name?: string;
+  readonly version?: string;
+  readonly tools?: readonly ToolCallback[];
+}
+export interface McpToolServer {
+  readonly name: string;
+  readonly version: string;
+  listTools(): readonly McpToolDescriptor[];
+  callTool(name: string, args?: Record<string, unknown>): Promise<McpCallToolResult>;
+  addTool(tool: ToolCallback): void;
+  removeTool(name: string): boolean;
+}
 export function createMcpToolServer(options: McpToolServerOptions = {}): McpToolServer {
   const tools = new Map<string, { descriptor: McpToolDescriptor; handler: McpToolHandler }>();
-  const addTool = (tool: ToolCallback) => { const wrapped = toolCallbackAsMcpTool(tool); if (tools.has(wrapped.descriptor.name)) throw new Error(`Duplicate MCP tool: ${wrapped.descriptor.name}`); tools.set(wrapped.descriptor.name, wrapped); };
+  const addTool = (tool: ToolCallback) => {
+    const wrapped = toolCallbackAsMcpTool(tool);
+    if (tools.has(wrapped.descriptor.name))
+      throw new Error(`Duplicate MCP tool: ${wrapped.descriptor.name}`);
+    tools.set(wrapped.descriptor.name, wrapped);
+  };
   for (const tool of options.tools ?? []) addTool(tool);
-  return { name: options.name ?? 'di-framework-ai', version: options.version ?? '1.0.0', listTools: () => [...tools.values()].map((v) => v.descriptor), callTool: async (name, args = {}) => { const tool = tools.get(name); if (!tool) return { isError: true, content: [{ type: 'text', text: `Unknown tool: ${name}` }] }; return tool.handler(args); }, addTool, removeTool: (name) => tools.delete(name) };
+  return {
+    name: options.name ?? 'di-framework-ai',
+    version: options.version ?? '1.0.0',
+    listTools: () => [...tools.values()].map((v) => v.descriptor),
+    callTool: async (name, args = {}) => {
+      const tool = tools.get(name);
+      if (!tool)
+        return { isError: true, content: [{ type: 'text', text: `Unknown tool: ${name}` }] };
+      return tool.handler(args);
+    },
+    addTool,
+    removeTool: (name) => tools.delete(name),
+  };
 }

--- a/packages/di-framework-ai/src/mcp/mcp-tool-server.ts
+++ b/packages/di-framework-ai/src/mcp/mcp-tool-server.ts
@@ -1,0 +1,11 @@
+import type { ToolCallback } from '../tool/tool-callback.ts';
+import { toolCallbackAsMcpTool, type McpToolHandler } from './tool-callback-as-mcp.ts';
+import type { McpCallToolResult, McpToolDescriptor } from './types.ts';
+export interface McpToolServerOptions { readonly name?: string; readonly version?: string; readonly tools?: readonly ToolCallback[]; }
+export interface McpToolServer { readonly name: string; readonly version: string; listTools(): readonly McpToolDescriptor[]; callTool(name: string, args?: Record<string, unknown>): Promise<McpCallToolResult>; addTool(tool: ToolCallback): void; removeTool(name: string): boolean; }
+export function createMcpToolServer(options: McpToolServerOptions = {}): McpToolServer {
+  const tools = new Map<string, { descriptor: McpToolDescriptor; handler: McpToolHandler }>();
+  const addTool = (tool: ToolCallback) => { const wrapped = toolCallbackAsMcpTool(tool); if (tools.has(wrapped.descriptor.name)) throw new Error(`Duplicate MCP tool: ${wrapped.descriptor.name}`); tools.set(wrapped.descriptor.name, wrapped); };
+  for (const tool of options.tools ?? []) addTool(tool);
+  return { name: options.name ?? 'di-framework-ai', version: options.version ?? '1.0.0', listTools: () => [...tools.values()].map((v) => v.descriptor), callTool: async (name, args = {}) => { const tool = tools.get(name); if (!tool) return { isError: true, content: [{ type: 'text', text: `Unknown tool: ${name}` }] }; return tool.handler(args); }, addTool, removeTool: (name) => tools.delete(name) };
+}

--- a/packages/di-framework-ai/src/provider/anthropic/anthropic-api-types.ts
+++ b/packages/di-framework-ai/src/provider/anthropic/anthropic-api-types.ts
@@ -4,6 +4,7 @@
 
 export type AnthropicContentBlock =
   | { type: 'text'; text: string }
+  | { type: 'image'; source: { type: 'base64' | 'url'; media_type?: string; data?: string; url?: string } }
   | {
       type: 'tool_use';
       id: string;

--- a/packages/di-framework-ai/src/provider/anthropic/anthropic-api-types.ts
+++ b/packages/di-framework-ai/src/provider/anthropic/anthropic-api-types.ts
@@ -4,7 +4,10 @@
 
 export type AnthropicContentBlock =
   | { type: 'text'; text: string }
-  | { type: 'image'; source: { type: 'base64' | 'url'; media_type?: string; data?: string; url?: string } }
+  | {
+      type: 'image';
+      source: { type: 'base64' | 'url'; media_type?: string; data?: string; url?: string };
+    }
   | {
       type: 'tool_use';
       id: string;

--- a/packages/di-framework-ai/src/provider/anthropic/map-messages.ts
+++ b/packages/di-framework-ai/src/provider/anthropic/map-messages.ts
@@ -6,6 +6,7 @@ import {
   isUserMessage,
 } from '../../chat/messages/message.ts';
 import type { ToolCallback } from '../../tool/tool-callback.ts';
+import type { Media } from '../../content/media.ts';
 import type {
   AnthropicContentBlock,
   AnthropicMessage,
@@ -35,7 +36,7 @@ export function toAnthropicMessages(messages: readonly ChatMessage[]): Anthropic
       continue;
     }
     if (isUserMessage(message)) {
-      raw.push({ role: 'user', content: message.text ?? '' });
+      raw.push({ role: 'user', content: anthropicContent(message.text, message.media) });
       continue;
     }
     if (isAssistantMessage(message)) {
@@ -43,6 +44,7 @@ export function toAnthropicMessages(messages: readonly ChatMessage[]): Anthropic
       if (message.text) {
         blocks.push({ type: 'text', text: message.text });
       }
+      blocks.push(...message.media.map(mediaBlock));
       for (const tc of message.toolCalls) {
         let input: unknown = {};
         try {
@@ -79,6 +81,16 @@ export function toAnthropicMessages(messages: readonly ChatMessage[]): Anthropic
     system: systemParts.length > 0 ? systemParts.join('\n\n') : undefined,
     messages: merged,
   };
+}
+
+function anthropicContent(text: string | null, media: readonly Media[]): string | AnthropicContentBlock[] {
+  if (!media.length) return text ?? '';
+  return [...(text ? [{ type: 'text' as const, text }] : []), ...media.map(mediaBlock)];
+}
+function mediaBlock(item: Media): AnthropicContentBlock {
+  if (typeof item.data === 'string' && item.data.startsWith('http')) return { type: 'image', source: { type: 'url', url: item.data } };
+  const data = typeof item.data === 'string' ? item.data.replace(/^data:[^;]+;base64,/, '') : item.data instanceof URL ? item.data.toString() : btoa(String.fromCharCode(...item.data));
+  return { type: 'image', source: { type: 'base64', media_type: item.mimeType, data } };
 }
 
 function mergeConsecutiveRoles(messages: AnthropicMessage[]): AnthropicMessage[] {

--- a/packages/di-framework-ai/src/provider/anthropic/map-messages.ts
+++ b/packages/di-framework-ai/src/provider/anthropic/map-messages.ts
@@ -5,8 +5,8 @@ import {
   isToolResponseMessage,
   isUserMessage,
 } from '../../chat/messages/message.ts';
-import type { ToolCallback } from '../../tool/tool-callback.ts';
 import type { Media } from '../../content/media.ts';
+import type { ToolCallback } from '../../tool/tool-callback.ts';
 import type {
   AnthropicContentBlock,
   AnthropicMessage,
@@ -83,13 +83,22 @@ export function toAnthropicMessages(messages: readonly ChatMessage[]): Anthropic
   };
 }
 
-function anthropicContent(text: string | null, media: readonly Media[]): string | AnthropicContentBlock[] {
+function anthropicContent(
+  text: string | null,
+  media: readonly Media[],
+): string | AnthropicContentBlock[] {
   if (!media.length) return text ?? '';
   return [...(text ? [{ type: 'text' as const, text }] : []), ...media.map(mediaBlock)];
 }
 function mediaBlock(item: Media): AnthropicContentBlock {
-  if (typeof item.data === 'string' && item.data.startsWith('http')) return { type: 'image', source: { type: 'url', url: item.data } };
-  const data = typeof item.data === 'string' ? item.data.replace(/^data:[^;]+;base64,/, '') : item.data instanceof URL ? item.data.toString() : btoa(String.fromCharCode(...item.data));
+  if (typeof item.data === 'string' && item.data.startsWith('http'))
+    return { type: 'image', source: { type: 'url', url: item.data } };
+  const data =
+    typeof item.data === 'string'
+      ? item.data.replace(/^data:[^;]+;base64,/, '')
+      : item.data instanceof URL
+        ? item.data.toString()
+        : btoa(String.fromCharCode(...item.data));
   return { type: 'image', source: { type: 'base64', media_type: item.mimeType, data } };
 }
 

--- a/packages/di-framework-ai/src/provider/openai/map-messages.ts
+++ b/packages/di-framework-ai/src/provider/openai/map-messages.ts
@@ -7,6 +7,7 @@ import {
   type ToolCall,
 } from '../../chat/messages/message.ts';
 import type { ToolCallback } from '../../tool/tool-callback.ts';
+import type { Media } from '../../content/media.ts';
 import type { OpenAiChatMessage, OpenAiFunctionTool, OpenAiToolCall } from './openai-api-types.ts';
 
 /**
@@ -21,14 +22,14 @@ export function toOpenAiMessages(messages: readonly ChatMessage[]): OpenAiChatMe
       continue;
     }
     if (isUserMessage(message)) {
-      out.push({ role: 'user', content: message.text ?? '' });
+      out.push({ role: 'user', content: mapOpenAiContent(message.text, message.media) });
       continue;
     }
     if (isAssistantMessage(message)) {
       const toolCalls = message.toolCalls.map(toOpenAiToolCall);
       out.push({
         role: 'assistant',
-        content: message.text,
+        content: mapOpenAiContent(message.text, message.media),
         ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
       });
       continue;
@@ -45,6 +46,20 @@ export function toOpenAiMessages(messages: readonly ChatMessage[]): OpenAiChatMe
     }
   }
   return out;
+}
+
+function mapOpenAiContent(text: string | null, media: readonly Media[]): string | Array<{ type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string } }> {
+  if (!media.length) return text ?? '';
+  const parts: Array<{ type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string } }> = [];
+  if (text) parts.push({ type: 'text', text });
+  for (const item of media) parts.push({ type: 'image_url', image_url: { url: mediaUrl(item) } });
+  return parts;
+}
+function mediaUrl(item: Media): string {
+  if (typeof item.data === 'string') return item.data.startsWith('data:') || item.data.startsWith('http') ? item.data : `data:${item.mimeType};base64,${item.data}`;
+  if (item.data instanceof URL) return item.data.toString();
+  let binary = ''; for (const byte of item.data) binary += String.fromCharCode(byte);
+  return `data:${item.mimeType};base64,${btoa(binary)}`;
 }
 
 export function toOpenAiToolCall(toolCall: ToolCall): OpenAiToolCall {

--- a/packages/di-framework-ai/src/provider/openai/map-messages.ts
+++ b/packages/di-framework-ai/src/provider/openai/map-messages.ts
@@ -29,7 +29,10 @@ export function toOpenAiMessages(messages: readonly ChatMessage[]): OpenAiChatMe
       const toolCalls = message.toolCalls.map(toOpenAiToolCall);
       out.push({
         role: 'assistant',
-        content: mapOpenAiContent(message.text, message.media),
+        // OpenAI permits null content for tool-call-only assistant turns.
+        content: message.media.length
+          ? mapOpenAiContent(message.text, message.media)
+          : message.text,
         ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
       });
       continue;

--- a/packages/di-framework-ai/src/provider/openai/map-messages.ts
+++ b/packages/di-framework-ai/src/provider/openai/map-messages.ts
@@ -6,8 +6,8 @@ import {
   isUserMessage,
   type ToolCall,
 } from '../../chat/messages/message.ts';
-import type { ToolCallback } from '../../tool/tool-callback.ts';
 import type { Media } from '../../content/media.ts';
+import type { ToolCallback } from '../../tool/tool-callback.ts';
 import type { OpenAiChatMessage, OpenAiFunctionTool, OpenAiToolCall } from './openai-api-types.ts';
 
 /**
@@ -48,17 +48,28 @@ export function toOpenAiMessages(messages: readonly ChatMessage[]): OpenAiChatMe
   return out;
 }
 
-function mapOpenAiContent(text: string | null, media: readonly Media[]): string | Array<{ type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string } }> {
+function mapOpenAiContent(
+  text: string | null,
+  media: readonly Media[],
+):
+  | string
+  | Array<{ type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string } }> {
   if (!media.length) return text ?? '';
-  const parts: Array<{ type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string } }> = [];
+  const parts: Array<
+    { type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string } }
+  > = [];
   if (text) parts.push({ type: 'text', text });
   for (const item of media) parts.push({ type: 'image_url', image_url: { url: mediaUrl(item) } });
   return parts;
 }
 function mediaUrl(item: Media): string {
-  if (typeof item.data === 'string') return item.data.startsWith('data:') || item.data.startsWith('http') ? item.data : `data:${item.mimeType};base64,${item.data}`;
+  if (typeof item.data === 'string')
+    return item.data.startsWith('data:') || item.data.startsWith('http')
+      ? item.data
+      : `data:${item.mimeType};base64,${item.data}`;
   if (item.data instanceof URL) return item.data.toString();
-  let binary = ''; for (const byte of item.data) binary += String.fromCharCode(byte);
+  let binary = '';
+  for (const byte of item.data) binary += String.fromCharCode(byte);
   return `data:${item.mimeType};base64,${btoa(binary)}`;
 }
 

--- a/packages/di-framework-ai/src/provider/openai/openai-api-types.ts
+++ b/packages/di-framework-ai/src/provider/openai/openai-api-types.ts
@@ -3,7 +3,12 @@
  * Not a full SDK — only what {@link OpenAiChatModel} needs.
  */
 
-export type OpenAiMessageContent = string | Array<{ type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string; detail?: 'auto' | 'low' | 'high' } }>;
+export type OpenAiMessageContent =
+  | string
+  | Array<
+      | { type: 'text'; text: string }
+      | { type: 'image_url'; image_url: { url: string; detail?: 'auto' | 'low' | 'high' } }
+    >;
 export interface OpenAiChatMessage {
   role: 'system' | 'user' | 'assistant' | 'tool';
   content?: OpenAiMessageContent | null;

--- a/packages/di-framework-ai/src/provider/openai/openai-api-types.ts
+++ b/packages/di-framework-ai/src/provider/openai/openai-api-types.ts
@@ -3,9 +3,10 @@
  * Not a full SDK — only what {@link OpenAiChatModel} needs.
  */
 
+export type OpenAiMessageContent = string | Array<{ type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string; detail?: 'auto' | 'low' | 'high' } }>;
 export interface OpenAiChatMessage {
   role: 'system' | 'user' | 'assistant' | 'tool';
-  content?: string | null;
+  content?: OpenAiMessageContent | null;
   name?: string;
   tool_call_id?: string;
   tool_calls?: OpenAiToolCall[];

--- a/packages/di-framework-ai/src/vectorstore/adapters/bun-sqlite.ts
+++ b/packages/di-framework-ai/src/vectorstore/adapters/bun-sqlite.ts
@@ -29,10 +29,34 @@ const cosine = (a: number[], b: number[]) => {
   }
   return aa && bb ? dot / Math.sqrt(aa * bb) : 0;
 };
-type WasmSimilarity = typeof import('wasm-similarity');
+interface WasmSimilarity {
+  cosine_similarity_dataspace(
+    dataspace: Float64Array,
+    rows: number,
+    dimensions: number,
+    query: Float64Array,
+  ): ArrayLike<number>;
+}
+interface VectorRow {
+  readonly id: string;
+  readonly text: string;
+  readonly metadata: Record<string, unknown>;
+  readonly embedding: number[];
+}
+interface ScoredRow {
+  readonly r: VectorRow;
+  readonly score: number;
+}
+const WASM_SIMILARITY_SPECIFIER = 'wasm-similarity';
 let wasmPromise: Promise<WasmSimilarity | null> | undefined;
 function loadWasm(): Promise<WasmSimilarity | null> {
-  wasmPromise ??= import('wasm-similarity').catch(() => null);
+  wasmPromise ??= import(WASM_SIMILARITY_SPECIFIER)
+    .then((module: unknown) =>
+      typeof (module as WasmSimilarity | null)?.cosine_similarity_dataspace === 'function'
+        ? (module as WasmSimilarity)
+        : null,
+    )
+    .catch(() => null);
   return wasmPromise;
 }
 export class BunSqliteVectorStore implements VectorStore {
@@ -76,27 +100,7 @@ export class BunSqliteVectorStore implements VectorStore {
       (r) =>
         !request.filterExpression || evaluateFilterExpression(request.filterExpression, r.metadata),
     );
-    const wasm = await loadWasm();
-    const ranked =
-      wasm && candidates.length > 0
-        ? wasm
-            .cosine_similarity_dataspace(
-              new Float64Array(candidates.flatMap((r) => r.embedding)),
-              candidates.length,
-              query.length,
-              new Float64Array(query),
-            )
-            .reduce<Array<{ r: (typeof candidates)[number]; score: number }>>(
-              (out, value, i, values) => {
-                if (i % 2 === 0 && i + 1 < values.length)
-                  out.push({ r: candidates[values[i + 1]!]!, score: value });
-                return out;
-              },
-              [],
-            )
-        : candidates
-            .map((r) => ({ r, score: cosine(query, r.embedding) }))
-            .sort((a, b) => b.score - a.score);
+    const ranked = (await this.score(query, candidates)).sort((a, b) => b.score - a.score);
     return ranked
       .filter((x) => x.score >= request.similarityThreshold)
       .slice(0, request.topK)
@@ -109,6 +113,22 @@ export class BunSqliteVectorStore implements VectorStore {
   }
   similaritySearchQuery(query: string) {
     return this.similaritySearch(searchRequest({ query }));
+  }
+  private async score(query: number[], candidates: readonly VectorRow[]): Promise<ScoredRow[]> {
+    const wasm = candidates.length > 0 ? await loadWasm() : null;
+    if (!wasm) return candidates.map((r) => ({ r, score: cosine(query, r.embedding) }));
+    const pairs = wasm.cosine_similarity_dataspace(
+      new Float64Array(candidates.flatMap((r) => r.embedding)),
+      candidates.length,
+      query.length,
+      new Float64Array(query),
+    );
+    const scored: ScoredRow[] = [];
+    for (let i = 0; i + 1 < pairs.length; i += 2) {
+      const candidate = candidates[pairs[i + 1] as number];
+      if (candidate) scored.push({ r: candidate, score: pairs[i] as number });
+    }
+    return scored;
   }
   private rows() {
     return this.db

--- a/packages/di-framework-ai/tests/ai-platform-additions.test.ts
+++ b/packages/di-framework-ai/tests/ai-platform-additions.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from 'bun:test';
+import type { CallAdvisorChain } from '../src/chat/client/advisor/advisor.ts';
+import { chatClientRequest } from '../src/chat/client/chat-client-request.ts';
+import { chatClientResponse } from '../src/chat/client/chat-client-response.ts';
 import {
-  RetryAdvisor,
-  StandardSchemaOutputConverter,
   createMcpToolServer,
   document,
   functionToolCallback,
@@ -9,18 +10,26 @@ import {
   media,
   parseStandardSchema,
   pdfDocumentLoader,
+  RetryAdvisor,
+  StandardSchemaOutputConverter,
   textDocumentLoader,
   toAnthropicMessages,
   toOpenAiMessages,
   userMessage,
 } from '../src/index.ts';
-import { chatClientRequest } from '../src/chat/client/chat-client-request.ts';
-import { chatClientResponse } from '../src/chat/client/chat-client-response.ts';
-import type { CallAdvisorChain } from '../src/chat/client/advisor/advisor.ts';
 
 describe('AI platform additions', () => {
   test('validates Standard Schema and converter output', async () => {
-    const schema = { '~standard': { version: 1 as const, vendor: 'test', validate: (v: unknown) => typeof v === 'object' && v !== null ? v as { ok: boolean } : { issues: [{ message: 'object expected' }] } } };
+    const schema = {
+      '~standard': {
+        version: 1 as const,
+        vendor: 'test',
+        validate: (v: unknown) =>
+          typeof v === 'object' && v !== null
+            ? (v as { ok: boolean })
+            : { issues: [{ message: 'object expected' }] },
+      },
+    };
     expect(await parseStandardSchema(schema, { ok: true })).toEqual({ ok: true });
     const converter = new StandardSchemaOutputConverter({ schema });
     expect(await converter.convertAsync('{"ok":true}')).toEqual({ ok: true });
@@ -29,30 +38,58 @@ describe('AI platform additions', () => {
 
   test('retries failed calls deterministically', async () => {
     let calls = 0;
-    const chain: CallAdvisorChain = { callAdvisors: [], async nextCall() { calls++; if (calls < 3) throw { details: { retryable: true } }; return chatClientResponse(undefined); } };
-    const result = await new RetryAdvisor({ maxAttempts: 3, backoffMs: 0 }).adviseCall(chatClientRequest({} as never), chain);
-    expect(result.chatResponse).toBeUndefined(); expect(calls).toBe(3);
+    const chain: CallAdvisorChain = {
+      callAdvisors: [],
+      async nextCall() {
+        calls++;
+        if (calls < 3) throw { details: { retryable: true } };
+        return chatClientResponse(undefined);
+      },
+    };
+    const result = await new RetryAdvisor({ maxAttempts: 3, backoffMs: 0 }).adviseCall(
+      chatClientRequest({} as never),
+      chain,
+    );
+    expect(result.chatResponse).toBeUndefined();
+    expect(calls).toBe(3);
   });
 
   test('maps multimodal content for both providers', () => {
     const msg = userMessage('describe', { media: [media('image/png', 'aGVsbG8=')] });
     const openai = toOpenAiMessages([msg]);
-    expect(openai[0]!.content).toEqual([{ type: 'text', text: 'describe' }, { type: 'image_url', image_url: { url: 'data:image/png;base64,aGVsbG8=' } }]);
+    expect(openai[0]!.content).toEqual([
+      { type: 'text', text: 'describe' },
+      { type: 'image_url', image_url: { url: 'data:image/png;base64,aGVsbG8=' } },
+    ]);
     const anthropic = toAnthropicMessages([msg]);
     expect(anthropic.messages[0]!.content).toHaveLength(2);
   });
 
   test('serves local tools through MCP surface', async () => {
-    const server = createMcpToolServer({ tools: [functionToolCallback({ name: 'add', inputSchema: { type: 'object' }, call: (input: { a: number }) => input.a + 1 })] });
+    const server = createMcpToolServer({
+      tools: [
+        functionToolCallback({
+          name: 'add',
+          inputSchema: { type: 'object' },
+          call: (input: { a: number }) => input.a + 1,
+        }),
+      ],
+    });
     expect(server.listTools()[0]?.name).toBe('add');
     expect(await server.callTool('add', { a: 2 })).toMatchObject({ content: [{ text: '3' }] });
     expect((await server.callTool('missing')).isError).toBe(true);
   });
 
   test('loads text, HTML, and injected PDF text', async () => {
-    expect((await textDocumentLoader().load(new TextEncoder().encode('hello')))[0]?.text).toBe('hello');
-    expect((await htmlDocumentLoader().load('<h1>Hello</h1><script>x</script>'))[0]?.text).toBe('Hello');
-    expect((await pdfDocumentLoader(() => 'pdf text').load(new Uint8Array([1])))[0]?.text).toBe('pdf text');
+    expect((await textDocumentLoader().load(new TextEncoder().encode('hello')))[0]?.text).toBe(
+      'hello',
+    );
+    expect((await htmlDocumentLoader().load('<h1>Hello</h1><script>x</script>'))[0]?.text).toBe(
+      'Hello',
+    );
+    expect((await pdfDocumentLoader(() => 'pdf text').load(new Uint8Array([1])))[0]?.text).toBe(
+      'pdf text',
+    );
     expect(document({ text: 'x' }).metadata).toEqual({});
   });
 });

--- a/packages/di-framework-ai/tests/ai-platform-additions.test.ts
+++ b/packages/di-framework-ai/tests/ai-platform-additions.test.ts
@@ -57,12 +57,16 @@ describe('AI platform additions', () => {
   test('maps multimodal content for both providers', () => {
     const msg = userMessage('describe', { media: [media('image/png', 'aGVsbG8=')] });
     const openai = toOpenAiMessages([msg]);
-    expect(openai[0]!.content).toEqual([
+    const openAiMessage = openai[0];
+    expect(openAiMessage).toBeDefined();
+    expect(openAiMessage?.content).toEqual([
       { type: 'text', text: 'describe' },
       { type: 'image_url', image_url: { url: 'data:image/png;base64,aGVsbG8=' } },
     ]);
     const anthropic = toAnthropicMessages([msg]);
-    expect(anthropic.messages[0]!.content).toHaveLength(2);
+    const anthropicMessage = anthropic.messages[0];
+    expect(anthropicMessage).toBeDefined();
+    expect(anthropicMessage?.content).toHaveLength(2);
   });
 
   test('serves local tools through MCP surface', async () => {

--- a/packages/di-framework-ai/tests/ai-platform-additions.test.ts
+++ b/packages/di-framework-ai/tests/ai-platform-additions.test.ts
@@ -96,4 +96,18 @@ describe('AI platform additions', () => {
     );
     expect(document({ text: 'x' }).metadata).toEqual({});
   });
+
+  test('strips HTML markup that defeats naive tag regexes', async () => {
+    const load = async (html: string) => (await htmlDocumentLoader().load(html))[0]?.text;
+    expect(await load('<script>evil()</script >keep')).toBe('keep');
+    expect(await load('<SCRIPT\ntype="text/javascript">evil()</SCRIPT>keep')).toBe('keep');
+    expect(await load('<style>a{}</style\t>keep')).toBe('keep');
+    expect(await load('<div title="a > b">keep</div>')).toBe('keep');
+    expect(await load('<!-- <script>evil()</script> -->keep')).toBe('keep');
+    expect(await load('<script>a</script><script>b</script>keep')).toBe('keep');
+    expect(await load('1 < 2 and 3 > 2')).toBe('1 < 2 and 3 > 2');
+    expect(await load('<p>a&nbsp;b</p>')).toBe('a b');
+    expect(await load('<title>Doc</title><p>body</p>')).toBe('Doc body');
+    expect(await load('<script>unterminated')).toBe('');
+  });
 });

--- a/packages/di-framework-ai/tests/ai-platform-additions.test.ts
+++ b/packages/di-framework-ai/tests/ai-platform-additions.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  RetryAdvisor,
+  StandardSchemaOutputConverter,
+  createMcpToolServer,
+  document,
+  functionToolCallback,
+  htmlDocumentLoader,
+  media,
+  parseStandardSchema,
+  pdfDocumentLoader,
+  textDocumentLoader,
+  toAnthropicMessages,
+  toOpenAiMessages,
+  userMessage,
+} from '../src/index.ts';
+import { chatClientRequest } from '../src/chat/client/chat-client-request.ts';
+import { chatClientResponse } from '../src/chat/client/chat-client-response.ts';
+import type { CallAdvisorChain } from '../src/chat/client/advisor/advisor.ts';
+
+describe('AI platform additions', () => {
+  test('validates Standard Schema and converter output', async () => {
+    const schema = { '~standard': { version: 1 as const, vendor: 'test', validate: (v: unknown) => typeof v === 'object' && v !== null ? v as { ok: boolean } : { issues: [{ message: 'object expected' }] } } };
+    expect(await parseStandardSchema(schema, { ok: true })).toEqual({ ok: true });
+    const converter = new StandardSchemaOutputConverter({ schema });
+    expect(await converter.convertAsync('{"ok":true}')).toEqual({ ok: true });
+    await expect(converter.convertAsync('null')).rejects.toThrow('object expected');
+  });
+
+  test('retries failed calls deterministically', async () => {
+    let calls = 0;
+    const chain: CallAdvisorChain = { callAdvisors: [], async nextCall() { calls++; if (calls < 3) throw { details: { retryable: true } }; return chatClientResponse(undefined); } };
+    const result = await new RetryAdvisor({ maxAttempts: 3, backoffMs: 0 }).adviseCall(chatClientRequest({} as never), chain);
+    expect(result.chatResponse).toBeUndefined(); expect(calls).toBe(3);
+  });
+
+  test('maps multimodal content for both providers', () => {
+    const msg = userMessage('describe', { media: [media('image/png', 'aGVsbG8=')] });
+    const openai = toOpenAiMessages([msg]);
+    expect(openai[0]!.content).toEqual([{ type: 'text', text: 'describe' }, { type: 'image_url', image_url: { url: 'data:image/png;base64,aGVsbG8=' } }]);
+    const anthropic = toAnthropicMessages([msg]);
+    expect(anthropic.messages[0]!.content).toHaveLength(2);
+  });
+
+  test('serves local tools through MCP surface', async () => {
+    const server = createMcpToolServer({ tools: [functionToolCallback({ name: 'add', inputSchema: { type: 'object' }, call: (input: { a: number }) => input.a + 1 })] });
+    expect(server.listTools()[0]?.name).toBe('add');
+    expect(await server.callTool('add', { a: 2 })).toMatchObject({ content: [{ text: '3' }] });
+    expect((await server.callTool('missing')).isError).toBe(true);
+  });
+
+  test('loads text, HTML, and injected PDF text', async () => {
+    expect((await textDocumentLoader().load(new TextEncoder().encode('hello')))[0]?.text).toBe('hello');
+    expect((await htmlDocumentLoader().load('<h1>Hello</h1><script>x</script>'))[0]?.text).toBe('Hello');
+    expect((await pdfDocumentLoader(() => 'pdf text').load(new Uint8Array([1])))[0]?.text).toBe('pdf text');
+    expect(document({ text: 'x' }).metadata).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

Second stack layer, based on #73: portable AI platform capabilities needed by production integrations and examples.

## Includes

- Implements #61, #62, #63, #64, and #65.
- Standard Schema adapters for tools and structured output.
- Retry advisor with transient-error classification, backoff, jitter, and cancellation.
- OpenAI/Anthropic multimodal message mapping.
- In-process MCP tool server hosting.
- Text, HTML, and optional PDF document loaders.
- Deterministic tests for the new APIs and provider behavior.

## Verification

- Typecheck passes with the repository TypeScript 5.9 toolchain.
- AI platform additions and existing AI tests pass.

This PR targets `stack/infra`; the next stack layer targets this branch.