### PR TITLE
feat(graphql): add auth-as-domain @Requires decorator (#21)

### DIFF
--- a/examples/packages/graphql/README.md
+++ b/examples/packages/graphql/README.md
@@ -49,7 +49,8 @@ trade-off is that the playground — and only the playground — needs a network
 | Input objects with behaviour | `BookInput.slug()`, `ReviewInput.clampedRating()` | GraphQL's plain input values are hydrated back onto the class. |
 | Hydration | `Book.shelfLabel()`, `Loan.renewable()` | Repository rows are plain data; they get their type's behaviour before resolution. |
 | Enums and scalars | `Genre`, `LoanState`, `ID`/`Int`/`Float`/`DateTime`/`JSON` | Types are runtime markers — no `reflect-metadata`. |
-| Request context | `@Ctx()`, and `myLoans(ctx)` by convention | Authorization (`requireLibrarian`) is a domain decision, not middleware. |
+| Request context | `@Ctx()`, and `myLoans(ctx)` by convention | Whatever the transport builds is threaded straight through. |
+| Authorization as domain | `@Requires({ roles: ['librarian'] })` on `addBook` | Declared on the action it protects, next to the invariant — not a guard clause or transport middleware. `schema.ts` wires the readers that find the member and roles on `LibraryContext`; denials surface as `FORBIDDEN` / `UNAUTHENTICATED` with no internal detail. |
 | Resolve info | `@Info()` in `CatalogPortal.books` | Feeds a `QueryStats` component. |
 | Subscriptions | `@Publisher('loan.checkedOut')` → `@Subscription(...)` | The service publishes on the container and knows nothing about GraphQL. `filter` sees the raw publisher envelope. |
 | Subscriptions over the wire | `sockets` in `server.ts` | ~60 lines of `graphql-transport-ws` so GraphiQL can stream them; the round trip is asserted in `index.test.ts`. |

--- a/examples/packages/graphql/domain/catalog.ts
+++ b/examples/packages/graphql/domain/catalog.ts
@@ -23,12 +23,13 @@ import {
   Lookup,
   Portal,
   registerEnum,
+  Requires,
   SemanticType,
 } from '@di-framework/graphql';
 import type { GraphQLResolveInfo } from 'graphql';
 // Must be evaluated before the first decorated class below. See registry.ts.
 import './registry.ts';
-import { type LibraryContext, requireLibrarian } from './context.ts';
+import type { LibraryContext } from './context.ts';
 
 /* -------------------------------------------------------------------------- */
 /* Enums                                                                      */
@@ -266,11 +267,12 @@ export class CatalogPortal {
 
   /**
    * An action on a portal is a plain root mutation. Authorization is a domain
-   * decision, so it is expressed here rather than in transport middleware.
+   * decision, so it is declared on the action with `@Requires` rather than
+   * checked by transport middleware or a guard clause in the body.
    */
+  @Requires({ roles: ['librarian'], message: 'Only librarians can acquire titles.' })
   @Action(() => Book, { description: 'Acquire a new title.' })
-  addBook(@Arg('input', () => BookInput) input: BookInput, @Ctx() ctx: LibraryContext): BookRow {
-    requireLibrarian(ctx);
+  addBook(@Arg('input', () => BookInput) input: BookInput): BookRow {
     return this.repo.add({
       id: input.slug(),
       title: input.title,

--- a/examples/packages/graphql/domain/context.ts
+++ b/examples/packages/graphql/domain/context.ts
@@ -14,16 +14,15 @@ export interface LibraryContext extends GraphQLContext {
   roles?: string[];
 }
 
-/** Authorization lives in the domain, not in a resolver map. */
+/**
+ * Authorization lives in the domain, not in a resolver map.
+ *
+ * Declarative requirements are expressed with `@Requires` on the field or
+ * action itself (see `addBook` in `catalog.ts`); `schema.ts` teaches it how to
+ * read the member and roles off this context. This helper remains for the rare
+ * check that has to run inside a method body.
+ */
 export function requireMember(ctx: LibraryContext): string {
   if (!ctx.memberId) throw new Error('Not authenticated: no member on this request.');
   return ctx.memberId;
-}
-
-export function requireLibrarian(ctx: LibraryContext): string {
-  const memberId = requireMember(ctx);
-  if (!ctx.roles?.includes('librarian')) {
-    throw new Error(`Member ${memberId} is not a librarian.`);
-  }
-  return memberId;
 }

--- a/examples/packages/graphql/index.test.ts
+++ b/examples/packages/graphql/index.test.ts
@@ -190,7 +190,11 @@ describe('mutations', () => {
     }`;
 
     const denied = await run(mutation, { memberId: 'm1', roles: [] });
-    expect(denied.errors?.[0]?.message).toContain('not a librarian');
+    expect(denied.errors?.[0]?.message).toBe('Only librarians can acquire titles.');
+    expect(denied.errors?.[0]?.extensions?.code).toBe('FORBIDDEN');
+
+    const anonymous = await run(mutation, { roles: ['librarian'] });
+    expect(anonymous.errors?.[0]?.extensions?.code).toBe('UNAUTHENTICATED');
 
     const allowed = data(await run(mutation, { memberId: 'm1', roles: ['librarian'] }));
     expect(allowed.addBook).toEqual({ id: 'the-dispossessed', title: 'The Dispossessed' });

--- a/examples/packages/graphql/schema.ts
+++ b/examples/packages/graphql/schema.ts
@@ -13,7 +13,7 @@
  *   the fields Lending contributed to `Book`.
  */
 
-import { buildSemanticSchema } from '@di-framework/graphql';
+import { type AuthorizationOptions, buildSemanticSchema } from '@di-framework/graphql';
 
 // Side-effect imports: defining the classes is what registers them.
 import './domain/catalog.ts';
@@ -21,8 +21,20 @@ import './domain/reviews.ts';
 import './domain/lending.ts';
 import { libraryRegistry } from './domain/registry.ts';
 
+/**
+ * Teach `@Requires` how to read *this* application's context.
+ *
+ * The defaults look for `ctx.user`; a `LibraryContext` carries the member id
+ * and roles at the top level, so both readers are pointed at them.
+ */
+const authorization: AuthorizationOptions = {
+  principal: (ctx) => ctx.memberId,
+  roles: (ctx) => ctx.roles ?? [],
+};
+
 /** The whole library API. */
 export const library = buildSemanticSchema({
+  authorization,
   // Read this application's declarations, not whatever else the process has
   // defined. Omit it and you get the global registry, which is fine for an app
   // that owns its process.
@@ -38,6 +50,7 @@ export const library = buildSemanticSchema({
 
 /** What a public, read-mostly catalog service would expose. */
 export const publicCatalog = buildSemanticSchema({
+  authorization,
   registry: libraryRegistry,
   contexts: ['Catalog', 'Reviews'],
   enforceBoundaries: true,

--- a/packages/di-framework-graphql/core.ts
+++ b/packages/di-framework-graphql/core.ts
@@ -7,6 +7,15 @@
  * execute queries.
  */
 
+export {
+  type AuthDenial,
+  type AuthorizationOptions,
+  type AuthRequirement,
+  type AuthRequirementContext,
+  denialToError,
+  evaluateRequirements,
+  SemanticAuthorizationError,
+} from './src/authorization.ts';
 export * from './src/decorators.ts';
 export * from './src/errors.ts';
 export { type BatchFunction, BatchLoader } from './src/loader.ts';
@@ -19,5 +28,5 @@ export { getRegistry, SemanticRegistry, setRegistry } from './src/registry.ts';
 export * from './src/scalars.ts';
 export { type PrintOptions, printSDL, printTypeNode } from './src/sdl.ts';
 export { buildTypeGraph, namedTypeNode } from './src/type-graph.ts';
-export { UnionRef } from './src/types.ts';
 export type * from './src/types.ts';
+export { UnionRef } from './src/types.ts';

--- a/packages/di-framework-graphql/src/authorization.ts
+++ b/packages/di-framework-graphql/src/authorization.ts
@@ -1,0 +1,174 @@
+/**
+ * Auth as a domain concern.
+ *
+ * A requirement is declared next to the field or action it protects, the same
+ * way ownership is declared with `@BoundedContext` — not threaded through
+ * hand-written `requireLibrarian(ctx)` guards at the top of every resolver.
+ *
+ * Requirements are read off the per-request context. What counts as the
+ * principal, its roles and its claims is application-specific, so every reader
+ * is overridable through {@link AuthorizationOptions}; the defaults cover the
+ * common `ctx.user = { roles, claims }` shape.
+ */
+
+import type { GraphQLContext } from './types.ts';
+
+/** Raised when a declared requirement is not met. */
+export class SemanticAuthorizationError extends Error {
+  readonly extensions: { code: string };
+
+  constructor(message = 'Not authorized.', code = 'FORBIDDEN') {
+    super(message);
+    this.name = 'SemanticAuthorizationError';
+    // graphql-js copies `extensions` off the original error, so this is what
+    // reaches the client — and it carries no internal detail.
+    this.extensions = { code };
+  }
+}
+
+export interface AuthRequirementContext {
+  parent: unknown;
+  args: Record<string, any>;
+  ctx: GraphQLContext;
+  info: any;
+}
+
+export interface AuthRequirement {
+  /** Satisfied when the principal holds *any* of these roles. */
+  roles?: readonly string[];
+  /** Satisfied only when the principal holds *every* one of these roles. */
+  allRoles?: readonly string[];
+  /**
+   * Claims that must match. A scalar must be equal; an array is satisfied when
+   * the principal's claim is one of its entries.
+   */
+  claims?: Readonly<Record<string, unknown>>;
+  /** Arbitrary domain rule — ownership checks and the like. */
+  predicate?: (context: AuthRequirementContext) => boolean | Promise<boolean>;
+  /** Message surfaced to the client. Keep it free of internals. */
+  message?: string;
+  /** Require only that a principal is present. */
+  authenticated?: boolean;
+}
+
+export interface AuthorizationOptions {
+  /** Defaults to `ctx.user ?? ctx.principal`. */
+  principal?: (ctx: GraphQLContext) => unknown;
+  /** Defaults to the principal's `roles`, else `ctx.roles`. */
+  roles?: (ctx: GraphQLContext, principal: unknown) => readonly string[];
+  /** Defaults to the principal's `claims`, else `ctx.claims`, else the principal. */
+  claims?: (ctx: GraphQLContext, principal: unknown) => Record<string, unknown>;
+  /** Build the error for a failed requirement. */
+  onDenied?: (denial: AuthDenial) => Error;
+}
+
+export interface AuthDenial {
+  /** `Type.field` the requirement was declared on. */
+  path: string;
+  requirement: AuthRequirement;
+  /** True when no principal was present at all. */
+  anonymous: boolean;
+  reason: 'unauthenticated' | 'roles' | 'claims' | 'predicate';
+}
+
+function defaultPrincipal(ctx: GraphQLContext): unknown {
+  return ctx?.user ?? ctx?.principal;
+}
+
+function defaultRoles(ctx: GraphQLContext, principal: unknown): readonly string[] {
+  const fromPrincipal = (principal as any)?.roles;
+  const roles = fromPrincipal ?? ctx?.roles;
+  if (Array.isArray(roles)) return roles.filter((role): role is string => typeof role === 'string');
+  return typeof roles === 'string' ? [roles] : [];
+}
+
+function defaultClaims(ctx: GraphQLContext, principal: unknown): Record<string, unknown> {
+  const fromPrincipal = (principal as any)?.claims;
+  const claims = fromPrincipal ?? ctx?.claims ?? principal;
+  return claims && typeof claims === 'object' ? (claims as Record<string, unknown>) : {};
+}
+
+function claimMatches(actual: unknown, expected: unknown): boolean {
+  if (Array.isArray(expected)) {
+    return Array.isArray(actual)
+      ? actual.some((value) => expected.includes(value))
+      : expected.includes(actual);
+  }
+  return Array.isArray(actual) ? actual.includes(expected) : actual === expected;
+}
+
+/**
+ * Check every requirement declared for a field.
+ *
+ * Requirements are conjunctive: each one must pass. Returns the first denial,
+ * or `null` when the caller is allowed through.
+ */
+export async function evaluateRequirements(
+  requirements: readonly AuthRequirement[],
+  path: string,
+  context: AuthRequirementContext,
+  options: AuthorizationOptions = {},
+): Promise<AuthDenial | null> {
+  if (requirements.length === 0) return null;
+
+  const { ctx } = context;
+  const principal = (options.principal ?? defaultPrincipal)(ctx);
+  const anonymous = principal === undefined || principal === null;
+
+  for (const requirement of requirements) {
+    const needsPrincipal =
+      requirement.authenticated === true ||
+      (requirement.roles?.length ?? 0) > 0 ||
+      (requirement.allRoles?.length ?? 0) > 0 ||
+      requirement.claims !== undefined;
+
+    if (needsPrincipal && anonymous) {
+      return { path, requirement, anonymous, reason: 'unauthenticated' };
+    }
+
+    if (requirement.roles?.length) {
+      const held = (options.roles ?? defaultRoles)(ctx, principal);
+      if (!requirement.roles.some((role) => held.includes(role))) {
+        return { path, requirement, anonymous, reason: 'roles' };
+      }
+    }
+
+    if (requirement.allRoles?.length) {
+      const held = (options.roles ?? defaultRoles)(ctx, principal);
+      if (!requirement.allRoles.every((role) => held.includes(role))) {
+        return { path, requirement, anonymous, reason: 'roles' };
+      }
+    }
+
+    if (requirement.claims) {
+      const held = (options.claims ?? defaultClaims)(ctx, principal);
+      for (const [key, expected] of Object.entries(requirement.claims)) {
+        if (!claimMatches(held[key], expected)) {
+          return { path, requirement, anonymous, reason: 'claims' };
+        }
+      }
+    }
+
+    if (requirement.predicate && !(await requirement.predicate(context))) {
+      return { path, requirement, anonymous, reason: 'predicate' };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Turn a denial into the error the client sees.
+ *
+ * The default deliberately says nothing about which rule failed or what the
+ * principal was missing — only whether to authenticate or give up.
+ */
+export function denialToError(denial: AuthDenial, options: AuthorizationOptions = {}): Error {
+  if (options.onDenied) return options.onDenied(denial);
+  return denial.reason === 'unauthenticated'
+    ? new SemanticAuthorizationError(
+        denial.requirement.message ?? 'Authentication is required.',
+        'UNAUTHENTICATED',
+      )
+    : new SemanticAuthorizationError(denial.requirement.message ?? 'Not authorized.', 'FORBIDDEN');
+}

--- a/packages/di-framework-graphql/src/decorators.ts
+++ b/packages/di-framework-graphql/src/decorators.ts
@@ -8,13 +8,16 @@
  */
 
 import { Container as ContainerDecorator } from '@di-framework/core/decorators';
+import type { AuthRequirement } from './authorization.ts';
 import { SemanticSchemaError } from './errors.ts';
 import {
   defineBoundedContext,
   defineFieldDeclaration,
   defineImplements,
   defineLookup,
+  defineMemberRequirements,
   defineParamDeclaration,
+  defineTypeRequirements,
 } from './metadata.ts';
 import { getRegistry } from './registry.ts';
 import { ScalarRef, scalarNameForConstructor } from './scalars.ts';
@@ -352,6 +355,43 @@ export function Subscription(
 ): any {
   const { type, options } = normalizeArgs<SubscriptionOptions>(typeOrOptions, maybeOptions);
   return declareMember('subscription', type, options, event);
+}
+
+/**
+ * Declares what a caller must satisfy before a field or action runs.
+ *
+ * Auth lives with the thing it protects, and fails the way boundary checks do:
+ * the requirement is part of the domain declaration rather than a guard clause
+ * repeated at the top of every resolver.
+ *
+ * Applies to a `@Field`, an `@Action`, a portal root, or a whole class — a
+ * class-level requirement guards every field on it. Requirements accumulate and
+ * are conjunctive: all of them must pass.
+ *
+ * @example
+ * ```ts
+ * @Portal()
+ * class Library {
+ *   @Requires({ roles: ['librarian'] })
+ *   @Action(() => Loan)
+ *   lend(@Arg('bookId', () => ID) bookId: string) { ... }
+ *
+ *   @Requires({ predicate: ({ parent, ctx }) => parent.ownerId === ctx.user.id })
+ *   @Field(() => String)
+ *   privateNote(): string { ... }
+ * }
+ * ```
+ */
+export function Requires(
+  ...requirements: AuthRequirement[]
+): ClassDecorator & PropertyDecorator & MethodDecorator {
+  return ((target: any, propertyKey?: string | symbol, _descriptor?: PropertyDescriptor): any => {
+    if (propertyKey === undefined) {
+      defineTypeRequirements(target as Ctor, requirements);
+      return target;
+    }
+    defineMemberRequirements(target, propertyKey as string, requirements);
+  }) as ClassDecorator & PropertyDecorator & MethodDecorator;
 }
 
 /**

--- a/packages/di-framework-graphql/src/metadata.ts
+++ b/packages/di-framework-graphql/src/metadata.ts
@@ -6,6 +6,7 @@
  */
 
 import { defineMetadata, getOwnMetadata } from '@di-framework/core/container';
+import type { AuthRequirement } from './authorization.ts';
 import type { Ctor, FieldDeclaration, ParamDeclaration, TypeThunk } from './types.ts';
 
 export const FIELDS_METADATA_KEY = 'graphql:fields';
@@ -13,6 +14,8 @@ export const PARAMS_METADATA_KEY = 'graphql:params';
 export const LOOKUP_METADATA_KEY = 'graphql:lookup';
 export const CONTEXT_METADATA_KEY = 'graphql:bounded-context';
 export const IMPLEMENTS_METADATA_KEY = 'graphql:implements';
+export const REQUIRES_METADATA_KEY = 'graphql:requires';
+export const TYPE_REQUIRES_METADATA_KEY = 'graphql:type-requires';
 
 type FieldMap = Record<string, FieldDeclaration>;
 type ParamMap = Record<string, Record<number, ParamDeclaration>>;
@@ -84,6 +87,56 @@ export function getLookup(target: Ctor): string | undefined {
     current = Object.getPrototypeOf(current);
   }
   return undefined;
+}
+
+/** Record a requirement on a member (`@Requires` on a `@Field`/`@Action`). */
+export function defineMemberRequirements(
+  prototype: object,
+  propertyKey: string,
+  requirements: readonly AuthRequirement[],
+): void {
+  const all: Record<string, AuthRequirement[]> =
+    getOwnMetadata(REQUIRES_METADATA_KEY, prototype) || {};
+  all[propertyKey] = [...requirements, ...(all[propertyKey] ?? [])];
+  defineMetadata(REQUIRES_METADATA_KEY, all, prototype);
+}
+
+/** Record a requirement covering every field of a class (`@Requires` on a type). */
+export function defineTypeRequirements(
+  target: Ctor,
+  requirements: readonly AuthRequirement[],
+): void {
+  const own: AuthRequirement[] = getOwnMetadata(TYPE_REQUIRES_METADATA_KEY, target) || [];
+  defineMetadata(TYPE_REQUIRES_METADATA_KEY, [...requirements, ...own], target);
+}
+
+/**
+ * Every requirement guarding a member: those declared on the class come first,
+ * then those on the member, walking the prototype chain so a subclass inherits
+ * whatever its base already required.
+ */
+export function getRequirements(target: Ctor, propertyKey: string): AuthRequirement[] {
+  const typeLevel: AuthRequirement[] = [];
+  let current: any = target;
+  while (current && current !== Function.prototype) {
+    const own: AuthRequirement[] | undefined = getOwnMetadata(TYPE_REQUIRES_METADATA_KEY, current);
+    if (own) typeLevel.unshift(...own);
+    current = Object.getPrototypeOf(current);
+  }
+
+  const memberLevel: AuthRequirement[] = [];
+  let prototype: object | null = target.prototype;
+  while (prototype && prototype !== Object.prototype) {
+    const all: Record<string, AuthRequirement[]> | undefined = getOwnMetadata(
+      REQUIRES_METADATA_KEY,
+      prototype,
+    );
+    const own = all?.[propertyKey];
+    if (own) memberLevel.unshift(...own);
+    prototype = Object.getPrototypeOf(prototype);
+  }
+
+  return [...typeLevel, ...memberLevel];
 }
 
 /** Record an interface implemented by a class (`@Implements`). */

--- a/packages/di-framework-graphql/src/resolvers.ts
+++ b/packages/di-framework-graphql/src/resolvers.ts
@@ -13,6 +13,7 @@
  */
 
 import { type Container, useContainer } from '@di-framework/core/container';
+import { type AuthorizationOptions, denialToError, evaluateRequirements } from './authorization.ts';
 import { BatchLoader } from './loader.ts';
 import type {
   Ctor,
@@ -27,6 +28,8 @@ export interface ResolverOptions {
   /** Container used to resolve portals, extensions and event subscriptions. */
   container?: Container;
   graph: TypeGraph;
+  /** How `@Requires` reads the principal off the request context. */
+  authorization?: AuthorizationOptions;
 }
 
 interface RequestState {
@@ -86,12 +89,14 @@ function stableStringify(value: unknown): string {
 
 export class ResolverFactory {
   private readonly container: Container;
+  private readonly authorization: AuthorizationOptions;
   private readonly inputsByName = new Map<string, ResolvedInputType>();
   /** Instances of classes that are not registered with the container. */
   private readonly unmanaged = new Map<Ctor, any>();
 
   constructor(private readonly options: ResolverOptions) {
     this.container = options.container ?? useContainer();
+    this.authorization = options.authorization ?? {};
     for (const input of options.graph.inputs) this.inputsByName.set(input.name, input);
   }
 
@@ -106,11 +111,11 @@ export class ResolverFactory {
       return () => constant;
     }
 
-    if (source.entity) return this.createEntityActionResolver(field);
+    if (source.entity) return this.authorized(field, this.createEntityActionResolver(field));
 
     const argTypes = new Map(field.args.map((arg) => [arg.name, arg.type]));
 
-    return (parent, args, ctx, info) => {
+    return this.authorized(field, (parent, args, ctx, info) => {
       const state = getRequestState(ctx);
       const holder = this.resolveHolder(field, parent, state);
 
@@ -123,7 +128,33 @@ export class ResolverFactory {
       }
 
       return this.invoke(holder, field, argTypes, parent, args, ctx, info);
-    };
+    });
+  }
+
+  /**
+   * Gate a resolver behind the field's `@Requires` declarations.
+   *
+   * The check runs before the member is read or invoked — and before the entity
+   * is loaded — so a denied caller never reaches the domain object at all.
+   */
+  private authorized<T extends (parent: any, args: any, ctx: any, info: any) => any>(
+    field: ResolvedField,
+    resolver: T,
+  ): T {
+    const requirements = field.source.requirements;
+    if (!requirements || requirements.length === 0) return resolver;
+
+    const path = `${field.source.target.name}.${field.name}`;
+    return (async (parent: any, args: any, ctx: any, info: any) => {
+      const denial = await evaluateRequirements(
+        requirements,
+        path,
+        { parent, args, ctx, info },
+        this.authorization,
+      );
+      if (denial) throw denialToError(denial, this.authorization);
+      return resolver(parent, args, ctx, info);
+    }) as unknown as T;
   }
 
   /** `subscribe` implementation for a `@Subscription` field. */
@@ -140,12 +171,31 @@ export class ResolverFactory {
       throw new Error(`${field.name} is not a subscription field`);
     }
 
-    return (_parent, args, ctx) =>
-      containerEventIterator(this.container, subscription.event, (payload) => {
-        if (subscription.filter && !subscription.filter(payload, args, ctx)) return SKIP;
-        if (subscription.map) return subscription.map(payload, args, ctx);
-        return unwrapPublisherPayload(payload);
+    const requirements = field.source.requirements;
+    const path = `${field.source.target.name}.${field.name}`;
+
+    return (_parent, args, ctx, info) => {
+      const stream = () =>
+        containerEventIterator(this.container, subscription.event, (payload) => {
+          if (subscription.filter && !subscription.filter(payload, args, ctx)) return SKIP;
+          if (subscription.map) return subscription.map(payload, args, ctx);
+          return unwrapPublisherPayload(payload);
+        });
+
+      if (!requirements || requirements.length === 0) return stream();
+
+      // Authorize before subscribing, so a denied caller never gets a stream.
+      return deferredIterator(async () => {
+        const denial = await evaluateRequirements(
+          requirements,
+          path,
+          { parent: _parent, args, ctx, info },
+          this.authorization,
+        );
+        if (denial) throw denialToError(denial, this.authorization);
+        return stream();
       });
+    };
   }
 
   /** Field resolver applied to each published event of a subscription. */
@@ -392,6 +442,35 @@ function unwrapPublisherPayload(payload: any): any {
     return payload.result;
   }
   return payload;
+}
+
+/**
+ * An iterator whose source is decided on first `next()`.
+ *
+ * Lets an async authorization check run before the underlying subscription is
+ * opened while still handing `subscribe` a synchronous iterator.
+ */
+function deferredIterator(open: () => Promise<AsyncIterableIterator<any>>) {
+  let source: AsyncIterableIterator<any> | undefined;
+  const ensure = async () => {
+    source ??= await open();
+    return source;
+  };
+  return {
+    async next(): Promise<IteratorResult<any>> {
+      return (await ensure()).next();
+    },
+    async return(): Promise<IteratorResult<any>> {
+      return (await source?.return?.()) ?? { value: undefined, done: true };
+    },
+    async throw(error: unknown): Promise<IteratorResult<any>> {
+      if (source?.throw) return source.throw(error);
+      throw error;
+    },
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  } as AsyncIterableIterator<any>;
 }
 
 /** Bridge container events onto an async iterator for GraphQL subscriptions. */

--- a/packages/di-framework-graphql/src/schema.ts
+++ b/packages/di-framework-graphql/src/schema.ts
@@ -38,6 +38,7 @@ import {
   subscribe,
   validate,
 } from 'graphql';
+import type { AuthorizationOptions } from './authorization.ts';
 import { SemanticSchemaError } from './errors.ts';
 import { ResolverFactory } from './resolvers.ts';
 import { registerScalarName, type ScalarRef } from './scalars.ts';
@@ -142,6 +143,8 @@ export function registerScalar(name: string, scalar: GraphQLScalarType): ScalarR
 export interface SemanticSchemaOptions extends BuildOptions {
   /** Container used to resolve portals and read the event bus. */
   container?: Container;
+  /** How `@Requires` reads the principal, roles and claims off the context. */
+  authorization?: AuthorizationOptions;
   /** Options for the SDL rendered onto `SemanticSchema.sdl`. */
   print?: PrintOptions;
   /** Optional query resource limits enforced before execution. */
@@ -184,7 +187,11 @@ class SchemaAssembler {
     private readonly graph: TypeGraph,
     options: SemanticSchemaOptions,
   ) {
-    this.factory = new ResolverFactory({ container: options.container, graph });
+    this.factory = new ResolverFactory({
+      container: options.container,
+      graph,
+      authorization: options.authorization,
+    });
   }
 
   assemble(): GraphQLSchema {

--- a/packages/di-framework-graphql/src/type-graph.ts
+++ b/packages/di-framework-graphql/src/type-graph.ts
@@ -15,6 +15,7 @@ import {
   getImplements,
   getLookup,
   getParamNames,
+  getRequirements,
 } from './metadata.ts';
 import { getRegistry } from './registry.ts';
 import { CUSTOM_SCALARS, ScalarRef, scalarNameForConstructor } from './scalars.ts';
@@ -408,6 +409,7 @@ class GraphBuilder {
     const path = `${ownerName}.${name}`;
     const type = this.resolveTypeRef(declaration.options.type, declaration.options, path);
     const { params, args } = this.planParams(target, declaration, holder, path);
+    const requirements = getRequirements(target, declaration.propertyKey);
 
     this.fieldContexts.set(path, context);
 
@@ -426,6 +428,7 @@ class GraphBuilder {
         params,
         batch: declaration.options.batch,
         middleware: declaration.options.middleware,
+        requirements: requirements.length > 0 ? requirements : undefined,
         subscription: declaration.event
           ? {
               event: declaration.event,
@@ -487,6 +490,7 @@ class GraphBuilder {
         : nonNull({ kind: 'object', name: object.name, target: object.target });
 
       const { params, args } = this.planParams(object.target, declaration, 'entity', path);
+      const entityRequirements = getRequirements(object.target, declaration.propertyKey);
       const keyArgName = declaration.options.keyArg ?? keyArg;
       if (!args.some((arg) => arg.name === keyArgName)) {
         args.unshift({
@@ -511,6 +515,7 @@ class GraphBuilder {
           member: declaration.member,
           holder: 'entity',
           params,
+          requirements: entityRequirements.length > 0 ? entityRequirements : undefined,
           entity: {
             typeName: object.name,
             keyArg: keyArgName,

--- a/packages/di-framework-graphql/src/types.ts
+++ b/packages/di-framework-graphql/src/types.ts
@@ -301,6 +301,8 @@ export interface FieldSource {
   };
   /** Synthesized field that always resolves to this value. */
   constant?: unknown;
+  /** Requirements that must pass before the member is read or invoked. */
+  requirements?: readonly import('./authorization.ts').AuthRequirement[];
 }
 
 export interface ResolvedArg {

--- a/packages/di-framework-graphql/tests/authorization.test.ts
+++ b/packages/di-framework-graphql/tests/authorization.test.ts
@@ -1,0 +1,326 @@
+/**
+ * `@Requires`: role, claim and predicate enforcement on fields, actions,
+ * portal roots and whole types — plus what a denied caller is allowed to learn.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { Container } from '@di-framework/core/container';
+import { evaluateRequirements, SemanticAuthorizationError } from '../src/authorization.ts';
+import {
+  Action,
+  Arg,
+  Ctx,
+  Field,
+  Lookup,
+  Portal,
+  Requires,
+  SemanticType,
+} from '../src/decorators.ts';
+import { ID } from '../src/scalars.ts';
+import { buildSemanticSchema } from '../src/schema.ts';
+import { withRegistry } from './helpers.ts';
+
+function librarySchema() {
+  @SemanticType({ key: 'id' })
+  class Book {
+    id!: string;
+    ownerId!: string;
+
+    @Field(() => String) title!: string;
+
+    // Guarded fields are nullable: a permission failure should blank the field,
+    // not null the whole book.
+    @Requires({ roles: ['librarian'] })
+    @Field(() => String, { nullable: true })
+    acquisitionCost(): string {
+      return '£42.00';
+    }
+
+    @Requires({ predicate: ({ parent, ctx }) => (parent as Book).ownerId === ctx.user?.id })
+    @Field(() => String, { nullable: true })
+    privateNote(): string {
+      return 'reserved for staff';
+    }
+
+    @Requires({ roles: ['librarian'] })
+    @Action(() => String, { nullable: true })
+    withdraw(): string {
+      return `withdrew ${this.id}`;
+    }
+
+    @Lookup()
+    static load(id: string) {
+      return Object.assign(new Book(), { id, ownerId: 'u1', title: 'Dune' });
+    }
+  }
+
+  @Portal()
+  class Query {
+    @Field(() => Book)
+    book(): Book {
+      return Book.load('b1');
+    }
+
+    @Requires({ authenticated: true })
+    @Field(() => String, { nullable: true })
+    whoami(@Ctx() ctx: any): string {
+      return ctx.user.id;
+    }
+
+    @Requires({ claims: { tenant: ['acme', 'globex'] } })
+    @Field(() => String, { nullable: true })
+    tenantSecret(): string {
+      return 'secret';
+    }
+
+    @Requires({ roles: ['admin'], message: 'Admins only.' })
+    @Action(() => String, { nullable: true })
+    purge(@Arg('scope', () => String) scope: string): string {
+      return `purged ${scope}`;
+    }
+
+    /** Non-null on purpose, to pin down how a denial propagates. */
+    @Requires({ roles: ['admin'] })
+    @Field(() => String)
+    strictSecret(): string {
+      return 'secret';
+    }
+  }
+
+  return buildSemanticSchema({ container: new Container() });
+}
+
+describe('@Requires on fields', () => {
+  it('allows a caller holding the required role', async () => {
+    const api = withRegistry(librarySchema);
+    const result = await api.execute({
+      query: '{ book { title acquisitionCost } }',
+      context: { user: { id: 'u9', roles: ['librarian'] } },
+    });
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.book).toEqual({ title: 'Dune', acquisitionCost: '£42.00' });
+  });
+
+  it('denies a caller without the role but still serves unguarded fields', async () => {
+    const api = withRegistry(librarySchema);
+    const result = await api.execute({
+      query: '{ book { title acquisitionCost } }',
+      context: { user: { id: 'u9', roles: ['member'] } },
+    });
+    expect(result.errors?.[0]?.message).toBe('Not authorized.');
+    expect(result.errors?.[0]?.extensions?.code).toBe('FORBIDDEN');
+    expect(result.data?.book).toEqual({ title: 'Dune', acquisitionCost: null });
+  });
+
+  it('nulls the parent when a denied field is non-null', async () => {
+    const api = withRegistry(librarySchema);
+    const result = await api.execute({
+      query: '{ strictSecret }',
+      context: { user: { id: 'u9', roles: ['member'] } },
+    });
+    expect(result.errors?.[0]?.extensions?.code).toBe('FORBIDDEN');
+    // Standard GraphQL non-null propagation — declare guarded fields nullable
+    // unless blanking the whole selection is what you want.
+    expect(result.data).toBeNull();
+  });
+
+  it('distinguishes anonymous callers with UNAUTHENTICATED', async () => {
+    const api = withRegistry(librarySchema);
+    const result = await api.execute({ query: '{ whoami }', context: {} });
+    expect(result.errors?.[0]?.extensions?.code).toBe('UNAUTHENTICATED');
+    expect(result.errors?.[0]?.message).toBe('Authentication is required.');
+  });
+
+  it('evaluates predicates against the parent object', async () => {
+    const api = withRegistry(librarySchema);
+    const owner = await api.execute({
+      query: '{ book { privateNote } }',
+      context: { user: { id: 'u1' } },
+    });
+    expect(owner.data?.book).toEqual({ privateNote: 'reserved for staff' });
+
+    const other = await withRegistry(librarySchema).execute({
+      query: '{ book { privateNote } }',
+      context: { user: { id: 'u2' } },
+    });
+    expect(other.errors?.[0]?.extensions?.code).toBe('FORBIDDEN');
+  });
+
+  it('matches a claim against any value in the allowed list', async () => {
+    const allowed = await withRegistry(librarySchema).execute({
+      query: '{ tenantSecret }',
+      context: { user: { id: 'u1', claims: { tenant: 'globex' } } },
+    });
+    expect(allowed.data?.tenantSecret).toBe('secret');
+
+    const denied = await withRegistry(librarySchema).execute({
+      query: '{ tenantSecret }',
+      context: { user: { id: 'u1', claims: { tenant: 'initech' } } },
+    });
+    expect(denied.errors?.[0]?.extensions?.code).toBe('FORBIDDEN');
+  });
+});
+
+describe('@Requires on actions', () => {
+  it('guards a portal mutation and surfaces the declared message', async () => {
+    const denied = await withRegistry(librarySchema).execute({
+      query: 'mutation { purge(scope: "all") }',
+      context: { user: { id: 'u1', roles: ['member'] } },
+    });
+    expect(denied.errors?.[0]?.message).toBe('Admins only.');
+    expect(denied.data?.purge).toBeNull();
+
+    const allowed = await withRegistry(librarySchema).execute({
+      query: 'mutation { purge(scope: "all") }',
+      context: { user: { id: 'u1', roles: ['admin'] } },
+    });
+    expect(allowed.data?.purge).toBe('purged all');
+  });
+
+  it('guards an entity action before the entity is loaded', async () => {
+    let loads = 0;
+    const api = withRegistry(() => {
+      @SemanticType({ key: 'id' })
+      class Vault {
+        id!: string;
+
+        @Field(() => String) label!: string;
+
+        @Requires({ roles: ['keyholder'] })
+        @Action(() => String)
+        open(): string {
+          return 'opened';
+        }
+
+        @Lookup()
+        static load(id: string) {
+          loads += 1;
+          return Object.assign(new Vault(), { id, label: 'v' });
+        }
+      }
+
+      @Portal()
+      class Query {
+        @Field(() => Vault)
+        vault(): Vault {
+          return Vault.load('v1');
+        }
+      }
+
+      return buildSemanticSchema({ container: new Container() });
+    });
+
+    loads = 0;
+    const denied = await api.execute({
+      query: 'mutation { vaultOpen(id: "v1") }',
+      context: { user: { id: 'u1', roles: [] } },
+    });
+    expect(denied.errors?.[0]?.extensions?.code).toBe('FORBIDDEN');
+    // The domain object is never even loaded for a denied caller.
+    expect(loads).toBe(0);
+  });
+});
+
+describe('@Requires on a whole type', () => {
+  it('guards every field of the class it is applied to', async () => {
+    const api = withRegistry(() => {
+      @Requires({ roles: ['staff'] })
+      @Portal()
+      class AdminQuery {
+        @Field(() => String, { nullable: true })
+        metrics(): string {
+          return 'ok';
+        }
+
+        @Field(() => ID, { nullable: true })
+        buildId(): string {
+          return 'b1';
+        }
+      }
+
+      return buildSemanticSchema({ container: new Container() });
+    });
+
+    const denied = await api.execute({ query: '{ metrics buildId }', context: { user: {} } });
+    expect(denied.errors).toHaveLength(2);
+    expect(denied.errors?.every((e) => e.extensions?.code === 'FORBIDDEN')).toBe(true);
+
+    const allowed = await withRegistry(() => {
+      @Requires({ roles: ['staff'] })
+      @Portal()
+      class AdminQuery {
+        @Field(() => String, { nullable: true })
+        metrics(): string {
+          return 'ok';
+        }
+      }
+      return buildSemanticSchema({ container: new Container() });
+    }).execute({ query: '{ metrics }', context: { user: { roles: ['staff'] } } });
+    expect(allowed.data?.metrics).toBe('ok');
+  });
+});
+
+describe('authorization wiring', () => {
+  it('honours a custom principal reader and onDenied hook', async () => {
+    const api = withRegistry(() => {
+      @Portal()
+      class Query {
+        @Requires({ roles: ['ops'] })
+        @Field(() => String)
+        restricted(): string {
+          return 'ok';
+        }
+      }
+
+      return buildSemanticSchema({
+        container: new Container(),
+        authorization: {
+          principal: (ctx) => ctx.session,
+          roles: (_ctx, principal: any) => principal?.grants ?? [],
+          onDenied: () => new SemanticAuthorizationError('Nope.', 'DENIED'),
+        },
+      });
+    });
+
+    const allowed = await api.execute({
+      query: '{ restricted }',
+      context: { session: { grants: ['ops'] } },
+    });
+    expect(allowed.data?.restricted).toBe('ok');
+
+    const denied = await api.execute({
+      query: '{ restricted }',
+      context: { session: { grants: ['dev'] } },
+    });
+    expect(denied.errors?.[0]?.message).toBe('Nope.');
+    expect(denied.errors?.[0]?.extensions?.code).toBe('DENIED');
+  });
+
+  it('leaks nothing about the rule that failed', async () => {
+    const denied = await withRegistry(librarySchema).execute({
+      query: '{ book { acquisitionCost } }',
+      context: { user: { id: 'u9', roles: ['member'] } },
+    });
+    const serialized = JSON.stringify(denied.errors);
+    expect(serialized).not.toContain('librarian');
+    expect(serialized).not.toContain('roles');
+    expect(serialized).not.toContain('acquisitionCost:');
+  });
+
+  it('treats multiple requirements as conjunctive', async () => {
+    const context = { parent: undefined, args: {}, ctx: { user: { roles: ['a'] } }, info: {} };
+    expect(
+      await evaluateRequirements([{ roles: ['a'] }, { roles: ['b'] }], 'X.y', context),
+    ).toMatchObject({ reason: 'roles' });
+    expect(await evaluateRequirements([{ roles: ['a'] }], 'X.y', context)).toBeNull();
+  });
+
+  it('requires every role when allRoles is used', async () => {
+    const context = { parent: undefined, args: {}, ctx: { user: { roles: ['a'] } }, info: {} };
+    expect(await evaluateRequirements([{ allRoles: ['a', 'b'] }], 'X.y', context)).toMatchObject({
+      reason: 'roles',
+    });
+    context.ctx.user.roles = ['a', 'b'];
+    expect(await evaluateRequirements([{ allRoles: ['a', 'b'] }], 'X.y', context)).toBeNull();
+  });
+});


### PR DESCRIPTION
Authorization becomes a declaration next to the thing it protects instead of a
`requireLibrarian(ctx)` guard clause at the top of every resolver.

- @Requires declares roles (any-of), allRoles (all-of), claims, an
  `authenticated` flag, or an arbitrary predicate over parent/args/ctx
- works on @Field, @Action, portal roots, and on a whole class, where it guards
  every field; requirements accumulate and are conjunctive
- checks run before the member is read or invoked — and before an entity
  @Lookup — so a denied caller never reaches the domain object
- subscriptions authorize before the stream is opened
- denials surface as GraphQL errors carrying only FORBIDDEN or UNAUTHENTICATED
  and a message the author chose; nothing about the failing rule leaks

How the principal, roles and claims are read off the context is
application-specific, so each reader is overridable via
`SemanticSchemaOptions.authorization`; the defaults cover `ctx.user`.

The library example drops requireLibrarian in favour of @Requires on addBook
and wires the readers for its own context shape.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>