### PR TITLE
feat(ai/graphql): add example, SSE, multipart, and persisted queries

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,18 @@
         "@di-framework/core": "workspace:*",
       },
     },
+    "examples/packages/ai-chat": {
+      "name": "@di-framework/ai-chat-example",
+      "version": "0.0.0",
+      "dependencies": {
+        "@di-framework/ai": "workspace:*",
+        "@di-framework/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5",
+      },
+    },
     "examples/packages/auth": {
       "name": "di-auth-example",
       "version": "0.0.0",
@@ -308,6 +320,8 @@
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
     "@di-framework/ai": ["@di-framework/ai@workspace:packages/di-framework-ai"],
+
+    "@di-framework/ai-chat-example": ["@di-framework/ai-chat-example@workspace:examples/packages/ai-chat"],
 
     "@di-framework/auth": ["@di-framework/auth@workspace:packages/di-framework-auth"],
 

--- a/examples/packages/ai-chat/README.md
+++ b/examples/packages/ai-chat/README.md
@@ -1,0 +1,10 @@
+# AI chat + tools + RAG example
+
+This example uses the annotation-first `@di-framework/ai` API:
+
+- `@AiService` defines the assistant.
+- `@ToolSet` and `@Tool` expose a domain tool.
+- `@WithRag` attaches retrieval augmentation.
+- `configureAi` wires the chat model, tool bean, and vector store through DI.
+
+The test uses `ScriptedChatModel`, `FakeEmbeddingModel`, and `SimpleVectorStore`, so it runs without an API key. Replace the scripted model with an OpenAI-compatible or Anthropic model in an application that has provider credentials.

--- a/examples/packages/ai-chat/package.json
+++ b/examples/packages/ai-chat/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@di-framework/ai-chat-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Annotation-first chat, tools, and RAG example for @di-framework/ai",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@di-framework/ai": "workspace:*",
+    "@di-framework/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5"
+  }
+}

--- a/examples/packages/ai-chat/src/main.test.ts
+++ b/examples/packages/ai-chat/src/main.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from 'bun:test';
+import { runExample } from './main.ts';
+
+test('runs annotation-first chat, tool, and RAG flow without live credentials', async () => {
+  await expect(runExample()).resolves.toContain('two-year warranty');
+});

--- a/examples/packages/ai-chat/src/main.ts
+++ b/examples/packages/ai-chat/src/main.ts
@@ -1,0 +1,78 @@
+import { Container } from '@di-framework/core/decorators';
+import {
+  AiService,
+  configureAi,
+  FakeEmbeddingModel,
+  IndexedDocument,
+  ScriptedChatModel,
+  SimpleVectorStore,
+  Tool,
+  ToolSet,
+  toolCall,
+  toolCallResponse,
+  UserMessageAnn,
+  WithRag,
+  resolveAiService,
+} from '@di-framework/ai';
+
+@ToolSet()
+@Container()
+export class ProductTools {
+  @Tool({
+    description: 'Look up the support policy for a product.',
+    inputSchema: {
+      type: 'object',
+      properties: { product: { type: 'string' } },
+      required: ['product'],
+    },
+  })
+  supportPolicy({ product }: { product: string }): string {
+    return `${product}: standard support is available Monday through Friday.`;
+  }
+}
+
+@IndexedDocument({
+  text: 'The Acme Widget includes a two-year warranty and weekday email support.',
+  metadata: { source: 'example-catalog' },
+})
+@WithRag({ topK: 1 })
+@AiService({ tools: [ProductTools] })
+export class SupportAssistant {
+  ask(@UserMessageAnn() _question: string): Promise<string> {
+    throw new Error('The annotation proxy supplies this method at runtime.');
+  }
+}
+
+/** Run the complete no-credentials example path. */
+export async function runExample(): Promise<string> {
+  const vectorStore = SimpleVectorStore.of(new FakeEmbeddingModel());
+  await vectorStore.add([
+    {
+      id: 'acme-widget',
+      text: 'The Acme Widget includes a two-year warranty and weekday email support.',
+      media: null,
+      metadata: { source: 'example-catalog' },
+      score: null,
+    },
+  ]);
+
+  const model = new ScriptedChatModel([
+    {
+      respond: () => toolCallResponse([toolCall('support-1', 'supportPolicy', { product: 'Acme Widget' })]),
+    },
+    { respond: 'The Acme Widget has a two-year warranty and weekday support.' },
+  ]);
+
+  configureAi({
+    chatModel: model,
+    toolBeans: [ProductTools],
+    vectorStore,
+    scanAnnotations: true,
+  });
+
+  return resolveAiService(SupportAssistant).ask('What support does the Acme Widget have?');
+}
+
+if (import.meta.main) {
+  console.log(await runExample());
+}

--- a/examples/packages/ai-chat/src/main.ts
+++ b/examples/packages/ai-chat/src/main.ts
@@ -1,9 +1,9 @@
-import { Container } from '@di-framework/core/decorators';
 import {
   AiService,
   configureAi,
   FakeEmbeddingModel,
   IndexedDocument,
+  resolveAiService,
   ScriptedChatModel,
   SimpleVectorStore,
   Tool,
@@ -12,8 +12,8 @@ import {
   toolCallResponse,
   UserMessageAnn,
   WithRag,
-  resolveAiService,
 } from '@di-framework/ai';
+import { Container } from '@di-framework/core/decorators';
 
 @ToolSet()
 @Container()
@@ -58,7 +58,8 @@ export async function runExample(): Promise<string> {
 
   const model = new ScriptedChatModel([
     {
-      respond: () => toolCallResponse([toolCall('support-1', 'supportPolicy', { product: 'Acme Widget' })]),
+      respond: () =>
+        toolCallResponse([toolCall('support-1', 'supportPolicy', { product: 'Acme Widget' })]),
     },
     { respond: 'The Acme Widget has a two-year warranty and weekday support.' },
   ]);

--- a/examples/packages/ai-chat/tsconfig.json
+++ b/examples/packages/ai-chat/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["**/*.ts"]
+}

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -7,7 +7,9 @@
       "@di-framework/http": ["../packages/di-framework-http/index.ts"],
       "@di-framework/http/*": ["../packages/di-framework-http/*"],
       "@di-framework/graphql": ["../packages/di-framework-graphql/index.ts"],
-      "@di-framework/graphql/*": ["../packages/di-framework-graphql/*"]
+      "@di-framework/graphql/*": ["../packages/di-framework-graphql/*"],
+      "@di-framework/ai": ["../packages/di-framework-ai/index.ts"],
+      "@di-framework/ai/*": ["../packages/di-framework-ai/*"]
     }
   },
   "include": [
@@ -17,7 +19,8 @@
     "packages/http-router/**/*.ts",
     "packages/services/**/*.ts",
     "packages/test-example/**/*.ts",
-    "packages/cf-worker/**/*.ts"
+    "packages/cf-worker/**/*.ts",
+    "packages/ai-chat/**/*.ts"
   ],
   "exclude": ["node_modules", "packages/deno-http/**/*", "packages/deno-sandboxes/**/*"]
 }

--- a/packages/di-framework-graphql/index.ts
+++ b/packages/di-framework-graphql/index.ts
@@ -9,10 +9,10 @@ export {
   type GraphQLRouteOptions,
   type GraphQLRouterLike,
   type HandlerOptions,
-  type SubscriptionHandlerOptions,
   JSONScalar,
   mountGraphQL,
   registerScalar,
   type SemanticSchema,
   type SemanticSchemaOptions,
+  type SubscriptionHandlerOptions,
 } from './src/schema.ts';

--- a/packages/di-framework-graphql/index.ts
+++ b/packages/di-framework-graphql/index.ts
@@ -3,11 +3,13 @@ export { containerEventIterator, hydrate, ResolverFactory } from './src/resolver
 export {
   buildSemanticSchema,
   createGraphQLHandler,
+  createGraphQLSSEHandler,
   DateTimeScalar,
   type ExecuteRequest,
   type GraphQLRouteOptions,
   type GraphQLRouterLike,
   type HandlerOptions,
+  type SubscriptionHandlerOptions,
   JSONScalar,
   mountGraphQL,
   registerScalar,

--- a/packages/di-framework-graphql/src/schema.ts
+++ b/packages/di-framework-graphql/src/schema.ts
@@ -476,6 +476,12 @@ export interface HandlerOptions {
   context?: (request: Request) => GraphQLContext | Promise<GraphQLContext>;
 }
 
+/** Options for the lightweight GraphQL-over-SSE subscription endpoint. */
+export interface SubscriptionHandlerOptions extends HandlerOptions {
+  /** Keep the stream open with periodic SSE comments (milliseconds). */
+  heartbeatMs?: number;
+}
+
 /** Minimal router surface accepted by {@link mountGraphQL}. */
 export interface GraphQLRouterLike {
   get(
@@ -557,6 +563,74 @@ export function mountGraphQL<R extends GraphQLRouterLike>(
   router.get(path, handler);
   router.post(path, handler);
   return router;
+}
+
+/**
+ * Serve GraphQL subscriptions over Server-Sent Events. The endpoint accepts a
+ * GET request with the standard `query`, `variables`, and `operationName`
+ * parameters and emits `data` events until the client aborts the request.
+ */
+export function createGraphQLSSEHandler(
+  api: SemanticSchema,
+  options: SubscriptionHandlerOptions = {},
+): (request: Request) => Promise<Response> {
+  return async (request) => {
+    if (request.method !== 'GET') {
+      return new Response(JSON.stringify({ errors: [{ message: 'Subscriptions require GET' }] }), {
+        status: 405,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    const url = new URL(request.url);
+    const query = url.searchParams.get('query');
+    if (!query) return new Response('Missing "query" parameter', { status: 400 });
+    const variables = url.searchParams.get('variables');
+    const context = options.context ? await options.context(request) : {};
+    const result = await api.subscribe({
+      query,
+      variables: variables ? JSON.parse(variables) : undefined,
+      operationName: url.searchParams.get('operationName'),
+      context,
+    });
+    if (!Symbol.asyncIterator || typeof (result as any)?.[Symbol.asyncIterator] !== 'function') {
+      return new Response(JSON.stringify(result), {
+        status: 400,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    const iterator = result as AsyncIterableIterator<ExecutionResult>;
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        let heartbeat: ReturnType<typeof setInterval> | undefined;
+        if (options.heartbeatMs && options.heartbeatMs > 0) {
+          heartbeat = setInterval(() => controller.enqueue(encoder.encode(': heartbeat\n\n')), options.heartbeatMs);
+        }
+        try {
+          for await (const item of iterator) {
+            controller.enqueue(encoder.encode(`event: next\ndata: ${JSON.stringify(item)}\n\n`));
+          }
+          controller.enqueue(encoder.encode('event: complete\ndata: {}\n\n'));
+          controller.close();
+        } catch (error) {
+          controller.enqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({ errors: [{ message: String(error) }] })}\n\n`));
+          controller.close();
+        } finally {
+          if (heartbeat) clearInterval(heartbeat);
+        }
+      },
+      async cancel() {
+        await iterator.return?.();
+      },
+    });
+    return new Response(stream, {
+      headers: {
+        'content-type': 'text/event-stream',
+        'cache-control': 'no-cache',
+        connection: 'keep-alive',
+      },
+    });
+  };
 }
 
 export { DateTimeScalar, JSONScalar };

--- a/packages/di-framework-graphql/src/schema.ts
+++ b/packages/di-framework-graphql/src/schema.ts
@@ -526,7 +526,13 @@ export function createGraphQLHandler(
       let query = url.searchParams.get('query');
       const hash = url.searchParams.get('extensions.persistedQuery.sha256Hash');
       if (!query && hash) query = options.persistedQueries?.get(hash) ?? null;
-      if (!query) return json({ errors: [{ message: hash ? 'Persisted query not found' : 'Missing "query" parameter' }] }, 400);
+      if (!query)
+        return json(
+          {
+            errors: [{ message: hash ? 'Persisted query not found' : 'Missing "query" parameter' }],
+          },
+          400,
+        );
       const variables = url.searchParams.get('variables');
       payload = {
         query,
@@ -549,7 +555,7 @@ export function createGraphQLHandler(
           if (hash && options.persistedQueries?.has(hash)) {
             body.query = options.persistedQueries.get(hash) as string;
           } else {
-          return json({ errors: [{ message: 'Missing "query" in request body' }] }, 400);
+            return json({ errors: [{ message: 'Missing "query" in request body' }] }, 400);
           }
         }
         payload = body;

--- a/packages/di-framework-graphql/src/schema.ts
+++ b/packages/di-framework-graphql/src/schema.ts
@@ -604,7 +604,10 @@ export function createGraphQLSSEHandler(
       async start(controller) {
         let heartbeat: ReturnType<typeof setInterval> | undefined;
         if (options.heartbeatMs && options.heartbeatMs > 0) {
-          heartbeat = setInterval(() => controller.enqueue(encoder.encode(': heartbeat\n\n')), options.heartbeatMs);
+          heartbeat = setInterval(
+            () => controller.enqueue(encoder.encode(': heartbeat\n\n')),
+            options.heartbeatMs,
+          );
         }
         try {
           for await (const item of iterator) {
@@ -613,7 +616,11 @@ export function createGraphQLSSEHandler(
           controller.enqueue(encoder.encode('event: complete\ndata: {}\n\n'));
           controller.close();
         } catch (error) {
-          controller.enqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({ errors: [{ message: String(error) }] })}\n\n`));
+          controller.enqueue(
+            encoder.encode(
+              `event: error\ndata: ${JSON.stringify({ errors: [{ message: String(error) }] })}\n\n`,
+            ),
+          );
           controller.close();
         } finally {
           if (heartbeat) clearInterval(heartbeat);

--- a/packages/di-framework-graphql/src/schema.ts
+++ b/packages/di-framework-graphql/src/schema.ts
@@ -155,6 +155,7 @@ export interface ExecuteRequest {
   /** Per-request context. Defaults to `{}` so request-scoped batching works. */
   context?: GraphQLContext;
   rootValue?: unknown;
+  extensions?: Record<string, any>;
 }
 
 export interface SemanticSchema {
@@ -474,6 +475,8 @@ export function buildSemanticSchema(options: SemanticSchemaOptions = {}): Semant
 export interface HandlerOptions {
   /** Build the per-request context. Receives the incoming request. */
   context?: (request: Request) => GraphQLContext | Promise<GraphQLContext>;
+  /** Optional persisted-query hash to document lookup. */
+  persistedQueries?: Map<string, string>;
 }
 
 /** Options for the lightweight GraphQL-over-SSE subscription endpoint. */
@@ -520,8 +523,10 @@ export function createGraphQLHandler(
 
     if (request.method === 'GET') {
       const url = new URL(request.url);
-      const query = url.searchParams.get('query');
-      if (!query) return json({ errors: [{ message: 'Missing "query" parameter' }] }, 400);
+      let query = url.searchParams.get('query');
+      const hash = url.searchParams.get('extensions.persistedQuery.sha256Hash');
+      if (!query && hash) query = options.persistedQueries?.get(hash) ?? null;
+      if (!query) return json({ errors: [{ message: hash ? 'Persisted query not found' : 'Missing "query" parameter' }] }, 400);
       const variables = url.searchParams.get('variables');
       payload = {
         query,
@@ -530,9 +535,22 @@ export function createGraphQLHandler(
       };
     } else if (request.method === 'POST') {
       try {
-        const body = (await request.json()) as ExecuteRequest;
+        const contentType = request.headers.get('content-type') ?? '';
+        let body: ExecuteRequest;
+        if (contentType.startsWith('multipart/form-data')) {
+          const form = await request.formData();
+          const operations = JSON.parse(String(form.get('operations') ?? '{}')) as ExecuteRequest;
+          body = operations;
+        } else {
+          body = (await request.json()) as ExecuteRequest;
+        }
         if (!body || typeof body.query !== 'string') {
+          const hash = (body?.extensions as any)?.persistedQuery?.sha256Hash;
+          if (hash && options.persistedQueries?.has(hash)) {
+            body.query = options.persistedQueries.get(hash) as string;
+          } else {
           return json({ errors: [{ message: 'Missing "query" in request body' }] }, 400);
+          }
         }
         payload = body;
       } catch {


### PR DESCRIPTION
## Summary

Fourth stack layer, based on #75: integration example plus the remaining transport/request features.

## Includes

- Implements #25 and #31.
- Implements the end-to-end example in #67.
- Adds GraphQL-over-SSE subscription handling with heartbeat, cancellation, and completion/error events.
- Adds persisted-query lookup and multipart request parsing.
- Adds `examples/packages/ai-chat` demonstrating annotation-first `@AiService`, `@ToolSet`/`@Tool`, `@WithRag`, DI configuration, vector retrieval, and a no-live-credentials scripted test path.

## Verification

- Example test passes with `ScriptedChatModel`, `FakeEmbeddingModel`, and `SimpleVectorStore`.
- Typecheck passes with the repository TypeScript 5.9 toolchain.

This PR targets `stack/graphql`.