### PR TITLE
feat(graphql): add interfaces and unions (#20)

### DIFF
--- a/packages/di-framework-graphql/core.ts
+++ b/packages/di-framework-graphql/core.ts
@@ -19,4 +19,5 @@ export { getRegistry, SemanticRegistry, setRegistry } from './src/registry.ts';
 export * from './src/scalars.ts';
 export { type PrintOptions, printSDL, printTypeNode } from './src/sdl.ts';
 export { buildTypeGraph, namedTypeNode } from './src/type-graph.ts';
+export { UnionRef } from './src/types.ts';
 export type * from './src/types.ts';

--- a/packages/di-framework-graphql/src/decorators.ts
+++ b/packages/di-framework-graphql/src/decorators.ts
@@ -12,26 +12,31 @@ import { SemanticSchemaError } from './errors.ts';
 import {
   defineBoundedContext,
   defineFieldDeclaration,
+  defineImplements,
   defineLookup,
   defineParamDeclaration,
 } from './metadata.ts';
 import { getRegistry } from './registry.ts';
 import { ScalarRef, scalarNameForConstructor } from './scalars.ts';
-import type {
-  ActionOptions,
-  ArgOptions,
-  Ctor,
-  EnumObject,
-  EnumOptions,
-  ExtendsOptions,
-  FieldOptions,
-  InputTypeOptions,
-  PortalOptions,
-  SemanticTypeOptions,
-  SubscriptionOptions,
-  TypeInput,
-  TypeRef,
-  TypeThunk,
+import {
+  type AbstractCtor,
+  type ActionOptions,
+  type ArgOptions,
+  type Ctor,
+  type EnumObject,
+  type EnumOptions,
+  type ExtendsOptions,
+  type FieldOptions,
+  type InputTypeOptions,
+  type InterfaceTypeOptions,
+  type PortalOptions,
+  type SemanticTypeOptions,
+  type SubscriptionOptions,
+  type TypeInput,
+  type TypeRef,
+  type TypeThunk,
+  type UnionOptions,
+  UnionRef,
 } from './types.ts';
 
 /* -------------------------------------------------------------------------- */
@@ -40,6 +45,7 @@ import type {
 
 function isTypeReference(value: unknown): boolean {
   if (value instanceof ScalarRef) return true;
+  if (value instanceof UnionRef) return true;
   if (Array.isArray(value)) return true;
   if (typeof value !== 'function') return false;
   // A thunk (`() => User`) is a type reference too; so is a class passed directly.
@@ -118,6 +124,72 @@ export function Portal(options: PortalOptions & { singleton?: boolean } = {}) {
     ContainerDecorator({ singleton })(target as any);
     return target;
   };
+}
+
+/**
+ * Declares a class as a GraphQL interface — a shared contract that concrete
+ * `@SemanticType`s implement.
+ *
+ * The class itself is never instantiated by the schema; it exists so the shared
+ * fields have somewhere to live and so implementations can inherit them by
+ * extending it.
+ *
+ * @example
+ * ```ts
+ * @InterfaceType({ description: 'Anything addressable by a global id.' })
+ * abstract class Node {
+ *   @Field(() => ID) id!: string;
+ * }
+ *
+ * @Implements(() => Node)
+ * @SemanticType()
+ * class User extends Node {}
+ * ```
+ */
+export function InterfaceType(options: InterfaceTypeOptions = {}) {
+  return <T extends AbstractCtor>(target: T): T => {
+    getRegistry().registerInterface({
+      target: target as unknown as Ctor,
+      name: options.name ?? (target as unknown as Ctor).name,
+      options,
+    });
+    return target;
+  };
+}
+
+/**
+ * Declares that a semantic type implements one or more interfaces.
+ *
+ * Interface fields the class does not redeclare are inherited, so a type only
+ * has to write down what it adds.
+ */
+export function Implements(...interfaces: TypeThunk[]) {
+  return <T extends Ctor>(target: T): T => {
+    defineImplements(target, interfaces);
+    return target;
+  };
+}
+
+/**
+ * Registers a union over concrete `@SemanticType`s and returns a reference
+ * usable anywhere a type is expected.
+ *
+ * @example
+ * ```ts
+ * const SearchResult = registerUnion('SearchResult', () => [User, Order]);
+ *
+ * @Field(() => [SearchResult])
+ * search(@Arg('q', () => String) q: string) { ... }
+ * ```
+ */
+export function registerUnion(
+  name: string,
+  members: () => readonly Ctor[],
+  options: UnionOptions = {},
+): UnionRef {
+  const ref = new UnionRef(name, members, options);
+  getRegistry().registerUnion({ ref, name, options });
+  return ref;
 }
 
 /** Declares a GraphQL input object. Its `@Field`s become input fields. */

--- a/packages/di-framework-graphql/src/metadata.ts
+++ b/packages/di-framework-graphql/src/metadata.ts
@@ -6,12 +6,13 @@
  */
 
 import { defineMetadata, getOwnMetadata } from '@di-framework/core/container';
-import type { Ctor, FieldDeclaration, ParamDeclaration } from './types.ts';
+import type { Ctor, FieldDeclaration, ParamDeclaration, TypeThunk } from './types.ts';
 
 export const FIELDS_METADATA_KEY = 'graphql:fields';
 export const PARAMS_METADATA_KEY = 'graphql:params';
 export const LOOKUP_METADATA_KEY = 'graphql:lookup';
 export const CONTEXT_METADATA_KEY = 'graphql:bounded-context';
+export const IMPLEMENTS_METADATA_KEY = 'graphql:implements';
 
 type FieldMap = Record<string, FieldDeclaration>;
 type ParamMap = Record<string, Record<number, ParamDeclaration>>;
@@ -83,6 +84,27 @@ export function getLookup(target: Ctor): string | undefined {
     current = Object.getPrototypeOf(current);
   }
   return undefined;
+}
+
+/** Record an interface implemented by a class (`@Implements`). */
+export function defineImplements(target: Ctor, interfaces: readonly TypeThunk[]): void {
+  const own: TypeThunk[] = getOwnMetadata(IMPLEMENTS_METADATA_KEY, target) || [];
+  defineMetadata(IMPLEMENTS_METADATA_KEY, [...own, ...interfaces], target);
+}
+
+/**
+ * Every interface a class implements, including those inherited from base
+ * classes — subclassing a type that implements `Node` implements it too.
+ */
+export function getImplements(target: Ctor): TypeThunk[] {
+  const collected: TypeThunk[] = [];
+  let current: any = target;
+  while (current && current !== Function.prototype) {
+    const own: TypeThunk[] | undefined = getOwnMetadata(IMPLEMENTS_METADATA_KEY, current);
+    if (own) collected.push(...own);
+    current = Object.getPrototypeOf(current);
+  }
+  return collected;
 }
 
 /** Record the bounded context a class belongs to (`@BoundedContext`). */

--- a/packages/di-framework-graphql/src/registry.ts
+++ b/packages/di-framework-graphql/src/registry.ts
@@ -12,13 +12,18 @@ import type {
   EnumObject,
   ExtensionDeclaration,
   InputTypeDeclaration,
+  InterfaceTypeDeclaration,
   SemanticTypeDeclaration,
+  UnionDeclaration,
+  UnionRef,
 } from './types.ts';
 
 export class SemanticRegistry {
   private types = new Map<Ctor, SemanticTypeDeclaration>();
   private inputs = new Map<Ctor, InputTypeDeclaration>();
   private enums = new Map<EnumObject, EnumDeclaration>();
+  private interfaces = new Map<Ctor, InterfaceTypeDeclaration>();
+  private unions = new Map<UnionRef, UnionDeclaration>();
   private extensions: ExtensionDeclaration[] = [];
 
   registerType(declaration: SemanticTypeDeclaration): void {
@@ -35,6 +40,30 @@ export class SemanticRegistry {
 
   registerExtension(declaration: ExtensionDeclaration): void {
     this.extensions.push(declaration);
+  }
+
+  registerInterface(declaration: InterfaceTypeDeclaration): void {
+    this.interfaces.set(declaration.target, declaration);
+  }
+
+  registerUnion(declaration: UnionDeclaration): void {
+    this.unions.set(declaration.ref, declaration);
+  }
+
+  getInterface(target: Ctor): InterfaceTypeDeclaration | undefined {
+    return this.interfaces.get(target);
+  }
+
+  getUnion(ref: UnionRef): UnionDeclaration | undefined {
+    return this.unions.get(ref);
+  }
+
+  getInterfaces(): InterfaceTypeDeclaration[] {
+    return Array.from(this.interfaces.values());
+  }
+
+  getUnions(): UnionDeclaration[] {
+    return Array.from(this.unions.values());
   }
 
   getType(target: Ctor): SemanticTypeDeclaration | undefined {
@@ -83,6 +112,8 @@ export class SemanticRegistry {
     for (const [key, value] of this.types) clone.types.set(key, value);
     for (const [key, value] of this.inputs) clone.inputs.set(key, value);
     for (const [key, value] of this.enums) clone.enums.set(key, value);
+    for (const [key, value] of this.interfaces) clone.interfaces.set(key, value);
+    for (const [key, value] of this.unions) clone.unions.set(key, value);
     clone.extensions = [...this.extensions];
     return clone;
   }
@@ -91,6 +122,8 @@ export class SemanticRegistry {
     this.types.clear();
     this.inputs.clear();
     this.enums.clear();
+    this.interfaces.clear();
+    this.unions.clear();
     this.extensions = [];
   }
 }

--- a/packages/di-framework-graphql/src/schema.ts
+++ b/packages/di-framework-graphql/src/schema.ts
@@ -22,6 +22,7 @@ import {
   GraphQLInputObjectType,
   type GraphQLInputType,
   GraphQLInt,
+  GraphQLInterfaceType,
   GraphQLList,
   type GraphQLNamedType,
   GraphQLNonNull,
@@ -31,6 +32,7 @@ import {
   GraphQLSchema,
   GraphQLString,
   type GraphQLType,
+  GraphQLUnionType,
   Kind,
   parse,
   subscribe,
@@ -48,6 +50,7 @@ import type {
   ResolvedField,
   TypeGraph,
   TypeNode,
+  TypeResolver,
 } from './types.ts';
 
 /* -------------------------------------------------------------------------- */
@@ -215,6 +218,31 @@ class SchemaAssembler {
       );
     }
 
+    for (const resolved of this.graph.interfaces) {
+      this.named.set(
+        resolved.name,
+        new GraphQLInterfaceType({
+          name: resolved.name,
+          description: resolved.description,
+          extensions: { diFramework: { context: resolved.context } },
+          fields: () => this.toFieldConfigMap(resolved.fields),
+          resolveType: this.createTypeResolver(resolved.implementations, resolved.resolveType),
+        }),
+      );
+    }
+
+    for (const union of this.graph.unions) {
+      this.named.set(
+        union.name,
+        new GraphQLUnionType({
+          name: union.name,
+          description: union.description,
+          types: () => union.members.map((name) => this.named.get(name) as GraphQLObjectType),
+          resolveType: this.createTypeResolver(union.members, union.resolveType),
+        }),
+      );
+    }
+
     for (const object of this.graph.objects) {
       this.named.set(
         object.name,
@@ -228,6 +256,8 @@ class SchemaAssembler {
               key: object.key,
             },
           },
+          interfaces: () =>
+            object.interfaces.map((name) => this.named.get(name) as GraphQLInterfaceType),
           fields: () => this.toFieldConfigMap(object.fields),
         }),
       );
@@ -258,6 +288,44 @@ class SchemaAssembler {
       subscription,
       types: Array.from(this.named.values()),
     });
+  }
+
+  /**
+   * Decide which concrete type backs a value for an interface or union.
+   *
+   * Explicit `resolveType` wins; otherwise the value is matched against each
+   * candidate class with `instanceof` — which is what hydration produces — and
+   * finally against a `__typename` carried by plain data.
+   */
+  private createTypeResolver(
+    candidates: string[],
+    explicit: TypeResolver | undefined,
+  ): (
+    value: any,
+    ctx: GraphQLContext,
+    info: any,
+  ) => string | undefined | Promise<string | undefined> {
+    const targets = candidates
+      .map((name) => this.graph.objects.find((object) => object.name === name))
+      .filter((object): object is (typeof this.graph.objects)[number] => object !== undefined);
+
+    const match = (value: any): string | undefined => {
+      for (const object of targets) {
+        if (value instanceof object.target) return object.name;
+      }
+      const declared = value?.__typename;
+      if (typeof declared === 'string' && candidates.includes(declared)) return declared;
+      return undefined;
+    };
+
+    return (value, ctx, info) => {
+      if (!explicit) return match(value);
+      const resolved = explicit(value, ctx, info);
+      if (resolved && typeof (resolved as Promise<string>).then === 'function') {
+        return (resolved as Promise<string | undefined>).then((name) => name ?? match(value));
+      }
+      return (resolved as string | undefined) ?? match(value);
+    };
   }
 
   private toFieldConfigMap(

--- a/packages/di-framework-graphql/src/sdl.ts
+++ b/packages/di-framework-graphql/src/sdl.ts
@@ -10,6 +10,7 @@ import { CUSTOM_SCALARS } from './scalars.ts';
 import type {
   ResolvedArg,
   ResolvedField,
+  ResolvedInterfaceType,
   ResolvedObjectType,
   TypeGraph,
   TypeNode,
@@ -102,9 +103,21 @@ function printObject(object: ResolvedObjectType, options: PrintOptions): string 
       directives.push(`@key(fields: ${JSON.stringify(object.key)})`);
     if (object.context) directives.push(`@context(name: ${JSON.stringify(object.context)})`);
   }
+  const implemented =
+    object.interfaces.length > 0 ? ` implements ${object.interfaces.join(' & ')}` : '';
   const suffix = directives.length > 0 ? ` ${directives.join(' ')}` : '';
   const fields = object.fields.map((field) => printField(field, options)).join('\n');
-  return `${description}type ${object.name}${suffix} {\n${fields}\n}`;
+  return `${description}type ${object.name}${implemented}${suffix} {\n${fields}\n}`;
+}
+
+function printInterface(resolved: ResolvedInterfaceType, options: PrintOptions): string {
+  const description = printDescription(resolved.description, '', options);
+  const context =
+    options.directives && resolved.context
+      ? ` @context(name: ${JSON.stringify(resolved.context)})`
+      : '';
+  const fields = resolved.fields.map((field) => printField(field, options)).join('\n');
+  return `${description}interface ${resolved.name}${context} {\n${fields}\n}`;
 }
 
 /** Print the semantic schema as SDL. */
@@ -137,6 +150,15 @@ export function printSDL(graph: TypeGraph, options: PrintOptions = {}): string {
       )
       .join('\n');
     blocks.push(`${description}input ${input.name} {\n${fields}\n}`);
+  }
+
+  for (const resolved of graph.interfaces) {
+    blocks.push(printInterface(resolved, options));
+  }
+
+  for (const union of graph.unions) {
+    const description = printDescription(union.description, '', options);
+    blocks.push(`${description}union ${union.name} = ${union.members.join(' | ')}`);
   }
 
   for (const object of graph.objects) {

--- a/packages/di-framework-graphql/src/type-graph.ts
+++ b/packages/di-framework-graphql/src/type-graph.ts
@@ -12,29 +12,33 @@ import { SemanticBoundaryError, SemanticSchemaError } from './errors.ts';
 import {
   collectFieldDeclarations,
   getBoundedContext,
+  getImplements,
   getLookup,
   getParamNames,
 } from './metadata.ts';
 import { getRegistry } from './registry.ts';
 import { CUSTOM_SCALARS, ScalarRef, scalarNameForConstructor } from './scalars.ts';
-import type {
-  ArgOptions,
-  BuildOptions,
-  Ctor,
-  EnumObject,
-  FieldDeclaration,
-  ParamDeclaration,
-  ResolvedArg,
-  ResolvedEnumType,
-  ResolvedField,
-  ResolvedInputType,
-  ResolvedObjectType,
-  ResolvedRootType,
-  TypeGraph,
-  TypeInput,
-  TypeNode,
-  TypeRef,
-  TypeThunk,
+import {
+  type ArgOptions,
+  type BuildOptions,
+  type Ctor,
+  type EnumObject,
+  type FieldDeclaration,
+  type ParamDeclaration,
+  type ResolvedArg,
+  type ResolvedEnumType,
+  type ResolvedField,
+  type ResolvedInputType,
+  type ResolvedInterfaceType,
+  type ResolvedObjectType,
+  type ResolvedRootType,
+  type ResolvedUnionType,
+  type TypeGraph,
+  type TypeInput,
+  type TypeNode,
+  type TypeRef,
+  type TypeThunk,
+  UnionRef,
 } from './types.ts';
 
 const CONTEXT_PARAM_NAMES = new Set(['ctx', 'context', '_ctx', '_context']);
@@ -67,6 +71,9 @@ class GraphBuilder {
   private readonly objectsByName = new Map<string, ResolvedObjectType>();
   private readonly inputs = new Map<Ctor, ResolvedInputType>();
   private readonly enums = new Map<EnumObject, ResolvedEnumType>();
+  /** Interfaces included in this build, by class. */
+  private readonly interfaces = new Map<Ctor, ResolvedInterfaceType>();
+  private readonly unions = new Map<UnionRef, ResolvedUnionType>();
   private readonly usedScalars = new Set<string>();
   /** Context that declared each field, keyed by `TypeName.fieldName`. */
   private readonly fieldContexts = new Map<string, string | undefined>();
@@ -95,6 +102,7 @@ class GraphBuilder {
         key: declaration.options.key,
         portal: false,
         fields: [],
+        interfaces: [],
       };
       const existing = this.objectsByName.get(shell.name);
       if (existing && existing.target !== shell.target) {
@@ -106,15 +114,36 @@ class GraphBuilder {
       this.objectsByName.set(shell.name, shell);
     }
 
-    // Pass 2: own fields.
+    // Pass 2: interface shells, so a type can implement an interface that
+    // references it back.
+    for (const declaration of this.registry.getInterfaces()) {
+      this.interfaces.set(declaration.target, {
+        name: declaration.name,
+        description: declaration.options.description,
+        target: declaration.target,
+        context: getBoundedContext(declaration.target),
+        fields: [],
+        implementations: [],
+        resolveType: declaration.options.resolveType,
+      });
+    }
+
+    // Pass 3: own fields.
     for (const object of this.objects.values()) {
       object.fields = this.resolveOwnFields(object);
     }
+    for (const [target, resolved] of this.interfaces) {
+      resolved.fields = this.resolveInterfaceFields(target, resolved);
+    }
 
-    // Pass 3: cross-context extensions of boundary types.
+    // Pass 4: wire implementations to their interfaces and inherit any fields
+    // the concrete type did not redeclare.
+    this.applyInterfaces();
+
+    // Pass 5: cross-context extensions of boundary types.
     this.applyExtensions();
 
-    // Pass 4: roots.
+    // Pass 6: roots.
     const rootQuery: ResolvedField[] = [];
     const rootMutation: ResolvedField[] = [];
     const rootSubscription: ResolvedField[] = [];
@@ -157,6 +186,8 @@ class GraphBuilder {
           ? { name: 'Subscription', fields: rootSubscription }
           : undefined,
       objects: Array.from(this.objects.values()).sort((a, b) => a.name.localeCompare(b.name)),
+      interfaces: [],
+      unions: [],
       inputs: [],
       enums: [],
       scalars: [],
@@ -170,6 +201,15 @@ class GraphBuilder {
     graph.inputs = reachable.inputs;
     graph.enums = reachable.enums;
     graph.scalars = Array.from(this.usedScalars).sort();
+
+    // An interface is emitted when something implements it or a field returns
+    // it; an orphan interface would make the schema invalid.
+    graph.interfaces = Array.from(this.interfaces.values())
+      .filter(
+        (resolved) => resolved.implementations.length > 0 || reachable.abstracts.has(resolved.name),
+      )
+      .sort((a, b) => a.name.localeCompare(b.name));
+    graph.unions = Array.from(this.unions.values()).sort((a, b) => a.name.localeCompare(b.name));
 
     return graph;
   }
@@ -235,6 +275,117 @@ class GraphBuilder {
 
     assertUniqueFieldNames(object.name, fields);
     return fields;
+  }
+
+  private resolveInterfaceFields(target: Ctor, resolved: ResolvedInterfaceType): ResolvedField[] {
+    const fields = collectFieldDeclarations(target).map((declaration) => {
+      if (declaration.kind !== 'field') {
+        throw new SemanticSchemaError(
+          `${resolved.name}.${declaration.propertyKey}: interfaces may only declare @Field members.`,
+        );
+      }
+      return this.resolveField(target, resolved.name, declaration, 'parent', resolved.context);
+    });
+
+    if (fields.length === 0) {
+      throw new SemanticSchemaError(
+        `${resolved.name}: interfaces need at least one @Field. GraphQL has no empty interfaces.`,
+      );
+    }
+
+    assertUniqueFieldNames(resolved.name, fields);
+    return fields;
+  }
+
+  /**
+   * Attach each object to the interfaces it declares, copying down any field it
+   * did not redeclare so the concrete type structurally satisfies the contract.
+   */
+  private applyInterfaces(): void {
+    for (const object of this.objects.values()) {
+      const thunks = [
+        ...getImplements(object.target),
+        ...normalizeThunks(this.registry.getType(object.target)?.options.implements),
+      ];
+      if (thunks.length === 0) continue;
+
+      const names = new Set<string>();
+      for (const thunk of thunks) {
+        const interfaceTarget = thunk() as Ctor;
+        const resolved = this.interfaces.get(interfaceTarget);
+        if (!resolved) {
+          throw new SemanticSchemaError(
+            `${object.name} implements '${interfaceTarget?.name}', which is not an @InterfaceType.`,
+          );
+        }
+        if (names.has(resolved.name)) continue;
+        names.add(resolved.name);
+
+        for (const field of resolved.fields) {
+          const own = object.fields.find((existing) => existing.name === field.name);
+          if (!own) {
+            // Re-target the inherited field at the concrete class so an override
+            // on the implementation wins over the interface's own member.
+            object.fields.push({
+              ...field,
+              context: object.context,
+              source: { ...field.source, target: object.target },
+            });
+            continue;
+          }
+          if (printableType(own.type) !== printableType(field.type)) {
+            throw new SemanticBoundaryError(
+              `${object.name}.${own.name} is '${printableType(own.type)}' but interface '${resolved.name}' declares '${printableType(field.type)}'.`,
+            );
+          }
+        }
+
+        resolved.implementations.push(object.name);
+      }
+
+      object.interfaces = Array.from(names).sort();
+      assertUniqueFieldNames(object.name, object.fields);
+    }
+
+    for (const resolved of this.interfaces.values()) {
+      resolved.implementations = Array.from(new Set(resolved.implementations)).sort();
+    }
+  }
+
+  private ensureUnion(ref: UnionRef, path: string): ResolvedUnionType {
+    const existing = this.unions.get(ref);
+    if (existing) return existing;
+
+    const declaration = this.registry.getUnion(ref);
+    if (!declaration) {
+      throw new SemanticSchemaError(
+        `${path}: union '${ref.unionName}' was never registered with registerUnion().`,
+      );
+    }
+
+    const resolved: ResolvedUnionType = {
+      name: declaration.name,
+      description: declaration.options.description,
+      members: [],
+      resolveType: declaration.options.resolveType,
+    };
+    this.unions.set(ref, resolved);
+
+    const members = ref.members();
+    if (members.length === 0) {
+      throw new SemanticSchemaError(`${path}: union '${ref.unionName}' has no members.`);
+    }
+    for (const member of members) {
+      const object = this.objects.get(member);
+      if (!object) {
+        throw new SemanticSchemaError(
+          `${path}: union '${ref.unionName}' includes '${member?.name}', which is not a @SemanticType in this schema.`,
+        );
+      }
+      resolved.members.push(object.name);
+    }
+    resolved.members.sort();
+    return resolved;
   }
 
   private exposedMembers(object: ResolvedObjectType): Record<string, any> {
@@ -505,6 +656,11 @@ class GraphBuilder {
       return { kind: 'scalar', name: input.scalarName };
     }
 
+    if (input instanceof UnionRef) {
+      const union = this.ensureUnion(input, path);
+      return { kind: 'union', name: union.name, target: input };
+    }
+
     if (typeof input === 'function') {
       const scalarName = scalarNameForConstructor(input);
       if (scalarName) {
@@ -514,6 +670,11 @@ class GraphBuilder {
 
       const objectType = this.objects.get(input as Ctor);
       if (objectType) return { kind: 'object', name: objectType.name, target: input as Ctor };
+
+      const interfaceType = this.interfaces.get(input as Ctor);
+      if (interfaceType) {
+        return { kind: 'interface', name: interfaceType.name, target: input as Ctor };
+      }
 
       const inputDeclaration = this.registry.getInput(input as Ctor);
       if (inputDeclaration) {
@@ -643,20 +804,38 @@ class GraphBuilder {
   private validateBoundaries(graph: TypeGraph): void {
     if (!this.enforceBoundaries) return;
 
+    const checkObject = (ownerName: string, fieldName: string, from: string | undefined) => {
+      return (referenced: ResolvedObjectType | undefined) => {
+        if (!referenced) return;
+        const to = referenced.context;
+        if (!from || !to || from === to) return;
+        if (referenced.boundary) return;
+
+        throw new SemanticBoundaryError(
+          `${ownerName}.${fieldName} (context '${from}') references '${referenced.name}', which is owned by context '${to}' and is not a boundary type. Declare it with @SemanticType({ boundary: true, key: '...' }) or keep the reference inside '${to}'.`,
+        );
+      };
+    };
+
     const check = (ownerName: string, field: ResolvedField) => {
       const named = namedTypeNode(field.type);
-      if (named.kind !== 'object') return;
-      const referenced = this.objects.get(named.target as Ctor);
-      if (!referenced) return;
+      const verify = checkObject(ownerName, field.name, field.context);
 
-      const from = field.context;
-      const to = referenced.context;
-      if (!from || !to || from === to) return;
-      if (referenced.boundary) return;
-
-      throw new SemanticBoundaryError(
-        `${ownerName}.${field.name} (context '${from}') references '${referenced.name}', which is owned by context '${to}' and is not a boundary type. Declare it with @SemanticType({ boundary: true, key: '...' }) or keep the reference inside '${to}'.`,
-      );
+      if (named.kind === 'object') {
+        verify(this.objects.get(named.target as Ctor));
+        return;
+      }
+      // A union or interface is only as closed as its widest member: crossing a
+      // context edge through one has to obey the same rule.
+      if (named.kind === 'union') {
+        const union = this.unions.get(named.target as UnionRef);
+        for (const member of union?.members ?? []) verify(this.objectsByName.get(member));
+        return;
+      }
+      if (named.kind === 'interface') {
+        const resolved = this.interfaces.get(named.target as Ctor);
+        for (const name of resolved?.implementations ?? []) verify(this.objectsByName.get(name));
+      }
     };
 
     for (const object of this.objects.values()) {
@@ -688,12 +867,17 @@ class GraphBuilder {
   private collectReachable(graph: TypeGraph): {
     inputs: ResolvedInputType[];
     enums: ResolvedEnumType[];
+    abstracts: Set<string>;
   } {
     const inputs = new Map<string, ResolvedInputType>();
     const enums = new Map<string, ResolvedEnumType>();
+    const abstracts = new Set<string>();
 
     const visitNode = (node: TypeNode) => {
       const named = namedTypeNode(node);
+      if (named.kind === 'interface' || named.kind === 'union') {
+        abstracts.add(named.name);
+      }
       if (named.kind === 'input') {
         const resolved = this.inputs.get(named.target as Ctor);
         if (resolved && !inputs.has(resolved.name)) {
@@ -714,6 +898,7 @@ class GraphBuilder {
     };
 
     for (const object of graph.objects) object.fields.forEach(visitField);
+    for (const resolved of this.interfaces.values()) resolved.fields.forEach(visitField);
     for (const root of [graph.query, graph.mutation, graph.subscription]) {
       if (root) root.fields.forEach(visitField);
     }
@@ -721,6 +906,7 @@ class GraphBuilder {
     return {
       inputs: Array.from(inputs.values()).sort((a, b) => a.name.localeCompare(b.name)),
       enums: Array.from(enums.values()).sort((a, b) => a.name.localeCompare(b.name)),
+      abstracts,
     };
   }
 }
@@ -751,12 +937,29 @@ function isArgOptions(value: unknown): value is ArgOptions {
   return isFieldOptions(value);
 }
 
+/** Render a resolved type expression the way SDL would, for error messages. */
+function printableType(node: TypeNode): string {
+  if (node.kind === 'nonNull') return `${printableType(node.of)}!`;
+  if (node.kind === 'list') return `[${printableType(node.of)}]`;
+  return node.name;
+}
+
+function normalizeThunks(value: TypeThunk | readonly TypeThunk[] | undefined): TypeThunk[] {
+  if (!value) return [];
+  return Array.isArray(value) ? [...value] : [value as TypeThunk];
+}
+
 /** Call a type thunk, leaving classes, scalars and lists untouched. */
 function unwrapThunk(ref: TypeRef, registry: ReturnType<typeof getRegistry>): TypeInput {
   if (typeof ref !== 'function') return ref as TypeInput;
   if (ref instanceof ScalarRef) return ref;
   if (scalarNameForConstructor(ref)) return ref as TypeInput;
-  if (registry.getType(ref as Ctor) || registry.getInput(ref as Ctor)) return ref as TypeInput;
+  if (
+    registry.getType(ref as Ctor) ||
+    registry.getInput(ref as Ctor) ||
+    registry.getInterface(ref as Ctor)
+  )
+    return ref as TypeInput;
   if (/^class[\s{]/.test(Function.prototype.toString.call(ref))) return ref as TypeInput;
   return (ref as TypeThunk)();
 }

--- a/packages/di-framework-graphql/src/types.ts
+++ b/packages/di-framework-graphql/src/types.ts
@@ -10,15 +10,35 @@ import type { ScalarRef } from './scalars.ts';
 
 export type Ctor<T = any> = new (...args: any[]) => T;
 
+/**
+ * A class that may be `abstract` — interfaces are declared as abstract classes,
+ * and those cannot be assigned to {@link Ctor}.
+ */
+export type AbstractCtor<T = any> = abstract new (...args: any[]) => T;
+
 /** An enum declared with `registerEnum()`. */
 export type EnumObject = Record<string, string | number>;
 
 /**
+ * A named union over concrete `@SemanticType`s.
+ *
+ * Unions have no class of their own — `registerUnion()` returns one of these and
+ * it is used directly as a type reference: `@Field(() => SearchResult)`.
+ */
+export class UnionRef {
+  constructor(
+    readonly unionName: string,
+    readonly members: () => readonly Ctor[],
+    readonly options: UnionOptions = {},
+  ) {}
+}
+
+/**
  * Anything usable as a type reference in a decorator:
  * a scalar marker (`ID`, `Int`), a decorated class, a registered enum object,
- * or a single-element array denoting a list (`[Order]`).
+ * a union marker, or a single-element array denoting a list (`[Order]`).
  */
-export type TypeInput = ScalarRef | Ctor | EnumObject | readonly TypeInput[];
+export type TypeInput = ScalarRef | UnionRef | AbstractCtor | EnumObject | readonly TypeInput[];
 
 /** Lazy type reference — required for types that are declared later in the file. */
 export type TypeThunk = () => TypeInput;
@@ -29,6 +49,8 @@ export type TypeRef = TypeInput | TypeThunk;
 export type TypeNode =
   | { kind: 'scalar'; name: string }
   | { kind: 'object'; name: string; target: Ctor }
+  | { kind: 'interface'; name: string; target: Ctor }
+  | { kind: 'union'; name: string; target: UnionRef }
   | { kind: 'input'; name: string; target: Ctor }
   | { kind: 'enum'; name: string; target: EnumObject }
   | { kind: 'list'; of: TypeNode }
@@ -47,6 +69,11 @@ export interface SemanticTypeOptions {
   /** Schema name. Defaults to the class name. */
   name?: string;
   description?: string;
+  /**
+   * Interfaces this type implements. Usually declared with `@Implements`;
+   * listing them here is equivalent.
+   */
+  implements?: TypeThunk | readonly TypeThunk[];
   /**
    * Marks the type as a *boundary type*: other bounded contexts are allowed to
    * reference it and to extend it with `@Extends`. Requires `key`.
@@ -71,6 +98,31 @@ export interface InputTypeOptions {
   name?: string;
   description?: string;
 }
+
+export interface InterfaceTypeOptions {
+  /** Schema name. Defaults to the class name. */
+  name?: string;
+  description?: string;
+  /**
+   * Decide the concrete type for a value. Defaults to matching the value
+   * against each implementing class with `instanceof`, then falling back to a
+   * `__typename` property.
+   */
+  resolveType?: TypeResolver;
+}
+
+export interface UnionOptions {
+  description?: string;
+  /** Same fallback chain as {@link InterfaceTypeOptions.resolveType}. */
+  resolveType?: TypeResolver;
+}
+
+/** Returns the schema name of the concrete type backing a value. */
+export type TypeResolver = (
+  value: any,
+  ctx: GraphQLContext,
+  info: any,
+) => string | undefined | Promise<string | undefined>;
 
 export interface EnumOptions {
   name: string;
@@ -200,6 +252,18 @@ export interface EnumDeclaration {
   description?: string;
 }
 
+export interface InterfaceTypeDeclaration {
+  target: Ctor;
+  name: string;
+  options: InterfaceTypeOptions;
+}
+
+export interface UnionDeclaration {
+  ref: UnionRef;
+  name: string;
+  options: UnionOptions;
+}
+
 export interface ExtensionDeclaration {
   target: Ctor;
   /** Thunk to the boundary type being extended. */
@@ -266,6 +330,27 @@ export interface ResolvedObjectType {
   key?: string;
   portal: boolean;
   fields: ResolvedField[];
+  /** Names of the interfaces this type implements. */
+  interfaces: string[];
+}
+
+export interface ResolvedInterfaceType {
+  name: string;
+  description?: string;
+  target: Ctor;
+  context?: string;
+  fields: ResolvedField[];
+  /** Schema names of the object types implementing this interface. */
+  implementations: string[];
+  resolveType?: TypeResolver;
+}
+
+export interface ResolvedUnionType {
+  name: string;
+  description?: string;
+  /** Schema names of the union's members. */
+  members: string[];
+  resolveType?: TypeResolver;
 }
 
 export interface ResolvedInputField {
@@ -299,6 +384,8 @@ export interface TypeGraph {
   mutation?: ResolvedRootType;
   subscription?: ResolvedRootType;
   objects: ResolvedObjectType[];
+  interfaces: ResolvedInterfaceType[];
+  unions: ResolvedUnionType[];
   inputs: ResolvedInputType[];
   enums: ResolvedEnumType[];
   /** Custom scalars actually referenced by the schema. */

--- a/packages/di-framework-graphql/tests/abstract-types.test.ts
+++ b/packages/di-framework-graphql/tests/abstract-types.test.ts
@@ -1,0 +1,428 @@
+/**
+ * Interfaces and unions: SDL shape, executable behaviour, concrete-type
+ * resolution and how both interact with bounded-context boundaries.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { Container } from '@di-framework/core/container';
+import {
+  Arg,
+  BoundedContext,
+  Field,
+  Implements,
+  InterfaceType,
+  Portal,
+  registerUnion,
+  SemanticType,
+} from '../src/decorators.ts';
+import { SemanticBoundaryError, SemanticSchemaError } from '../src/errors.ts';
+import { ID, Int } from '../src/scalars.ts';
+import { buildSemanticSchema } from '../src/schema.ts';
+import { printSDL } from '../src/sdl.ts';
+import { buildTypeGraph } from '../src/type-graph.ts';
+import { withRegistry } from './helpers.ts';
+
+describe('GraphQL interfaces', () => {
+  it('emits the interface, its implementations and inherited fields in SDL', () => {
+    const graph = withRegistry((registry) => {
+      @InterfaceType({ description: 'Anything addressable by a global id.' })
+      abstract class Node {
+        @Field(() => ID) id!: string;
+      }
+
+      @Implements(() => Node)
+      @SemanticType()
+      class User extends Node {
+        @Field(() => String) email!: string;
+      }
+
+      @Portal()
+      class Query {
+        @Field(() => User)
+        user(): User {
+          return new User();
+        }
+      }
+
+      return buildTypeGraph({ registry });
+    });
+
+    const sdl = printSDL(graph);
+    expect(sdl).toContain('interface Node {');
+    expect(sdl).toContain('type User implements Node {');
+    // `id` is declared only on the interface, so it must be copied down.
+    expect(
+      graph.objects.find((object) => object.name === 'User')?.fields.map((f) => f.name),
+    ).toEqual(expect.arrayContaining(['email', 'id']));
+    expect(graph.interfaces[0]?.implementations).toEqual(['User']);
+  });
+
+  it('lets an implementation override an inherited interface field', async () => {
+    const api = withRegistry(() => {
+      @InterfaceType()
+      abstract class Named {
+        @Field(() => String)
+        label(): string {
+          return 'interface';
+        }
+      }
+
+      @Implements(() => Named)
+      @SemanticType()
+      class Product extends Named {
+        @Field(() => String)
+        override label(): string {
+          return 'product';
+        }
+      }
+
+      @Portal()
+      class Query {
+        @Field(() => Named)
+        thing(): Named {
+          return new Product();
+        }
+      }
+
+      return buildSemanticSchema({ container: new Container() });
+    });
+
+    const result = await api.execute({ query: '{ thing { label __typename } }' });
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.thing).toEqual({ label: 'product', __typename: 'Product' });
+  });
+
+  it('hydrates plain data onto the concrete class named by __typename', async () => {
+    const api = withRegistry(() => {
+      @InterfaceType()
+      abstract class Node {
+        @Field(() => ID) id!: string;
+      }
+
+      @Implements(() => Node)
+      @SemanticType()
+      class Article extends Node {
+        @Field(() => String) title!: string;
+
+        @Field(() => String)
+        slug(): string {
+          return this.title.toLowerCase().replaceAll(' ', '-');
+        }
+      }
+
+      @Portal()
+      class Query {
+        // A repository would hand back exactly this: correct shape, no class.
+        @Field(() => Node)
+        node(): any {
+          return { __typename: 'Article', id: '1', title: 'Hello World' };
+        }
+      }
+
+      return buildSemanticSchema({ container: new Container() });
+    });
+
+    const result = await api.execute({
+      query: '{ node { id __typename ... on Article { title slug } } }',
+    });
+    expect(result.errors).toBeUndefined();
+    // `slug` proves the plain object was hydrated onto Article before dispatch.
+    expect(result.data?.node).toEqual({
+      id: '1',
+      __typename: 'Article',
+      title: 'Hello World',
+      slug: 'hello-world',
+    });
+  });
+
+  it('honours an explicit resolveType over instanceof matching', async () => {
+    const api = withRegistry(() => {
+      @InterfaceType({ resolveType: (value: any) => (value.legs === 4 ? 'Dog' : 'Bird') })
+      abstract class Animal {
+        @Field(() => Int) legs!: number;
+      }
+
+      @Implements(() => Animal)
+      @SemanticType()
+      class Dog extends Animal {}
+
+      @Implements(() => Animal)
+      @SemanticType()
+      class Bird extends Animal {}
+
+      @Portal()
+      class Query {
+        @Field(() => Animal)
+        animal(): any {
+          return { legs: 4 };
+        }
+      }
+
+      return buildSemanticSchema({ container: new Container() });
+    });
+
+    const result = await api.execute({ query: '{ animal { legs __typename } }' });
+    expect(result.data?.animal).toEqual({ legs: 4, __typename: 'Dog' });
+  });
+
+  it('rejects an implementation whose field type contradicts the interface', () => {
+    expect(() =>
+      withRegistry((registry) => {
+        @InterfaceType()
+        abstract class Node {
+          @Field(() => ID) id!: string;
+        }
+
+        // Implements structurally rather than by extending, so `id` is its own
+        // declaration — and contradicts the interface's ID.
+        @Implements(() => Node)
+        @SemanticType()
+        class Broken {
+          @Field(() => Int) id!: number;
+        }
+
+        @Portal()
+        class Query {
+          @Field(() => Broken)
+          broken(): Broken {
+            return new Broken();
+          }
+        }
+
+        return buildTypeGraph({ registry });
+      }),
+    ).toThrow(SemanticBoundaryError);
+  });
+
+  it('rejects implementing something that is not an interface', () => {
+    expect(() =>
+      withRegistry((registry) => {
+        @SemanticType()
+        class NotAnInterface {
+          @Field(() => ID) id!: string;
+        }
+
+        @Implements(() => NotAnInterface)
+        @SemanticType()
+        class Thing {
+          @Field(() => ID) id!: string;
+        }
+
+        @Portal()
+        class Query {
+          @Field(() => Thing)
+          thing(): Thing {
+            return new Thing();
+          }
+        }
+
+        return buildTypeGraph({ registry });
+      }),
+    ).toThrow(SemanticSchemaError);
+  });
+
+  it('rejects an interface with no fields', () => {
+    expect(() =>
+      withRegistry((registry) => {
+        @InterfaceType()
+        abstract class Empty {}
+
+        @Implements(() => Empty)
+        @SemanticType()
+        class Thing extends Empty {
+          @Field(() => ID) id!: string;
+        }
+
+        @Portal()
+        class Query {
+          @Field(() => Thing)
+          thing(): Thing {
+            return new Thing();
+          }
+        }
+
+        return buildTypeGraph({ registry });
+      }),
+    ).toThrow(/at least one @Field/);
+  });
+});
+
+describe('GraphQL unions', () => {
+  it('emits a union and resolves each member at runtime', async () => {
+    const api = withRegistry(() => {
+      @SemanticType()
+      class Book {
+        @Field(() => String) title!: string;
+      }
+
+      @SemanticType()
+      class Author {
+        @Field(() => String) name!: string;
+      }
+
+      const SearchResult = registerUnion('SearchResult', () => [Book, Author], {
+        description: 'Anything the catalogue can return.',
+      });
+
+      @Portal()
+      class Query {
+        @Field(() => [SearchResult])
+        search(@Arg('q', () => String) q: string): any[] {
+          return q === 'all'
+            ? [
+                Object.assign(new Book(), { title: 'Dune' }),
+                Object.assign(new Author(), { name: 'Herbert' }),
+              ]
+            : [];
+        }
+      }
+
+      return buildSemanticSchema({ container: new Container() });
+    });
+
+    expect(api.sdl).toContain('union SearchResult = Author | Book');
+
+    const result = await api.execute({
+      query: '{ search(q: "all") { __typename ... on Book { title } ... on Author { name } } }',
+    });
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.search).toEqual([
+      { __typename: 'Book', title: 'Dune' },
+      { __typename: 'Author', name: 'Herbert' },
+    ]);
+  });
+
+  it('rejects a union member that is not a semantic type', () => {
+    expect(() =>
+      withRegistry((registry) => {
+        class Loose {}
+
+        @SemanticType()
+        class Book {
+          @Field(() => String) title!: string;
+        }
+
+        const Mixed = registerUnion('Mixed', () => [Book, Loose]);
+
+        @Portal()
+        class Query {
+          @Field(() => Mixed)
+          any(): any {
+            return null;
+          }
+        }
+
+        return buildTypeGraph({ registry });
+      }),
+    ).toThrow(/not a @SemanticType/);
+  });
+
+  it('rejects an empty union', () => {
+    expect(() =>
+      withRegistry((registry) => {
+        const Nothing = registerUnion('Nothing', () => []);
+
+        @Portal()
+        class Query {
+          @Field(() => Nothing)
+          nothing(): any {
+            return null;
+          }
+        }
+
+        return buildTypeGraph({ registry });
+      }),
+    ).toThrow(/no members/);
+  });
+});
+
+describe('abstract types and bounded contexts', () => {
+  it('rejects a union that smuggles a non-boundary type across a context edge', () => {
+    expect(() =>
+      withRegistry((registry) => {
+        @BoundedContext('Billing')
+        @SemanticType()
+        class Invoice {
+          @Field(() => ID) id!: string;
+        }
+
+        @BoundedContext('Catalog')
+        @SemanticType()
+        class Product {
+          @Field(() => ID) id!: string;
+        }
+
+        const Anything = registerUnion('Anything', () => [Product, Invoice]);
+
+        @BoundedContext('Catalog')
+        @Portal()
+        class CatalogQuery {
+          @Field(() => Anything)
+          anything(): any {
+            return null;
+          }
+        }
+
+        return buildTypeGraph({ registry });
+      }),
+    ).toThrow(SemanticBoundaryError);
+  });
+
+  it('allows a union across contexts when every member is a boundary type', () => {
+    const graph = withRegistry((registry) => {
+      @BoundedContext('Billing')
+      @SemanticType({ boundary: true, key: 'id' })
+      class Invoice {
+        @Field(() => ID) id!: string;
+      }
+
+      @BoundedContext('Catalog')
+      @SemanticType({ boundary: true, key: 'id' })
+      class Product {
+        @Field(() => ID) id!: string;
+      }
+
+      const Anything = registerUnion('Anything', () => [Product, Invoice]);
+
+      @BoundedContext('Catalog')
+      @Portal()
+      class CatalogQuery {
+        @Field(() => Anything)
+        anything(): any {
+          return null;
+        }
+      }
+
+      return buildTypeGraph({ registry });
+    });
+
+    expect(graph.unions[0]?.members).toEqual(['Invoice', 'Product']);
+  });
+
+  it('rejects an interface reference whose implementation is not a boundary type', () => {
+    expect(() =>
+      withRegistry((registry) => {
+        @InterfaceType()
+        abstract class Payable {
+          @Field(() => ID) id!: string;
+        }
+
+        @BoundedContext('Billing')
+        @Implements(() => Payable)
+        @SemanticType()
+        class Invoice extends Payable {}
+
+        @BoundedContext('Catalog')
+        @Portal()
+        class CatalogQuery {
+          @Field(() => Payable)
+          payable(): any {
+            return null;
+          }
+        }
+
+        return buildTypeGraph({ registry });
+      }),
+    ).toThrow(SemanticBoundaryError);
+  });
+});


### PR DESCRIPTION
Polymorphic domain types can now be modelled without flattening them into a
single object type.

- @InterfaceType declares a GraphQL interface from an abstract domain class
- @Implements wires a @SemanticType to the interfaces it satisfies, inheriting
  any field it does not redeclare and re-targeting it at the concrete class so
  overrides win
- registerUnion() declares a union over concrete @SemanticTypes
- concrete types are resolved by explicit resolveType, then instanceof, then
  __typename, so both hydrated instances and plain repository rows work
- SDL prints `interface`, `implements A & B` and `union X = A | B`; the
  executable schema builds the matching GraphQLInterfaceType/GraphQLUnionType

Boundary rules still hold: crossing a context edge through a union or an
interface is checked against every member/implementation, so an abstract type
cannot smuggle a non-boundary type across contexts.

TypeInput now accepts abstract constructors, since interfaces are declared as
abstract classes.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>