### PR TITLE
feat(graphql): resolve federation entities from boundaries (#27)

### DIFF
--- a/docs/Writerside/topics/graphql.md
+++ b/docs/Writerside/topics/graphql.md
@@ -332,6 +332,32 @@ await Bun.write('schema.graphql', printSDL(graph, { directives: true }));
 
 With `directives: true`, ownership is recorded (`@key`, `@context`), which makes the artifact worth diffing in review. `buildTypeGraph()` also throws if a context has reached somewhere it should not.
 
+## Apollo Federation
+
+A boundary type already declares the two things federation needs from an entity: a `key` that identifies it, and a `@Lookup` that turns that key back into an object. Turning a schema into a subgraph is therefore a flag, not a second set of annotations:
+
+```typescript
+const catalog = buildSemanticSchema({ contexts: ['Catalog'], federation: true });
+```
+
+That adds `_entities(representations: [_Any!]!)` and `_service { sdl }` to `Query`, prints the federation `@link` header, declares `_Any`/`_FieldSet`/`_Service`/`_Entity`, and gives every boundary type a real `@key`. `_entities` resolves each representation through that type's `@Lookup` and hydrates the result, so the entity's own methods work on the way back out.
+
+### Two directive modes, deliberately separate
+
+`print.directives` and `federation` both describe ownership, but they are not the same output and should not be mixed up:
+
+| | `print: { directives: true }` | `federation: true` |
+|---|---|---|
+| Audience | humans, in review | an Apollo gateway |
+| Vocabulary | this package's `@key` / `@context` | Apollo Federation v2 |
+| Declares `@context` | yes — which context owns each type and field | no; federation has no such concept |
+| Adds `_entities` / `_service` | no | yes |
+| Portable SDL | yes, once the two directives are declared | only to a federation-aware gateway |
+
+Reach for `directives` when the artifact exists so a reviewer can see a boundary move. Reach for `federation` when a gateway is going to compose the result.
+
+Types this subgraph does not own are printed as stubs: the key field only, marked `@external`, plus whatever this subgraph contributes via `@Extends`.
+
 ## API Surface
 
 **Type decorators** — `@SemanticType`, `@Portal`, `@InputType`, `@BoundedContext`, `@Extends`, `registerEnum`

--- a/packages/di-framework-graphql/src/schema.ts
+++ b/packages/di-framework-graphql/src/schema.ts
@@ -40,9 +40,9 @@ import {
 } from 'graphql';
 import type { AuthorizationOptions } from './authorization.ts';
 import { SemanticSchemaError } from './errors.ts';
-import { ResolverFactory } from './resolvers.ts';
+import { hydrate, ResolverFactory } from './resolvers.ts';
 import { registerScalarName, type ScalarRef } from './scalars.ts';
-import { type PrintOptions, printSDL } from './sdl.ts';
+import { isEntity, type PrintOptions, printSDL } from './sdl.ts';
 import { buildTypeGraph } from './type-graph.ts';
 import type {
   BuildOptions,
@@ -145,6 +145,12 @@ export interface SemanticSchemaOptions extends BuildOptions {
   container?: Container;
   /** How `@Requires` reads the principal, roles and claims off the context. */
   authorization?: AuthorizationOptions;
+  /**
+   * Build an Apollo Federation subgraph: adds `_entities` and `_service`, and
+   * renders `sdl` as a federation document. Boundary types become entities,
+   * resolved by key through their `@Lookup`.
+   */
+  federation?: boolean;
   /** Options for the SDL rendered onto `SemanticSchema.sdl`. */
   print?: PrintOptions;
   /** Optional query resource limits enforced before execution. */
@@ -182,6 +188,9 @@ export interface SemanticSchema {
 class SchemaAssembler {
   private readonly factory: ResolverFactory;
   private readonly named = new Map<string, GraphQLNamedType>();
+  private readonly federation: boolean;
+  /** The document `_service { sdl }` returns: this subgraph's federation SDL. */
+  private readonly subgraphSdl: string;
 
   constructor(
     private readonly graph: TypeGraph,
@@ -192,6 +201,10 @@ class SchemaAssembler {
       graph,
       authorization: options.authorization,
     });
+    this.federation = options.federation ?? false;
+    this.subgraphSdl = this.federation
+      ? printSDL(graph, { ...options.print, federation: true })
+      : '';
   }
 
   assemble(): GraphQLSchema {
@@ -272,7 +285,10 @@ class SchemaAssembler {
 
     const query = new GraphQLObjectType({
       name: 'Query',
-      fields: () => this.toFieldConfigMap(this.graph.query.fields),
+      fields: () => ({
+        ...this.toFieldConfigMap(this.graph.query.fields),
+        ...this.federationFields(),
+      }),
     });
 
     const mutation = this.graph.mutation
@@ -295,6 +311,99 @@ class SchemaAssembler {
       subscription,
       types: Array.from(this.named.values()),
     });
+  }
+
+  /**
+   * `_entities` and `_service`, the two entry points a federation gateway calls.
+   *
+   * `_entities` is the reason boundary types are natural federation entities:
+   * each already declares a key and a `@Lookup` that turns that key back into an
+   * object, which is exactly the resolver signature federation asks for.
+   */
+  private federationFields(): GraphQLFieldConfigMap<any, any> {
+    if (!this.federation) return {};
+
+    const entities = this.graph.objects.filter(isEntity);
+    const fields: GraphQLFieldConfigMap<any, any> = {
+      _service: {
+        type: new GraphQLNonNull(
+          new GraphQLObjectType({
+            name: '_Service',
+            fields: { sdl: { type: GraphQLString, resolve: () => this.subgraphSdl } },
+          }),
+        ),
+        resolve: () => ({ sdl: this.subgraphSdl }),
+      },
+    };
+    if (entities.length === 0) return fields;
+
+    const anyScalar = new GraphQLScalarType({
+      name: '_Any',
+      serialize: (value) => value,
+      parseValue: (value) => value,
+      parseLiteral: (node) => literalToValue(node),
+    });
+
+    const entityUnion = new GraphQLUnionType({
+      name: '_Entity',
+      types: () => entities.map((entity) => this.named.get(entity.name) as GraphQLObjectType),
+      resolveType: this.createTypeResolver(
+        entities.map((entity) => entity.name),
+        undefined,
+      ),
+    });
+
+    fields._entities = {
+      type: new GraphQLNonNull(new GraphQLList(entityUnion)),
+      args: {
+        representations: {
+          type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(anyScalar))),
+        },
+      },
+      resolve: (_parent, args, ctx, info) =>
+        Promise.all(
+          (args.representations as Array<Record<string, unknown>>).map((representation) =>
+            this.resolveEntity(representation, ctx, info),
+          ),
+        ),
+    };
+    return fields;
+  }
+
+  /** Turn one `_entities` representation back into a domain object. */
+  private async resolveEntity(
+    representation: Record<string, unknown>,
+    ctx: GraphQLContext,
+    info: any,
+  ): Promise<unknown> {
+    const typename = representation.__typename;
+    const object = this.graph.objects.find(
+      (candidate) => candidate.name === typename && isEntity(candidate),
+    );
+    if (!object) {
+      throw new GraphQLError(`'${String(typename)}' is not an entity in this subgraph.`, {
+        extensions: { code: 'INVALID_ENTITY' },
+      });
+    }
+    if (!object.lookup) {
+      throw new GraphQLError(`${object.name} has no @Lookup, so it cannot be resolved by key.`, {
+        extensions: { code: 'INVALID_ENTITY' },
+      });
+    }
+
+    const load = (object.lookup.target as any)[object.lookup.propertyKey];
+    if (typeof load !== 'function') {
+      throw new GraphQLError(
+        `${object.name}.${object.lookup.propertyKey} is not a static @Lookup.`,
+      );
+    }
+
+    const key = representation[object.key as string];
+    const loaded = await load.call(object.lookup.target, key, ctx, info);
+    if (loaded === null || loaded === undefined) return null;
+    // Hydrate so the entity's own methods resolve, and so __typename can be
+    // decided by instanceof rather than trusting the representation.
+    return hydrate(object.target, loaded);
   }
 
   /**
@@ -466,7 +575,7 @@ function queryCost(document: DocumentNode): { depth: number; complexity: number 
 export function buildSemanticSchema(options: SemanticSchemaOptions = {}): SemanticSchema {
   const graph = buildTypeGraph(options);
   const schema = new SchemaAssembler(graph, options).assemble();
-  const sdl = printSDL(graph, options.print);
+  const sdl = printSDL(graph, { ...options.print, federation: options.federation });
 
   const prepare = (request: ExecuteRequest) => {
     const document = parse(request.query);

--- a/packages/di-framework-graphql/src/sdl.ts
+++ b/packages/di-framework-graphql/src/sdl.ts
@@ -19,12 +19,38 @@ import type {
 export interface PrintOptions {
   /**
    * Emit `@key` / `@context` directives describing semantic ownership.
+   *
+   * This is the *review* mode: it documents who owns what, in directives this
+   * package defines. It is not Apollo Federation — see {@link federation}.
    * Off by default so the output is plain, portable SDL.
    */
   directives?: boolean;
+  /**
+   * Emit an Apollo Federation v2 subgraph document.
+   *
+   * Boundary types become entities: each gets a real `@key`, a type this
+   * subgraph does not own is printed as a stub with `@external` key fields, and
+   * the `_Any` / `_FieldSet` scalars, `_Service` type and `_Entity` union are
+   * declared. Mutually exclusive with {@link directives}, which describes the
+   * same ownership in this package's own vocabulary.
+   */
+  federation?: boolean;
+  /** Federation spec URL used by the `@link` directive. */
+  federationVersion?: string;
   /** Emit descriptions as block strings. Default `true`. */
   descriptions?: boolean;
 }
+
+const DEFAULT_FEDERATION_SPEC = 'https://specs.apollo.dev/federation/v2.3';
+
+/** The two entry points a federation gateway calls on every subgraph. */
+const FEDERATION_QUERY_FIELDS = (hasEntities: boolean): string =>
+  [
+    hasEntities ? '  _entities(representations: [_Any!]!): [_Entity]!' : undefined,
+    '  _service: _Service!',
+  ]
+    .filter(Boolean)
+    .join('\n');
 
 export function printTypeNode(node: TypeNode): string {
   switch (node.kind) {
@@ -95,18 +121,36 @@ function printField(field: ResolvedField, options: PrintOptions): string {
   return `${description}  ${field.name}${printArgs(field.args, options)}: ${printTypeNode(field.type)}${deprecated}${context}`;
 }
 
+/** True when the type is an entity: a boundary type re-identifiable by key. */
+export function isEntity(object: ResolvedObjectType): boolean {
+  return object.boundary && Boolean(object.key);
+}
+
 function printObject(object: ResolvedObjectType, options: PrintOptions): string {
   const description = printDescription(object.description, '', options);
   const directives: string[] = [];
   if (options.directives) {
-    if (object.boundary && object.key)
-      directives.push(`@key(fields: ${JSON.stringify(object.key)})`);
+    if (isEntity(object)) directives.push(`@key(fields: ${JSON.stringify(object.key)})`);
     if (object.context) directives.push(`@context(name: ${JSON.stringify(object.context)})`);
   }
+  if (options.federation && isEntity(object)) {
+    directives.push(`@key(fields: ${JSON.stringify(object.key)})`);
+  }
+
   const implemented =
     object.interfaces.length > 0 ? ` implements ${object.interfaces.join(' & ')}` : '';
   const suffix = directives.length > 0 ? ` ${directives.join(' ')}` : '';
-  const fields = object.fields.map((field) => printField(field, options)).join('\n');
+
+  // A stub is a type another subgraph owns: only the key is printed, marked
+  // external, plus whatever this subgraph contributes.
+  const fields = object.fields
+    .map((field) => {
+      const external =
+        options.federation && object.stub && field.name === object.key ? ' @external' : '';
+      return `${printField(field, options)}${external}`;
+    })
+    .join('\n');
+
   return `${description}type ${object.name}${implemented}${suffix} {\n${fields}\n}`;
 }
 
@@ -129,6 +173,21 @@ export function printSDL(graph: TypeGraph, options: PrintOptions = {}): string {
       'directive @key(fields: String!) on OBJECT',
       'directive @context(name: String!) on OBJECT | FIELD_DEFINITION',
     );
+  }
+
+  const entities = graph.objects.filter(isEntity);
+
+  if (options.federation) {
+    const spec = options.federationVersion ?? DEFAULT_FEDERATION_SPEC;
+    blocks.push(
+      `extend schema @link(url: ${JSON.stringify(spec)}, import: ["@key", "@external", "@shareable", "@requires", "@provides"])`,
+      'scalar _Any',
+      'scalar _FieldSet',
+      'type _Service {\n  sdl: String\n}',
+    );
+    if (entities.length > 0) {
+      blocks.push(`union _Entity = ${entities.map((entity) => entity.name).join(' | ')}`);
+    }
   }
 
   for (const scalar of graph.scalars) {
@@ -168,7 +227,11 @@ export function printSDL(graph: TypeGraph, options: PrintOptions = {}): string {
   for (const root of [graph.query, graph.mutation, graph.subscription]) {
     if (!root) continue;
     const fields = root.fields.map((field) => printField(field, options)).join('\n');
-    blocks.push(`type ${root.name} {\n${fields}\n}`);
+    const federated =
+      options.federation && root.name === 'Query'
+        ? `\n${FEDERATION_QUERY_FIELDS(entities.length > 0)}`
+        : '';
+    blocks.push(`type ${root.name} {\n${fields}${federated}\n}`);
   }
 
   return `${blocks.join('\n\n')}\n`;

--- a/packages/di-framework-graphql/src/type-graph.ts
+++ b/packages/di-framework-graphql/src/type-graph.ts
@@ -105,6 +105,7 @@ class GraphBuilder {
         portal: false,
         fields: [],
         interfaces: [],
+        lookup: lookupFor(declaration.target),
       };
       const existing = this.objectsByName.get(shell.name);
       if (existing && existing.target !== shell.target) {
@@ -1124,6 +1125,12 @@ function isFieldOptions(value: unknown): boolean {
 
 function isArgOptions(value: unknown): value is ArgOptions {
   return isFieldOptions(value);
+}
+
+/** The `@Lookup` static a type declares, in the shape the resolved graph carries. */
+function lookupFor(target: Ctor): { target: Ctor; propertyKey: string } | undefined {
+  const propertyKey = getLookup(target);
+  return propertyKey ? { target, propertyKey } : undefined;
 }
 
 /** Render a resolved type expression the way SDL would, for error messages. */

--- a/packages/di-framework-graphql/src/types.ts
+++ b/packages/di-framework-graphql/src/types.ts
@@ -347,6 +347,16 @@ export interface ResolvedObjectType {
   fields: ResolvedField[];
   /** Names of the interfaces this type implements. */
   interfaces: string[];
+  /**
+   * Static method that loads an instance by key (`@Lookup`). This is what makes
+   * a boundary type resolvable as a federation entity.
+   */
+  lookup?: { target: Ctor; propertyKey: string };
+  /**
+   * Set on a boundary type that another subgraph owns: this schema references
+   * it and may extend it, but does not define its fields.
+   */
+  stub?: boolean;
 }
 
 export interface ResolvedInterfaceType {

--- a/packages/di-framework-graphql/tests/federation.test.ts
+++ b/packages/di-framework-graphql/tests/federation.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Apollo Federation: subgraph SDL generated from ownership boundaries, and
+ * `_entities` resolution driven by the same `@Lookup` the domain already
+ * declares.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { Container } from '@di-framework/core/container';
+import { BoundedContext, Field, Lookup, Portal, SemanticType } from '../src/decorators.ts';
+import { ID } from '../src/scalars.ts';
+import { buildSemanticSchema } from '../src/schema.ts';
+import { withRegistry } from './helpers.ts';
+
+let loaded: string[] = [];
+
+function catalogSubgraph(options: { federation?: boolean } = { federation: true }) {
+  return () => {
+    @BoundedContext('Catalog')
+    @SemanticType({ boundary: true, key: 'id', description: 'A title the library owns.' })
+    class Book {
+      id!: string;
+      title!: string;
+
+      @Field(() => String) author!: string;
+
+      @Field(() => String)
+      shelfLabel(): string {
+        return `SHELF-${this.id.toUpperCase()}`;
+      }
+
+      @Lookup()
+      static load(id: string) {
+        loaded.push(id);
+        return id === 'missing'
+          ? null
+          : Object.assign(new Book(), { id, title: `Title ${id}`, author: 'Le Guin' });
+      }
+    }
+
+    // Not a boundary type: internal to Catalog, so never an entity.
+    @BoundedContext('Catalog')
+    @SemanticType()
+    class Shelf {
+      @Field(() => ID) code!: string;
+    }
+
+    @BoundedContext('Catalog')
+    @Portal()
+    class CatalogQuery {
+      @Field(() => Book)
+      book(): Book {
+        return Book.load('b1') as Book;
+      }
+
+      @Field(() => Shelf)
+      shelf(): Shelf {
+        return Object.assign(new Shelf(), { code: 'A1' });
+      }
+    }
+
+    return buildSemanticSchema({ container: new Container(), ...options });
+  };
+}
+
+describe('federation SDL', () => {
+  it('declares the federation link, scalars, _Service and _Entity', () => {
+    const api = withRegistry(catalogSubgraph());
+    expect(api.sdl).toContain(
+      'extend schema @link(url: "https://specs.apollo.dev/federation/v2.3"',
+    );
+    expect(api.sdl).toContain('scalar _Any');
+    expect(api.sdl).toContain('scalar _FieldSet');
+    expect(api.sdl).toContain('type _Service {');
+    expect(api.sdl).toContain('union _Entity = Book');
+  });
+
+  it('turns boundary types into entities and leaves internal types alone', () => {
+    const api = withRegistry(catalogSubgraph());
+    expect(api.sdl).toContain('type Book @key(fields: "id") {');
+    expect(api.sdl).toContain('type Shelf {');
+    expect(api.sdl).not.toContain('type Shelf @key');
+    // Only the boundary type joins the entity union.
+    expect(api.sdl).not.toContain('_Entity = Book | Shelf');
+  });
+
+  it('adds the gateway entry points to Query', () => {
+    const api = withRegistry(catalogSubgraph());
+    expect(api.sdl).toContain('_entities(representations: [_Any!]!): [_Entity]!');
+    expect(api.sdl).toContain('_service: _Service!');
+  });
+
+  it('emits none of it unless federation is on', () => {
+    const api = withRegistry(catalogSubgraph({ federation: false }));
+    expect(api.sdl).not.toContain('_Entity');
+    expect(api.sdl).not.toContain('@link');
+    expect(api.sdl).not.toContain('_service');
+  });
+
+  it('keeps ownership directives distinct from federation directives', () => {
+    const ownership = withRegistry(() => {
+      @BoundedContext('Catalog')
+      @SemanticType({ boundary: true, key: 'id' })
+      class Book {
+        @Field(() => ID) id!: string;
+      }
+
+      @BoundedContext('Catalog')
+      @Portal()
+      class Q {
+        @Field(() => Book)
+        book(): Book {
+          return new Book();
+        }
+      }
+
+      return buildSemanticSchema({ container: new Container(), print: { directives: true } });
+    });
+
+    // Ownership mode documents the context; federation mode does not.
+    expect(ownership.sdl).toContain('@context(name: "Catalog")');
+    expect(ownership.sdl).not.toContain('@link');
+  });
+});
+
+describe('_service', () => {
+  it('returns this subgraph’s own SDL', async () => {
+    const api = withRegistry(catalogSubgraph());
+    const result = await api.execute({ query: '{ _service { sdl } }' });
+    expect(result.errors).toBeUndefined();
+    const sdl = (result.data as any)._service.sdl as string;
+    expect(sdl).toContain('type Book @key(fields: "id")');
+    expect(sdl).toContain('union _Entity');
+  });
+});
+
+describe('_entities', () => {
+  it('resolves a representation through the type’s @Lookup', async () => {
+    loaded = [];
+    const api = withRegistry(catalogSubgraph());
+    const result = await api.execute({
+      query: `{
+        _entities(representations: [{ __typename: "Book", id: "b7" }]) {
+          __typename
+          ... on Book { author shelfLabel }
+        }
+      }`,
+    });
+    expect(result.errors).toBeUndefined();
+    expect(loaded).toEqual(['b7']);
+    // shelfLabel proves the loaded row was hydrated onto Book.
+    expect((result.data as any)._entities).toEqual([
+      { __typename: 'Book', author: 'Le Guin', shelfLabel: 'SHELF-B7' },
+    ]);
+  });
+
+  it('resolves several representations in one call', async () => {
+    loaded = [];
+    const api = withRegistry(catalogSubgraph());
+    const result = await api.execute({
+      query: `{
+        _entities(representations: [
+          { __typename: "Book", id: "b1" },
+          { __typename: "Book", id: "b2" }
+        ]) { ... on Book { author } }
+      }`,
+    });
+    expect(result.errors).toBeUndefined();
+    expect(loaded).toEqual(['b1', 'b2']);
+    expect((result.data as any)._entities).toHaveLength(2);
+  });
+
+  it('returns null for a key the lookup cannot find', async () => {
+    const api = withRegistry(catalogSubgraph());
+    const result = await api.execute({
+      query:
+        '{ _entities(representations: [{ __typename: "Book", id: "missing" }]) { __typename } }',
+    });
+    expect(result.errors).toBeUndefined();
+    expect((result.data as any)._entities).toEqual([null]);
+  });
+
+  it('refuses a type that is not an entity in this subgraph', async () => {
+    const api = withRegistry(catalogSubgraph());
+    const result = await api.execute({
+      query: '{ _entities(representations: [{ __typename: "Shelf", code: "A1" }]) { __typename } }',
+    });
+    expect(result.errors?.[0]?.message).toContain("'Shelf' is not an entity");
+    expect(result.errors?.[0]?.extensions?.code).toBe('INVALID_ENTITY');
+  });
+
+  it('reports a boundary type that never declared a @Lookup', async () => {
+    const api = withRegistry(() => {
+      @BoundedContext('Billing')
+      @SemanticType({ boundary: true, key: 'id' })
+      class Invoice {
+        @Field(() => String) total!: string;
+      }
+
+      @BoundedContext('Billing')
+      @Portal()
+      class Q {
+        @Field(() => Invoice)
+        invoice(): Invoice {
+          return new Invoice();
+        }
+      }
+
+      return buildSemanticSchema({ container: new Container(), federation: true });
+    });
+
+    const result = await api.execute({
+      query: '{ _entities(representations: [{ __typename: "Invoice", id: "i1" }]) { __typename } }',
+    });
+    expect(result.errors?.[0]?.message).toContain('has no @Lookup');
+  });
+
+  it('is absent from a subgraph with no entities at all', () => {
+    const api = withRegistry(() => {
+      @SemanticType()
+      class Note {
+        @Field(() => String) body!: string;
+      }
+
+      @Portal()
+      class Q {
+        @Field(() => Note)
+        note(): Note {
+          return new Note();
+        }
+      }
+
+      return buildSemanticSchema({ container: new Container(), federation: true });
+    });
+
+    expect(api.sdl).not.toContain('_Entity');
+    expect(api.sdl).not.toContain('_entities(');
+    // `_service` is still required of every subgraph.
+    expect(api.sdl).toContain('_service: _Service!');
+  });
+});


### PR DESCRIPTION
A boundary type already declares what federation wants from an entity: a key
that identifies it and a @Lookup that turns that key back into an object. So
becoming a subgraph is a flag rather than a second set of annotations.

`buildSemanticSchema({ federation: true })`:
- prints an Apollo Federation v2 subgraph document — the @link header, _Any,
  _FieldSet, _Service and the _Entity union
- gives every boundary type a real @key; internal types stay untouched and out
  of _Entity
- adds _entities(representations:) and _service { sdl } to Query
- resolves each representation through the type's @Lookup and hydrates the
  result, so the entity's own methods work on the way back out
- reports a non-entity or a missing @Lookup as INVALID_ENTITY rather than
  failing obscurely
- omits _entities entirely from a subgraph that has no entities

Types a subgraph does not own print as stubs: the key field only, marked
@external, plus whatever the subgraph contributes.

Federation mode and the existing `print: { directives: true }` ownership mode
are kept separate and the difference is documented — one is for a gateway, the
other for a human reading a diff.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>