### PR TITLE
feat(graphql): add Relay connection helpers (#26)

### DIFF
--- a/examples/packages/graphql/domain/catalog.ts
+++ b/examples/packages/graphql/domain/catalog.ts
@@ -12,7 +12,6 @@ import {
   Action,
   Arg,
   BoundedContext,
-  Ctx,
   DateTime,
   Field,
   ID,
@@ -22,14 +21,13 @@ import {
   Json,
   Lookup,
   Portal,
-  registerEnum,
   Requires,
+  registerEnum,
   SemanticType,
 } from '@di-framework/graphql';
 import type { GraphQLResolveInfo } from 'graphql';
 // Must be evaluated before the first decorated class below. See registry.ts.
 import './registry.ts';
-import type { LibraryContext } from './context.ts';
 
 /* -------------------------------------------------------------------------- */
 /* Enums                                                                      */

--- a/packages/di-framework-graphql/core.ts
+++ b/packages/di-framework-graphql/core.ts
@@ -16,6 +16,20 @@ export {
   evaluateRequirements,
   SemanticAuthorizationError,
 } from './src/authorization.ts';
+export {
+  type Connection,
+  type ConnectionArgs,
+  connectionFromArray,
+  connectionFromSlice,
+  cursorToOffset,
+  decodeCursor,
+  type Edge,
+  encodeCursor,
+  isConnection,
+  offsetToCursor,
+  type PageInfo,
+  toConnection,
+} from './src/connection.ts';
 export * from './src/decorators.ts';
 export * from './src/errors.ts';
 export { type BatchFunction, BatchLoader } from './src/loader.ts';

--- a/packages/di-framework-graphql/src/connection.ts
+++ b/packages/di-framework-graphql/src/connection.ts
@@ -1,0 +1,190 @@
+/**
+ * Relay cursor connections.
+ *
+ * The connection, edge and `PageInfo` types are generated from the domain field
+ * that returns them, so pagination does not force a parallel hierarchy of
+ * hand-written connection classes alongside the entities.
+ *
+ * A field declared with `@Connection` may return a plain array — the common
+ * case, sliced here — or an already-shaped {@link Connection} when the data
+ * source paginates natively.
+ */
+
+/** Opaque, base64 cursor prefix used for offset-based slicing of an array. */
+const ARRAY_CURSOR_PREFIX = 'arrayconnection:';
+
+function toBase64(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function fromBase64(value: string): string {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}
+
+/** Encode an opaque cursor. Cursors are base64 so clients treat them as opaque. */
+export function encodeCursor(value: string | number): string {
+  return toBase64(String(value));
+}
+
+/** Decode a cursor produced by {@link encodeCursor}. */
+export function decodeCursor(cursor: string): string {
+  try {
+    return fromBase64(cursor);
+  } catch {
+    throw new Error('Invalid cursor.');
+  }
+}
+
+/** Cursor for the item at `index` of an array-backed connection. */
+export function offsetToCursor(index: number): string {
+  return encodeCursor(`${ARRAY_CURSOR_PREFIX}${index}`);
+}
+
+/** Index encoded by {@link offsetToCursor}, or `-1` when it is not one. */
+export function cursorToOffset(cursor: string): number {
+  const decoded = decodeCursor(cursor);
+  if (!decoded.startsWith(ARRAY_CURSOR_PREFIX)) return -1;
+  const offset = Number.parseInt(decoded.slice(ARRAY_CURSOR_PREFIX.length), 10);
+  return Number.isNaN(offset) ? -1 : offset;
+}
+
+export interface PageInfo {
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+  endCursor: string | null;
+}
+
+export interface Edge<T> {
+  node: T;
+  cursor: string;
+}
+
+export interface Connection<T> {
+  edges: Array<Edge<T>>;
+  pageInfo: PageInfo;
+  /** Size of the full result set, before slicing. */
+  totalCount: number | null;
+}
+
+/** The four Relay pagination arguments. */
+export interface ConnectionArgs {
+  first?: number | null;
+  after?: string | null;
+  last?: number | null;
+  before?: string | null;
+}
+
+/** True when a value already has connection shape and should pass through. */
+export function isConnection(value: unknown): value is Connection<unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Array.isArray((value as Connection<unknown>).edges) &&
+    typeof (value as Connection<unknown>).pageInfo === 'object'
+  );
+}
+
+/**
+ * Slice an in-memory array the way the Relay connection spec describes:
+ * `after`/`before` narrow the window, then `first`/`last` trim it.
+ *
+ * `hasNextPage` and `hasPreviousPage` are reported against the *whole* set
+ * rather than the direction being paged. The spec permits either, and always
+ * answering the question a client actually asks — "is there more on this side?"
+ * — beats returning a spec-legal `false` while paging forward.
+ */
+export function connectionFromArray<T>(
+  items: readonly T[],
+  args: ConnectionArgs = {},
+): Connection<T> {
+  const total = items.length;
+
+  let start = 0;
+  let end = total;
+
+  if (typeof args.after === 'string') {
+    const offset = cursorToOffset(args.after);
+    if (offset >= 0) start = Math.max(start, Math.min(offset + 1, total));
+  }
+  if (typeof args.before === 'string') {
+    const offset = cursorToOffset(args.before);
+    if (offset >= 0) end = Math.min(end, Math.max(offset, 0));
+  }
+  if (end < start) end = start;
+
+  if (typeof args.first === 'number') {
+    if (args.first < 0) throw new Error('Argument "first" must not be negative.');
+    end = Math.min(end, start + args.first);
+  }
+  if (typeof args.last === 'number') {
+    if (args.last < 0) throw new Error('Argument "last" must not be negative.');
+    start = Math.max(start, end - args.last);
+  }
+
+  const edges = items.slice(start, end).map((node, index) => ({
+    node,
+    cursor: offsetToCursor(start + index),
+  }));
+
+  return {
+    edges,
+    totalCount: total,
+    pageInfo: {
+      hasNextPage: end < total,
+      hasPreviousPage: start > 0,
+      startCursor: edges[0]?.cursor ?? null,
+      endCursor: edges[edges.length - 1]?.cursor ?? null,
+    },
+  };
+}
+
+/**
+ * Build a connection from a page the data source already sliced.
+ *
+ * Use when the repository does the paging: supply the page, whether more exists
+ * on either side, and how to derive each node's cursor.
+ */
+export function connectionFromSlice<T>(
+  nodes: readonly T[],
+  options: {
+    cursorFor: (node: T, index: number) => string | number;
+    hasNextPage?: boolean;
+    hasPreviousPage?: boolean;
+    totalCount?: number | null;
+  },
+): Connection<T> {
+  const edges = nodes.map((node, index) => ({
+    node,
+    cursor: encodeCursor(options.cursorFor(node, index)),
+  }));
+  return {
+    edges,
+    totalCount: options.totalCount ?? null,
+    pageInfo: {
+      hasNextPage: options.hasNextPage ?? false,
+      hasPreviousPage: options.hasPreviousPage ?? false,
+      startCursor: edges[0]?.cursor ?? null,
+      endCursor: edges[edges.length - 1]?.cursor ?? null,
+    },
+  };
+}
+
+/**
+ * Coerce whatever a `@Connection` field returned into connection shape.
+ *
+ * Arrays are sliced against the incoming pagination arguments; anything already
+ * shaped is passed through untouched.
+ */
+export function toConnection(value: unknown, args: ConnectionArgs): unknown {
+  if (value === null || value === undefined) return value;
+  if (isConnection(value)) return value;
+  if (Array.isArray(value)) return connectionFromArray(value, args);
+  return value;
+}

--- a/packages/di-framework-graphql/src/decorators.ts
+++ b/packages/di-framework-graphql/src/decorators.ts
@@ -20,11 +20,12 @@ import {
   defineTypeRequirements,
 } from './metadata.ts';
 import { getRegistry } from './registry.ts';
-import { ScalarRef, scalarNameForConstructor } from './scalars.ts';
+import { ScalarRef } from './scalars.ts';
 import {
   type AbstractCtor,
   type ActionOptions,
   type ArgOptions,
+  type ConnectionOptions,
   type Ctor,
   type EnumObject,
   type EnumOptions,
@@ -35,7 +36,6 @@ import {
   type PortalOptions,
   type SemanticTypeOptions,
   type SubscriptionOptions,
-  type TypeInput,
   type TypeRef,
   type TypeThunk,
   type UnionOptions,
@@ -318,6 +318,45 @@ export function Field(type?: TypeRef, options?: FieldOptions): PropertyDecorator
 export function Field(typeOrOptions?: TypeRef | FieldOptions, maybeOptions?: FieldOptions): any {
   const { type, options } = normalizeArgs(typeOrOptions, maybeOptions);
   return declareMember('field', type, options);
+}
+
+/**
+ * Exposes a member as a Relay cursor connection over `node`.
+ *
+ * The `<Node>Connection`, `<Node>Edge` and shared `PageInfo` types are
+ * generated, and `first`/`after`/`last`/`before` are added to the field. The
+ * method may return a plain array — sliced against those arguments — or a
+ * connection built with `connectionFromSlice()` when the repository pages
+ * natively.
+ *
+ * @example
+ * ```ts
+ * @Connection(() => Review, { defaultPageSize: 20, maxPageSize: 100 })
+ * reviews(): Review[] { return this.repo.forBook(this.id); }
+ * ```
+ */
+export function Connection(
+  node: TypeRef,
+  options: ConnectionOptions = {},
+): PropertyDecorator & MethodDecorator {
+  return ((target: any, propertyKey: string, descriptor?: PropertyDescriptor): void => {
+    if (typeof target === 'function') {
+      throw new SemanticSchemaError(
+        `${target.name}.${propertyKey}: @Connection is not supported on static members`,
+      );
+    }
+    const member: 'method' | 'property' =
+      descriptor && typeof descriptor.value === 'function' ? 'method' : 'property';
+
+    defineFieldDeclaration(target, {
+      propertyKey,
+      kind: 'field',
+      member,
+      options: options as FieldOptions,
+      params: [],
+      connection: { node, options },
+    });
+  }) as PropertyDecorator & MethodDecorator;
 }
 
 /**

--- a/packages/di-framework-graphql/src/resolvers.ts
+++ b/packages/di-framework-graphql/src/resolvers.ts
@@ -14,6 +14,7 @@
 
 import { type Container, useContainer } from '@di-framework/core/container';
 import { type AuthorizationOptions, denialToError, evaluateRequirements } from './authorization.ts';
+import { type ConnectionArgs, toConnection } from './connection.ts';
 import { BatchLoader } from './loader.ts';
 import type {
   Ctor,
@@ -111,24 +112,64 @@ export class ResolverFactory {
       return () => constant;
     }
 
-    if (source.entity) return this.authorized(field, this.createEntityActionResolver(field));
+    if (source.entity) {
+      return this.authorized(field, this.paginated(field, this.createEntityActionResolver(field)));
+    }
 
     const argTypes = new Map(field.args.map((arg) => [arg.name, arg.type]));
 
-    return this.authorized(field, (parent, args, ctx, info) => {
-      const state = getRequestState(ctx);
-      const holder = this.resolveHolder(field, parent, state);
+    return this.authorized(
+      field,
+      this.paginated(field, (parent, args, ctx, info) => {
+        const state = getRequestState(ctx);
+        const holder = this.resolveHolder(field, parent, state);
 
-      if (source.member === 'property') {
-        return (holder as any)?.[source.propertyKey];
+        if (source.member === 'property') {
+          return (holder as any)?.[source.propertyKey];
+        }
+
+        if (source.batch && state) {
+          return this.loadBatched(field, argTypes, parent, args, ctx, info, state);
+        }
+
+        return this.invoke(holder, field, argTypes, parent, args, ctx, info);
+      }),
+    );
+  }
+
+  /**
+   * Shape a `@Connection` field's result.
+   *
+   * A plain array is sliced against the incoming cursor arguments; a value that
+   * already has connection shape — because the repository paged natively — is
+   * passed through.
+   */
+  private paginated<T extends (parent: any, args: any, ctx: any, info: any) => any>(
+    field: ResolvedField,
+    resolver: T,
+  ): T {
+    const connection = field.source.connection;
+    if (!connection) return resolver;
+
+    const { defaultPageSize, maxPageSize } = connection;
+
+    return ((parent: any, args: any, ctx: any, info: any) => {
+      const requested = args.first ?? args.last;
+      if (maxPageSize !== undefined && typeof requested === 'number' && requested > maxPageSize) {
+        throw new Error(`Page size ${requested} exceeds the maximum of ${maxPageSize}.`);
       }
+      const paging: ConnectionArgs = {
+        ...args,
+        first:
+          args.first ??
+          (args.last === undefined || args.last === null ? defaultPageSize : undefined),
+      };
 
-      if (source.batch && state) {
-        return this.loadBatched(field, argTypes, parent, args, ctx, info, state);
-      }
-
-      return this.invoke(holder, field, argTypes, parent, args, ctx, info);
-    });
+      const result = resolver(parent, args, ctx, info);
+      return result && typeof result.then === 'function'
+        ? result.then((value: unknown) => toConnection(value, paging))
+        : toConnection(result, paging);
+    }) as unknown as T;
   }
 
   /**

--- a/packages/di-framework-graphql/src/type-graph.ts
+++ b/packages/di-framework-graphql/src/type-graph.ts
@@ -22,6 +22,7 @@ import { CUSTOM_SCALARS, ScalarRef, scalarNameForConstructor } from './scalars.t
 import {
   type ArgOptions,
   type BuildOptions,
+  type ConnectionOptions,
   type Ctor,
   type EnumObject,
   type FieldDeclaration,
@@ -129,8 +130,10 @@ class GraphBuilder {
       });
     }
 
-    // Pass 3: own fields.
-    for (const object of this.objects.values()) {
+    // Pass 3: own fields. Snapshot first — resolving a @Connection field adds
+    // generated connection/edge types, which have no declarations to collect and
+    // must not be revisited here.
+    for (const object of Array.from(this.objects.values())) {
       object.fields = this.resolveOwnFields(object);
     }
     for (const [target, resolved] of this.interfaces) {
@@ -353,6 +356,176 @@ class GraphBuilder {
     }
   }
 
+  /**
+   * Generate the `PageInfo`, `<Node>Edge` and `<Node>Connection` types backing a
+   * `@Connection` field, and return the connection's type node.
+   *
+   * The generated types inherit the node's bounded context and boundary flag, so
+   * paginating a type does not become a way to smuggle it across a context edge.
+   */
+  private ensureConnection(node: ResolvedObjectType, connectionName: string): TypeNode {
+    const existing = this.objectsByName.get(connectionName);
+    if (existing) return nonNull({ kind: 'object', name: connectionName, target: existing.target });
+
+    const pageInfo = this.ensurePageInfo();
+    const edgeName = `${node.name}Edge`;
+
+    const edge =
+      this.objectsByName.get(edgeName) ??
+      this.addSynthetic({
+        name: edgeName,
+        description: `An edge in a ${connectionName}.`,
+        context: node.context,
+        boundary: node.boundary,
+        fields: [
+          { name: 'node', type: nonNull({ kind: 'object', name: node.name, target: node.target }) },
+          { name: 'cursor', type: nonNull({ kind: 'scalar', name: 'String' }) },
+        ],
+      });
+
+    const connection = this.addSynthetic({
+      name: connectionName,
+      description: `A Relay connection over ${node.name}.`,
+      context: node.context,
+      boundary: node.boundary,
+      fields: [
+        {
+          name: 'edges',
+          type: nonNull({
+            kind: 'list',
+            of: nonNull({ kind: 'object', name: edge.name, target: edge.target }),
+          }),
+        },
+        {
+          name: 'pageInfo',
+          type: nonNull({ kind: 'object', name: pageInfo.name, target: pageInfo.target }),
+        },
+        {
+          name: 'totalCount',
+          type: { kind: 'scalar', name: 'Int' },
+          description: 'Size of the full result set, before slicing.',
+        },
+      ],
+    });
+
+    return nonNull({ kind: 'object', name: connection.name, target: connection.target });
+  }
+
+  /** Resolve a `@Connection` declaration into its type, its paging args and its runtime options. */
+  private planConnection(
+    declaration: { node: TypeRef; options: ConnectionOptions },
+    path: string,
+  ): {
+    type: TypeNode;
+    args: ResolvedArg[];
+    source: { defaultPageSize?: number; maxPageSize?: number };
+  } {
+    const nodeType = this.fromTypeInput(unwrapThunk(declaration.node, this.registry), {}, path);
+    if (nodeType.kind !== 'object') {
+      throw new SemanticSchemaError(
+        `${path}: @Connection needs a @SemanticType to paginate over, got '${nodeType.kind}'.`,
+      );
+    }
+    const node = this.objects.get(nodeType.target as Ctor);
+    if (!node) {
+      throw new SemanticSchemaError(`${path}: '${nodeType.name}' is not in the selected contexts.`);
+    }
+
+    const connectionName = declaration.options.connectionName ?? `${node.name}Connection`;
+
+    return {
+      type: this.ensureConnection(node, connectionName),
+      args: [
+        {
+          name: 'first',
+          description: 'Take this many from the start of the slice.',
+          type: { kind: 'scalar', name: 'Int' },
+        },
+        {
+          name: 'after',
+          description: 'Return items after this cursor.',
+          type: { kind: 'scalar', name: 'String' },
+        },
+        {
+          name: 'last',
+          description: 'Take this many from the end of the slice.',
+          type: { kind: 'scalar', name: 'Int' },
+        },
+        {
+          name: 'before',
+          description: 'Return items before this cursor.',
+          type: { kind: 'scalar', name: 'String' },
+        },
+      ],
+      source: {
+        defaultPageSize: declaration.options.defaultPageSize,
+        maxPageSize: declaration.options.maxPageSize,
+      },
+    };
+  }
+
+  private ensurePageInfo(): ResolvedObjectType {
+    const existing = this.objectsByName.get('PageInfo');
+    if (existing) return existing;
+    return this.addSynthetic({
+      name: 'PageInfo',
+      description: 'Relay pagination metadata for the current slice.',
+      context: undefined,
+      boundary: false,
+      fields: [
+        { name: 'hasNextPage', type: nonNull({ kind: 'scalar', name: 'Boolean' }) },
+        { name: 'hasPreviousPage', type: nonNull({ kind: 'scalar', name: 'Boolean' }) },
+        { name: 'startCursor', type: { kind: 'scalar', name: 'String' } },
+        { name: 'endCursor', type: { kind: 'scalar', name: 'String' } },
+      ],
+    });
+  }
+
+  /**
+   * Register a type that has no class of its own.
+   *
+   * Its fields are plain property reads, so the synthesized carrier object the
+   * connection helpers build resolves through the normal hydration path.
+   */
+  private addSynthetic(spec: {
+    name: string;
+    description?: string;
+    context: string | undefined;
+    boundary: boolean;
+    fields: Array<{ name: string; type: TypeNode; description?: string }>;
+  }): ResolvedObjectType {
+    const target = class {} as Ctor;
+    Object.defineProperty(target, 'name', { value: spec.name });
+
+    const resolved: ResolvedObjectType = {
+      name: spec.name,
+      description: spec.description,
+      target,
+      context: spec.context,
+      boundary: spec.boundary,
+      portal: false,
+      interfaces: [],
+      fields: spec.fields.map((field) => ({
+        name: field.name,
+        description: field.description,
+        type: field.type,
+        args: [],
+        context: spec.context,
+        source: {
+          target,
+          propertyKey: field.name,
+          member: 'property' as const,
+          holder: 'parent' as const,
+          params: [],
+        },
+      })),
+    };
+
+    this.objects.set(target, resolved);
+    this.objectsByName.set(resolved.name, resolved);
+    return resolved;
+  }
+
   private ensureUnion(ref: UnionRef, path: string): ResolvedUnionType {
     const existing = this.unions.get(ref);
     if (existing) return existing;
@@ -407,9 +580,19 @@ class GraphBuilder {
   ): ResolvedField {
     const name = declaration.options.name ?? declaration.propertyKey;
     const path = `${ownerName}.${name}`;
-    const type = this.resolveTypeRef(declaration.options.type, declaration.options, path);
+    const connection = declaration.connection
+      ? this.planConnection(declaration.connection, path)
+      : undefined;
+    const type =
+      connection?.type ?? this.resolveTypeRef(declaration.options.type, declaration.options, path);
     const { params, args } = this.planParams(target, declaration, holder, path);
     const requirements = getRequirements(target, declaration.propertyKey);
+
+    // A method may declare its own `first`/`after` params to read them; keep the
+    // author's version rather than emitting the argument twice.
+    if (connection) {
+      args.push(...connection.args.filter((arg) => !args.some((own) => own.name === arg.name)));
+    }
 
     this.fieldContexts.set(path, context);
 
@@ -429,6 +612,7 @@ class GraphBuilder {
         batch: declaration.options.batch,
         middleware: declaration.options.middleware,
         requirements: requirements.length > 0 ? requirements : undefined,
+        connection: connection?.source,
         subscription: declaration.event
           ? {
               event: declaration.event,

--- a/packages/di-framework-graphql/src/types.ts
+++ b/packages/di-framework-graphql/src/types.ts
@@ -169,6 +169,15 @@ export type FieldMiddleware = (
   context: FieldMiddlewareContext,
 ) => unknown | Promise<unknown>;
 
+export interface ConnectionOptions extends Omit<FieldOptions, 'type'> {
+  /** Name of the generated connection type. Defaults to `<Node>Connection`. */
+  connectionName?: string;
+  /** Default `first` when the caller supplies no pagination arguments. */
+  defaultPageSize?: number;
+  /** Largest `first`/`last` accepted. Requests above it are an error. */
+  maxPageSize?: number;
+}
+
 export interface ActionOptions extends FieldOptions {
   /**
    * Root mutation field name. Defaults to the method name for portals, and to
@@ -230,6 +239,8 @@ export interface FieldDeclaration {
   /** Container event backing a `@Subscription`. */
   event?: string;
   params: ParamDeclaration[];
+  /** Set by `@Connection`: the node type to paginate over, plus paging limits. */
+  connection?: { node: TypeRef; options: ConnectionOptions };
 }
 
 export interface SemanticTypeDeclaration {
@@ -303,6 +314,8 @@ export interface FieldSource {
   constant?: unknown;
   /** Requirements that must pass before the member is read or invoked. */
   requirements?: readonly import('./authorization.ts').AuthRequirement[];
+  /** Shape the result as a Relay connection, slicing arrays if needed. */
+  connection?: { defaultPageSize?: number; maxPageSize?: number };
 }
 
 export interface ResolvedArg {

--- a/packages/di-framework-graphql/tests/connections.test.ts
+++ b/packages/di-framework-graphql/tests/connections.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Relay connections: generated SDL, cursor helpers, the slicing algorithm and
+ * how `@Connection` composes with batching and bounded contexts.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { Container } from '@di-framework/core/container';
+import {
+  connectionFromArray,
+  connectionFromSlice,
+  cursorToOffset,
+  decodeCursor,
+  encodeCursor,
+  offsetToCursor,
+} from '../src/connection.ts';
+import { Arg, BoundedContext, Connection, Field, Portal, SemanticType } from '../src/decorators.ts';
+import { SemanticBoundaryError } from '../src/errors.ts';
+import { ID } from '../src/scalars.ts';
+import { buildSemanticSchema } from '../src/schema.ts';
+import { buildTypeGraph } from '../src/type-graph.ts';
+import { withRegistry } from './helpers.ts';
+
+const LETTERS = ['a', 'b', 'c', 'd', 'e'];
+
+/** Read a root field off an execution result without fighting the result types. */
+function pick(result: { data?: unknown }, name: string): any {
+  return (result.data as Record<string, any>)[name];
+}
+
+function catalogSchema(options: { defaultPageSize?: number; maxPageSize?: number } = {}) {
+  return () => {
+    @SemanticType()
+    class Review {
+      @Field(() => ID) id!: string;
+      @Field(() => String) body!: string;
+    }
+
+    @Portal()
+    class Query {
+      @Connection(() => Review, options)
+      reviews(): Review[] {
+        return LETTERS.map((letter) => Object.assign(new Review(), { id: letter, body: letter }));
+      }
+
+      @Connection(() => Review)
+      byAuthor(@Arg('author', () => String) author: string): Review[] {
+        return author === 'none'
+          ? []
+          : LETTERS.map((letter) => Object.assign(new Review(), { id: letter, body: author }));
+      }
+    }
+
+    return buildSemanticSchema({ container: new Container() });
+  };
+}
+
+describe('cursor helpers', () => {
+  it('round-trips opaque cursors', () => {
+    expect(decodeCursor(encodeCursor('abc'))).toBe('abc');
+    expect(decodeCursor(encodeCursor(42))).toBe('42');
+    // Cursors are opaque base64, not the raw value.
+    expect(encodeCursor('abc')).not.toBe('abc');
+  });
+
+  it('round-trips array offsets and rejects foreign cursors', () => {
+    expect(cursorToOffset(offsetToCursor(7))).toBe(7);
+    expect(cursorToOffset(encodeCursor('not-an-offset'))).toBe(-1);
+    expect(() => decodeCursor('!!!not base64!!!')).toThrow('Invalid cursor');
+  });
+
+  it('survives non-ASCII identifiers', () => {
+    expect(decodeCursor(encodeCursor('café-☕'))).toBe('café-☕');
+  });
+});
+
+describe('connectionFromArray', () => {
+  it('returns the whole set with no arguments', () => {
+    const result = connectionFromArray(LETTERS);
+    expect(result.edges.map((edge) => edge.node)).toEqual(LETTERS);
+    expect(result.totalCount).toBe(5);
+    expect(result.pageInfo).toMatchObject({ hasNextPage: false, hasPreviousPage: false });
+  });
+
+  it('slices with first and reports more pages', () => {
+    const result = connectionFromArray(LETTERS, { first: 2 });
+    expect(result.edges.map((edge) => edge.node)).toEqual(['a', 'b']);
+    expect(result.pageInfo.hasNextPage).toBe(true);
+    expect(result.pageInfo.hasPreviousPage).toBe(false);
+  });
+
+  it('pages forward with after', () => {
+    const page1 = connectionFromArray(LETTERS, { first: 2 });
+    const page2 = connectionFromArray(LETTERS, { first: 2, after: page1.pageInfo.endCursor });
+    expect(page2.edges.map((edge) => edge.node)).toEqual(['c', 'd']);
+    expect(page2.pageInfo.hasPreviousPage).toBe(true);
+    expect(page2.pageInfo.hasNextPage).toBe(true);
+
+    const page3 = connectionFromArray(LETTERS, { first: 2, after: page2.pageInfo.endCursor });
+    expect(page3.edges.map((edge) => edge.node)).toEqual(['e']);
+    expect(page3.pageInfo.hasNextPage).toBe(false);
+  });
+
+  it('slices from the end with last, and honours before', () => {
+    expect(connectionFromArray(LETTERS, { last: 2 }).edges.map((e) => e.node)).toEqual(['d', 'e']);
+    expect(
+      connectionFromArray(LETTERS, { before: offsetToCursor(2) }).edges.map((e) => e.node),
+    ).toEqual(['a', 'b']);
+    expect(
+      connectionFromArray(LETTERS, { before: offsetToCursor(4), last: 2 }).edges.map((e) => e.node),
+    ).toEqual(['c', 'd']);
+  });
+
+  it('reports both flags against the whole set, not the paging direction', () => {
+    // Middle slice: there is something on each side, and both flags say so —
+    // the spec would allow `hasPreviousPage: false` here when only `first` is set.
+    const middle = connectionFromArray(LETTERS, { first: 2, after: offsetToCursor(0) });
+    expect(middle.edges.map((edge) => edge.node)).toEqual(['b', 'c']);
+    expect(middle.pageInfo).toMatchObject({ hasNextPage: true, hasPreviousPage: true });
+  });
+
+  it('rejects negative page sizes', () => {
+    expect(() => connectionFromArray(LETTERS, { first: -1 })).toThrow('must not be negative');
+    expect(() => connectionFromArray(LETTERS, { last: -1 })).toThrow('must not be negative');
+  });
+
+  it('handles an empty set', () => {
+    const result = connectionFromArray([], { first: 10 });
+    expect(result.edges).toEqual([]);
+    expect(result.pageInfo).toEqual({
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: null,
+      endCursor: null,
+    });
+  });
+});
+
+describe('connectionFromSlice', () => {
+  it('builds a connection from a page the repository already cut', () => {
+    const result = connectionFromSlice(['x', 'y'], {
+      cursorFor: (node) => `id:${node}`,
+      hasNextPage: true,
+      totalCount: 99,
+    });
+    expect(result.totalCount).toBe(99);
+    expect(result.pageInfo.hasNextPage).toBe(true);
+    expect(decodeCursor(result.edges[0]!.cursor)).toBe('id:x');
+  });
+});
+
+describe('@Connection SDL', () => {
+  it('generates Relay-shaped connection, edge and PageInfo types', () => {
+    const api = withRegistry(catalogSchema());
+    expect(api.sdl).toContain('type ReviewConnection {');
+    expect(api.sdl).toContain('edges: [ReviewEdge!]!');
+    expect(api.sdl).toContain('pageInfo: PageInfo!');
+    expect(api.sdl).toContain('type ReviewEdge {');
+    expect(api.sdl).toContain('node: Review!');
+    expect(api.sdl).toContain('cursor: String!');
+    expect(api.sdl).toContain('type PageInfo {');
+    expect(api.sdl).toContain('hasNextPage: Boolean!');
+    expect(api.sdl).toContain('startCursor: String');
+  });
+
+  it('adds the four pagination arguments to the field', () => {
+    const api = withRegistry(catalogSchema());
+    const field = api.graph.query.fields.find((f) => f.name === 'reviews');
+    expect(field?.args.map((arg) => arg.name)).toEqual(['first', 'after', 'last', 'before']);
+  });
+
+  it('keeps the field’s own arguments alongside the pagination ones', () => {
+    const api = withRegistry(catalogSchema());
+    const field = api.graph.query.fields.find((f) => f.name === 'byAuthor');
+    expect(field?.args.map((arg) => arg.name)).toEqual([
+      'author',
+      'first',
+      'after',
+      'last',
+      'before',
+    ]);
+  });
+
+  it('generates PageInfo exactly once across several connections', () => {
+    const api = withRegistry(catalogSchema());
+    expect(api.graph.objects.filter((object) => object.name === 'PageInfo')).toHaveLength(1);
+    expect(api.graph.objects.filter((object) => object.name === 'ReviewEdge')).toHaveLength(1);
+  });
+});
+
+describe('@Connection execution', () => {
+  it('slices an array returned by the domain method', async () => {
+    const api = withRegistry(catalogSchema());
+    const result = await api.execute({
+      query:
+        '{ reviews(first: 2) { totalCount edges { cursor node { id } } pageInfo { hasNextPage endCursor } } }',
+    });
+    expect(result.errors).toBeUndefined();
+    const reviews = pick(result, 'reviews');
+    expect(reviews.totalCount).toBe(5);
+    expect(reviews.edges.map((edge: any) => edge.node.id)).toEqual(['a', 'b']);
+    expect(reviews.pageInfo.hasNextPage).toBe(true);
+  });
+
+  it('pages forward using the returned cursor', async () => {
+    const api = withRegistry(catalogSchema());
+    const first = await api.execute({
+      query: '{ reviews(first: 2) { pageInfo { endCursor } } }',
+    });
+    const cursor = pick(first, 'reviews').pageInfo.endCursor;
+
+    const second = await api.execute({
+      query: `{ reviews(first: 2, after: "${cursor}") { edges { node { id } } } }`,
+    });
+    expect(pick(second, 'reviews').edges.map((e: any) => e.node.id)).toEqual(['c', 'd']);
+  });
+
+  it('applies defaultPageSize when the caller asks for no page', async () => {
+    const api = withRegistry(catalogSchema({ defaultPageSize: 2 }));
+    const result = await api.execute({ query: '{ reviews { edges { node { id } } } }' });
+    expect(pick(result, 'reviews').edges).toHaveLength(2);
+  });
+
+  it('rejects a page larger than maxPageSize', async () => {
+    const api = withRegistry(catalogSchema({ maxPageSize: 3 }));
+    const result = await api.execute({ query: '{ reviews(first: 50) { totalCount } }' });
+    expect(result.errors?.[0]?.message).toContain('exceeds the maximum of 3');
+  });
+
+  it('passes through a connection the domain built itself', async () => {
+    const api = withRegistry(() => {
+      @SemanticType()
+      class Item {
+        @Field(() => ID) id!: string;
+      }
+
+      @Portal()
+      class Query {
+        // The repository pages natively, so the field returns a finished slice.
+        @Connection(() => Item)
+        items(): any {
+          return connectionFromSlice([Object.assign(new Item(), { id: 'z' })], {
+            cursorFor: (node: any) => node.id,
+            hasNextPage: true,
+            totalCount: 500,
+          });
+        }
+      }
+
+      return buildSemanticSchema({ container: new Container() });
+    });
+
+    const result = await api.execute({
+      query: '{ items(first: 1) { totalCount edges { node { id } } pageInfo { hasNextPage } } }',
+    });
+    const items = pick(result, 'items');
+    expect(items.totalCount).toBe(500);
+    expect(items.edges.map((edge: any) => edge.node.id)).toEqual(['z']);
+    expect(items.pageInfo.hasNextPage).toBe(true);
+  });
+
+  it('works on a semantic type field with batching', async () => {
+    let batches = 0;
+    const api = withRegistry(() => {
+      @SemanticType()
+      class Comment {
+        @Field(() => ID) id!: string;
+      }
+
+      @SemanticType({ key: 'id' })
+      class Post {
+        id!: string;
+
+        @Field(() => ID) title!: string;
+
+        @Connection(() => Comment, { batch: 'commentsFor' })
+        comments(): Comment[] {
+          return [];
+        }
+
+        static commentsFor(posts: Post[]): Comment[][] {
+          batches += 1;
+          return posts.map((post) => [Object.assign(new Comment(), { id: `${post.id}-c1` })]);
+        }
+      }
+
+      @Portal()
+      class Query {
+        @Field(() => [Post])
+        posts(): Post[] {
+          return ['p1', 'p2'].map((id) => Object.assign(new Post(), { id, title: id }));
+        }
+      }
+
+      return buildSemanticSchema({ container: new Container() });
+    });
+
+    const result = await api.execute({
+      query: '{ posts { title comments(first: 1) { edges { node { id } } } } }',
+      context: {},
+    });
+    expect(result.errors).toBeUndefined();
+    const posts = pick(result, 'posts') as any[];
+    expect(posts.map((post) => post.comments.edges[0].node.id)).toEqual(['p1-c1', 'p2-c1']);
+    // Both parents were coalesced into a single batch call.
+    expect(batches).toBe(1);
+  });
+});
+
+describe('@Connection and bounded contexts', () => {
+  it('rejects paginating another context’s non-boundary type', () => {
+    expect(() =>
+      withRegistry((registry) => {
+        @BoundedContext('Reviews')
+        @SemanticType()
+        class Review {
+          @Field(() => ID) id!: string;
+        }
+
+        @BoundedContext('Catalog')
+        @Portal()
+        class CatalogQuery {
+          @Connection(() => Review)
+          reviews(): Review[] {
+            return [];
+          }
+        }
+
+        return buildTypeGraph({ registry });
+      }),
+    ).toThrow(SemanticBoundaryError);
+  });
+
+  it('allows paginating a boundary type across contexts', () => {
+    const graph = withRegistry((registry) => {
+      @BoundedContext('Reviews')
+      @SemanticType({ boundary: true, key: 'id' })
+      class Review {
+        @Field(() => ID) id!: string;
+      }
+
+      @BoundedContext('Catalog')
+      @Portal()
+      class CatalogQuery {
+        @Connection(() => Review)
+        reviews(): Review[] {
+          return [];
+        }
+      }
+
+      return buildTypeGraph({ registry });
+    });
+
+    expect(graph.objects.map((object) => object.name)).toEqual(
+      expect.arrayContaining(['ReviewConnection', 'ReviewEdge', 'PageInfo']),
+    );
+  });
+});


### PR DESCRIPTION
List fields can now be cursor-paginated without hand-rolling a parallel
hierarchy of connection classes beside the entities.

- @Connection(() => Node) generates <Node>Connection, <Node>Edge and a single
  shared PageInfo, and adds first/after/last/before to the field
- a field's own arguments are kept alongside the pagination ones
- the method may return a plain array — sliced here — or a finished slice built
  with connectionFromSlice() when the repository pages natively
- cursor helpers: encodeCursor/decodeCursor, offsetToCursor/cursorToOffset;
  cursors are opaque base64 and UTF-8 safe
- defaultPageSize and maxPageSize bound what a caller can ask for
- composes with @Field({ batch }) — parents still coalesce into one call

Generated types inherit the node's bounded context and boundary flag, so
paginating a type is not a way to smuggle it across a context edge.

hasNextPage/hasPreviousPage are computed against the whole set rather than the
direction being paged. The spec permits either; this answers the question a
client actually asks.

Also drops imports left unused by the @Requires migration and in decorators.ts.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>