### PR TITLE
feat(graphql): slice contexts into deployable subgraphs (#28)

### DIFF
--- a/docs/Writerside/topics/graphql.md
+++ b/docs/Writerside/topics/graphql.md
@@ -358,6 +358,44 @@ Reach for `directives` when the artifact exists so a reviewer can see a boundary
 
 Types this subgraph does not own are printed as stubs: the key field only, marked `@external`, plus whatever this subgraph contributes via `@Extends`.
 
+## Deployable Subgraphs
+
+`contexts: [...]` slices a schema. What makes a slice *deployable* is that it still resolves references across the seam — through boundary stubs:
+
+```typescript
+const subgraphs = buildSemanticSubgraphs({ federation: true });
+// { Catalog: SemanticSchema, Lending: SemanticSchema }
+
+Bun.serve({ port: 4001, fetch: createGraphQLHandler(subgraphs.Catalog) });
+```
+
+For SDL artifacts, `buildContextSubgraphs()` does the same on the `graphql`-free path:
+
+```typescript
+import { buildContextSubgraphs, printSDL } from '@di-framework/graphql/core';
+
+for (const [context, graph] of Object.entries(buildContextSubgraphs())) {
+  await Bun.write(`${context}.graphql`, printSDL(graph, { federation: true }));
+}
+```
+
+### What crosses the slice
+
+A context sees another context's type only if that type is a boundary type, and then only as a stub. The rules are:
+
+| | Stays inside the owning slice | Crosses as a stub |
+|---|---|---|
+| Non-boundary type | ✅ never leaves | — |
+| Boundary type's key | — | ✅ the whole contract |
+| Boundary type's other fields | ✅ owner only | ❌ |
+| `@Action` behaviour | ✅ owner only | ❌ |
+| Fields added with `@Extends` | — | ✅ they belong to the extending context |
+| Portals | ✅ owner only | ❌ |
+
+So `Book` in the Lending subgraph is `{ id, onLoan }`: the key it is identified by, plus the field Lending itself contributed. `title` and `bookReshelve` belong to Catalog and never appear. Two services independently generated from the same domain therefore agree on the shared type by construction.
+
+Stubs nothing references are pruned, so a slice does not carry types it never mentions. Set `boundaryStubs: false` to get the strict old behaviour, where a cross-context reference is a build error instead.
+
 ## API Surface
 
 **Type decorators** — `@SemanticType`, `@Portal`, `@InputType`, `@BoundedContext`, `@Extends`, `registerEnum`

--- a/packages/di-framework-graphql/core.ts
+++ b/packages/di-framework-graphql/core.ts
@@ -40,7 +40,7 @@ export {
 } from './src/metadata.ts';
 export { getRegistry, SemanticRegistry, setRegistry } from './src/registry.ts';
 export * from './src/scalars.ts';
-export { type PrintOptions, printSDL, printTypeNode } from './src/sdl.ts';
-export { buildTypeGraph, namedTypeNode } from './src/type-graph.ts';
+export { isEntity, type PrintOptions, printSDL, printTypeNode } from './src/sdl.ts';
+export { buildContextSubgraphs, buildTypeGraph, namedTypeNode } from './src/type-graph.ts';
 export type * from './src/types.ts';
 export { UnionRef } from './src/types.ts';

--- a/packages/di-framework-graphql/index.ts
+++ b/packages/di-framework-graphql/index.ts
@@ -2,6 +2,7 @@ export * from './core.ts';
 export { containerEventIterator, hydrate, ResolverFactory } from './src/resolvers.ts';
 export {
   buildSemanticSchema,
+  buildSemanticSubgraphs,
   createGraphQLHandler,
   createGraphQLSSEHandler,
   DateTimeScalar,

--- a/packages/di-framework-graphql/src/registry.ts
+++ b/packages/di-framework-graphql/src/registry.ts
@@ -6,6 +6,7 @@
  * schema, with an escape hatch (`new SemanticRegistry()`) for tests.
  */
 
+import { getBoundedContext } from './metadata.ts';
 import type {
   Ctor,
   EnumDeclaration,
@@ -94,16 +95,24 @@ export class SemanticRegistry {
     return [...this.extensions];
   }
 
-  /** Bounded contexts that have declared something. */
+  /**
+   * Bounded contexts that have declared something.
+   *
+   * `@SemanticType` records no context of its own — class decorators run
+   * bottom-up, so `@BoundedContext` may not have applied yet and the context is
+   * read from metadata instead. Both sources are consulted here.
+   */
   getContexts(): string[] {
     const names = new Set<string>();
     for (const declaration of this.types.values()) {
-      if (declaration.context) names.add(declaration.context);
+      const context = declaration.context ?? getBoundedContext(declaration.target);
+      if (context) names.add(context);
     }
     for (const extension of this.extensions) {
-      if (extension.context) names.add(extension.context);
+      const context = extension.context ?? getBoundedContext(extension.target);
+      if (context) names.add(context);
     }
-    return Array.from(names);
+    return Array.from(names).sort();
   }
 
   /** Copy every declaration into a fresh registry (prototype pattern, as the container does). */

--- a/packages/di-framework-graphql/src/schema.ts
+++ b/packages/di-framework-graphql/src/schema.ts
@@ -40,6 +40,7 @@ import {
 } from 'graphql';
 import type { AuthorizationOptions } from './authorization.ts';
 import { SemanticSchemaError } from './errors.ts';
+import { getRegistry } from './registry.ts';
 import { hydrate, ResolverFactory } from './resolvers.ts';
 import { registerScalarName, type ScalarRef } from './scalars.ts';
 import { isEntity, type PrintOptions, printSDL } from './sdl.ts';
@@ -650,6 +651,31 @@ export function buildSemanticSchema(options: SemanticSchemaOptions = {}): Semant
       return formatResult(result as ExecutionResult);
     },
   };
+}
+
+/**
+ * Build one executable schema per bounded context.
+ *
+ * Each is a deployable service: it owns its types and portals and sees the rest
+ * only through boundary stubs. Pair with `federation: true` and a gateway
+ * composes them back into one graph.
+ *
+ * @example
+ * ```ts
+ * const subgraphs = buildSemanticSubgraphs({ federation: true });
+ * Bun.serve({ fetch: createGraphQLHandler(subgraphs.Catalog) });
+ * ```
+ */
+export function buildSemanticSubgraphs(
+  options: SemanticSchemaOptions = {},
+): Record<string, SemanticSchema> {
+  const registry = options.registry ?? getRegistry();
+  const contexts = options.contexts ?? registry.getContexts();
+  const subgraphs: Record<string, SemanticSchema> = {};
+  for (const context of [...contexts].sort()) {
+    subgraphs[context] = buildSemanticSchema({ ...options, contexts: [context] });
+  }
+  return subgraphs;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/packages/di-framework-graphql/src/sdl.ts
+++ b/packages/di-framework-graphql/src/sdl.ts
@@ -69,7 +69,8 @@ function printDescription(
   options: PrintOptions,
 ): string {
   if (!description || options.descriptions === false) return '';
-  const escaped = description.replace(/"""/g, '\\"""');
+  // Escape backslashes first so a trailing `\` cannot neutralize `"""` escaping.
+  const escaped = description.replace(/\\/g, '\\\\').replace(/"""/g, '\\"""');
   if (!escaped.includes('\n')) return `${indent}"""${escaped}"""\n`;
   const body = escaped
     .split('\n')

--- a/packages/di-framework-graphql/src/type-graph.ts
+++ b/packages/di-framework-graphql/src/type-graph.ts
@@ -80,11 +80,14 @@ class GraphBuilder {
   /** Context that declared each field, keyed by `TypeName.fieldName`. */
   private readonly fieldContexts = new Map<string, string | undefined>();
 
+  private readonly boundaryStubs: boolean;
+
   constructor(options: BuildOptions) {
     this.registry = options.registry ?? getRegistry();
     this.enforceBoundaries = options.enforceBoundaries ?? true;
     this.strictTypes = options.strictTypes ?? false;
     this.contextFilter = options.contexts ? new Set(options.contexts) : undefined;
+    this.boundaryStubs = options.boundaryStubs ?? true;
   }
 
   build(): TypeGraph {
@@ -117,6 +120,33 @@ class GraphBuilder {
       this.objectsByName.set(shell.name, shell);
     }
 
+    // Pass 1b: stubs for boundary types the slice does not own, so a reference
+    // across the seam still resolves. Unreferenced stubs are pruned later.
+    if (this.contextFilter && this.boundaryStubs) {
+      for (const declaration of this.registry.getTypes()) {
+        if (declaration.portal) continue;
+        if (this.inSelectedContext(getBoundedContext(declaration.target))) continue;
+        if (!declaration.options.boundary || !declaration.options.key) continue;
+        if (this.objects.has(declaration.target)) continue;
+
+        const stub: ResolvedObjectType = {
+          name: declaration.name,
+          description: declaration.options.description,
+          target: declaration.target,
+          context: getBoundedContext(declaration.target),
+          boundary: true,
+          key: declaration.options.key,
+          portal: false,
+          fields: [],
+          interfaces: [],
+          lookup: lookupFor(declaration.target),
+          stub: true,
+        };
+        this.objects.set(declaration.target, stub);
+        this.objectsByName.set(stub.name, stub);
+      }
+    }
+
     // Pass 2: interface shells, so a type can implement an interface that
     // references it back.
     for (const declaration of this.registry.getInterfaces()) {
@@ -135,7 +165,9 @@ class GraphBuilder {
     // generated connection/edge types, which have no declarations to collect and
     // must not be revisited here.
     for (const object of Array.from(this.objects.values())) {
-      object.fields = this.resolveOwnFields(object);
+      // A stub carries only the contract: its key. Everything else about it is
+      // the owning subgraph's business.
+      object.fields = object.stub ? [this.keyField(object)] : this.resolveOwnFields(object);
     }
     for (const [target, resolved] of this.interfaces) {
       resolved.fields = this.resolveInterfaceFields(target, resolved);
@@ -182,6 +214,8 @@ class GraphBuilder {
     if (rootQuery.length === 0) {
       rootQuery.push(this.contextsField());
     }
+
+    this.pruneUnreferencedStubs([rootQuery, rootMutation, rootSubscription]);
 
     const graph: TypeGraph = {
       query: { name: 'Query', fields: rootQuery },
@@ -260,26 +294,29 @@ class GraphBuilder {
 
     // A boundary type is identified by its key, so the key is always exposed.
     if (object.key && !fields.some((field) => field.source.propertyKey === object.key)) {
-      const declaration = this.registry.getType(object.target);
-      fields.unshift(
-        this.resolveField(
-          object.target,
-          object.name,
-          {
-            propertyKey: object.key,
-            kind: 'field',
-            member: 'property',
-            options: { type: declaration?.options.keyType ?? new ScalarRef('ID') },
-            params: [],
-          },
-          'parent',
-          object.context,
-        ),
-      );
+      fields.unshift(this.keyField(object));
     }
 
     assertUniqueFieldNames(object.name, fields);
     return fields;
+  }
+
+  /** The field that exposes a type's key — the whole of a stub's contract. */
+  private keyField(object: ResolvedObjectType): ResolvedField {
+    const declaration = this.registry.getType(object.target);
+    return this.resolveField(
+      object.target,
+      object.name,
+      {
+        propertyKey: object.key as string,
+        kind: 'field',
+        member: 'property',
+        options: { type: declaration?.options.keyType ?? new ScalarRef('ID') },
+        params: [],
+      },
+      'parent',
+      object.context,
+    );
   }
 
   private resolveInterfaceFields(target: Ctor, resolved: ResolvedInterfaceType): ResolvedField[] {
@@ -644,6 +681,9 @@ class GraphBuilder {
   }
 
   private resolveEntityActions(object: ResolvedObjectType): ResolvedField[] {
+    // Behaviour on a stub belongs to the subgraph that owns the type.
+    if (object.stub) return [];
+
     const declarations = collectFieldDeclarations(object.target).filter(
       (declaration) => declaration.kind === 'action',
     );
@@ -710,6 +750,50 @@ class GraphBuilder {
         },
       };
     });
+  }
+
+  /**
+   * Drop boundary stubs nothing in the slice actually mentions.
+   *
+   * Stubs are added for every foreign boundary type up front because references
+   * are only known once fields are resolved. Reachability is a fixpoint: one
+   * stub may be reached only through a field another stub contributed.
+   */
+  private pruneUnreferencedStubs(roots: ResolvedField[][]): void {
+    const referenced = new Set<string>();
+
+    const visit = (fields: ResolvedField[]) => {
+      for (const field of fields) {
+        const named = namedTypeNode(field.type);
+        if (named.kind === 'object') referenced.add(named.name);
+        for (const arg of field.args) {
+          const argNamed = namedTypeNode(arg.type);
+          if (argNamed.kind === 'object') referenced.add(argNamed.name);
+        }
+      }
+    };
+
+    for (const root of roots) visit(root);
+    for (const object of this.objects.values()) if (!object.stub) visit(object.fields);
+    for (const resolved of this.interfaces.values()) visit(resolved.fields);
+
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const object of this.objects.values()) {
+        if (!object.stub || !referenced.has(object.name)) continue;
+        const before = referenced.size;
+        visit(object.fields);
+        if (referenced.size !== before) changed = true;
+      }
+    }
+
+    for (const [target, object] of this.objects) {
+      if (object.stub && !referenced.has(object.name)) {
+        this.objects.delete(target);
+        this.objectsByName.delete(object.name);
+      }
+    }
   }
 
   private contextsField(): ResolvedField {
@@ -1045,7 +1129,10 @@ class GraphBuilder {
 
   private collectContexts(): string[] {
     const names = new Set<string>();
-    for (const object of this.objects.values()) if (object.context) names.add(object.context);
+    // Stubs belong to a context this slice depends on, not one it represents.
+    for (const object of this.objects.values()) {
+      if (object.context && !object.stub) names.add(object.context);
+    }
     for (const declaration of this.registry.getTypes()) {
       const context = getBoundedContext(declaration.target);
       if (declaration.portal && context && this.inSelectedContext(context)) names.add(context);
@@ -1168,4 +1255,32 @@ function unwrapThunk(ref: TypeRef, registry: ReturnType<typeof getRegistry>): Ty
  */
 export function buildTypeGraph(options: BuildOptions = {}): TypeGraph {
   return new GraphBuilder(options).build();
+}
+
+/**
+ * Build one type graph per bounded context.
+ *
+ * Each slice is deployable on its own: it owns its types and portals, and sees
+ * every other context only through boundary stubs — the key, plus whatever this
+ * context contributes with `@Extends`. That stub *is* the contract between the
+ * two services, so what crosses the seam is exactly what was declared as a
+ * boundary and nothing else.
+ *
+ * @example
+ * ```ts
+ * for (const [context, graph] of Object.entries(buildContextSubgraphs())) {
+ *   await Bun.write(`${context}.graphql`, printSDL(graph, { federation: true }));
+ * }
+ * ```
+ */
+export function buildContextSubgraphs(
+  options: Omit<BuildOptions, 'contexts'> & { contexts?: string[] } = {},
+): Record<string, TypeGraph> {
+  const registry = options.registry ?? getRegistry();
+  const contexts = options.contexts ?? registry.getContexts();
+  const subgraphs: Record<string, TypeGraph> = {};
+  for (const context of [...contexts].sort()) {
+    subgraphs[context] = buildTypeGraph({ ...options, contexts: [context] });
+  }
+  return subgraphs;
 }

--- a/packages/di-framework-graphql/src/types.ts
+++ b/packages/di-framework-graphql/src/types.ts
@@ -423,6 +423,16 @@ export interface BuildOptions {
   /** Restrict the schema to these bounded contexts. Defaults to all. */
   contexts?: string[];
   /**
+   * When slicing by context, include *stubs* of boundary types owned by the
+   * contexts left out — the key field, plus anything this slice contributes
+   * through `@Extends`.
+   *
+   * This is what makes a slice deployable on its own: a reference across the
+   * seam still resolves, and the stub is exactly the shared contract the two
+   * services agree on. Defaults to `true` whenever `contexts` is set.
+   */
+  boundaryStubs?: boolean;
+  /**
    * Reject cross-context references to non-boundary types. Default `true` —
    * this is the point of the package; turn it off only while migrating.
    */

--- a/packages/di-framework-graphql/tests/subgraphs.test.ts
+++ b/packages/di-framework-graphql/tests/subgraphs.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Per-context slicing into deployable subgraphs: what each slice owns, what it
+ * sees of the others, and what is allowed to cross the seam.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { Container } from '@di-framework/core/container';
+import {
+  Action,
+  BoundedContext,
+  Extends,
+  Field,
+  Lookup,
+  Parent,
+  Portal,
+  SemanticType,
+} from '../src/decorators.ts';
+import { ID } from '../src/scalars.ts';
+import { buildSemanticSchema, buildSemanticSubgraphs } from '../src/schema.ts';
+import { printSDL } from '../src/sdl.ts';
+import { buildContextSubgraphs, buildTypeGraph } from '../src/type-graph.ts';
+import { withRegistry } from './helpers.ts';
+
+/**
+ * Two contexts sharing one boundary type:
+ *   Catalog owns Book (boundary, key `id`).
+ *   Lending owns Loan, references Book, and contributes `onLoan` to it.
+ *   Catalog also owns Shelf, which is internal and must never leave.
+ */
+function library<T>(build: () => T): T {
+  return withRegistry(() => {
+    @BoundedContext('Catalog')
+    @SemanticType({ boundary: true, key: 'id' })
+    class Book {
+      id!: string;
+
+      @Field(() => String) title!: string;
+
+      @Field(() => ID)
+      shelfCode(): string {
+        return 'A1';
+      }
+
+      @Action(() => String)
+      reshelve(): string {
+        return 'moved';
+      }
+
+      @Lookup()
+      static load(id: string) {
+        return Object.assign(new Book(), { id, title: `Title ${id}` });
+      }
+    }
+
+    @BoundedContext('Catalog')
+    @SemanticType()
+    class Shelf {
+      @Field(() => ID) code!: string;
+    }
+
+    @BoundedContext('Lending')
+    @SemanticType({ key: 'id' })
+    class Loan {
+      id!: string;
+
+      @Field(() => ID) id2!: string;
+
+      @Field(() => Book)
+      book(): Book {
+        return Book.load('b1');
+      }
+    }
+
+    @BoundedContext('Lending')
+    @Extends(() => Book)
+    class BookAvailability {
+      @Field(() => String)
+      onLoan(@Parent() book: Book): string {
+        return `${book.id} is available`;
+      }
+    }
+
+    @BoundedContext('Catalog')
+    @Portal()
+    class CatalogQuery {
+      @Field(() => Book)
+      book(): Book {
+        return Book.load('b1');
+      }
+
+      @Field(() => Shelf)
+      shelf(): Shelf {
+        return Object.assign(new Shelf(), { code: 'A1' });
+      }
+    }
+
+    @BoundedContext('Lending')
+    @Portal()
+    class LendingQuery {
+      @Field(() => Loan)
+      loan(): Loan {
+        return Object.assign(new Loan(), { id: 'l1', id2: 'l1' });
+      }
+    }
+
+    return build();
+  });
+}
+
+describe('boundary stubs', () => {
+  it('gives a slice the key of a boundary type it does not own', () => {
+    const graph = library(() => buildTypeGraph({ contexts: ['Lending'] }));
+    const book = graph.objects.find((object) => object.name === 'Book');
+    expect(book?.stub).toBe(true);
+    // The contract is the key plus what Lending itself contributes.
+    expect(book?.fields.map((field) => field.name).sort()).toEqual(['id', 'onLoan']);
+  });
+
+  it('never leaks the owning context’s internal fields or behaviour', () => {
+    const graph = library(() => buildTypeGraph({ contexts: ['Lending'] }));
+    const sdl = printSDL(graph);
+    expect(sdl).not.toContain('title');
+    expect(sdl).not.toContain('shelfCode');
+    // Behaviour on a stub belongs to the subgraph that owns the type.
+    expect(sdl).not.toContain('bookReshelve');
+    // A type that is not a boundary never appears at all.
+    expect(sdl).not.toContain('type Shelf');
+  });
+
+  it('keeps the owning slice complete', () => {
+    const graph = library(() => buildTypeGraph({ contexts: ['Catalog'] }));
+    const book = graph.objects.find((object) => object.name === 'Book');
+    expect(book?.stub).toBeUndefined();
+    expect(book?.fields.map((field) => field.name).sort()).toEqual(['id', 'shelfCode', 'title']);
+    // Catalog owns the behaviour, so it exposes the mutation.
+    expect(graph.mutation?.fields.map((field) => field.name)).toEqual(['bookReshelve']);
+    // Lending's contribution stays in Lending.
+    expect(book?.fields.some((field) => field.name === 'onLoan')).toBe(false);
+  });
+
+  it('reports only the contexts a slice represents, not the ones it depends on', () => {
+    const graph = library(() => buildTypeGraph({ contexts: ['Lending'] }));
+    expect(graph.contexts).toEqual(['Lending']);
+  });
+
+  it('prunes stubs nothing in the slice references', () => {
+    const graph = withRegistry((registry) => {
+      @BoundedContext('Unused')
+      @SemanticType({ boundary: true, key: 'id' })
+      class Orphan {
+        @Field(() => ID) id!: string;
+      }
+
+      @BoundedContext('Main')
+      @SemanticType()
+      class Thing {
+        @Field(() => ID) id!: string;
+      }
+
+      @BoundedContext('Main')
+      @Portal()
+      class MainQuery {
+        @Field(() => Thing)
+        thing(): Thing {
+          return new Thing();
+        }
+      }
+
+      return buildTypeGraph({ registry, contexts: ['Main'] });
+    });
+
+    expect(graph.objects.map((object) => object.name)).toEqual(['Thing']);
+  });
+
+  it('can be turned off, which puts the cross-context reference back out of reach', () => {
+    expect(() =>
+      library(() => buildTypeGraph({ contexts: ['Lending'], boundaryStubs: false })),
+    ).toThrow(/outside the selected bounded contexts/);
+  });
+
+  it('builds the whole graph unchanged when no slice is requested', () => {
+    const graph = library(() => buildTypeGraph());
+    const book = graph.objects.find((object) => object.name === 'Book');
+    expect(book?.stub).toBeUndefined();
+    expect(book?.fields.map((field) => field.name).sort()).toEqual([
+      'id',
+      'onLoan',
+      'shelfCode',
+      'title',
+    ]);
+    expect(graph.contexts).toEqual(['Catalog', 'Lending']);
+  });
+});
+
+describe('buildContextSubgraphs', () => {
+  it('emits one graph per context', () => {
+    const subgraphs = library(() => buildContextSubgraphs());
+    expect(Object.keys(subgraphs)).toEqual(['Catalog', 'Lending']);
+    expect(subgraphs.Catalog?.query.fields.map((f) => f.name)).toEqual(['book', 'shelf']);
+    expect(subgraphs.Lending?.query.fields.map((f) => f.name)).toEqual(['loan']);
+  });
+
+  it('agrees with the others on the shared boundary type', () => {
+    const subgraphs = library(() => buildContextSubgraphs());
+    const owned = subgraphs.Catalog?.objects.find((object) => object.name === 'Book');
+    const stub = subgraphs.Lending?.objects.find((object) => object.name === 'Book');
+    // Same name, same key: that is the whole contract between the two services.
+    expect(stub?.key).toBe(owned?.key as string);
+    expect(stub?.boundary).toBe(true);
+  });
+});
+
+describe('subgraphs as SDL artifacts and executable schemas', () => {
+  it('prints a federation subgraph per context, with foreign keys marked external', () => {
+    const subgraphs = library(() => buildContextSubgraphs());
+    const lending = printSDL(subgraphs.Lending!, { federation: true });
+
+    expect(lending).toContain('type Book @key(fields: "id")');
+    // Book is owned elsewhere, so Lending declares its key as external.
+    expect(lending).toContain('id: ID! @external');
+    expect(lending).toContain('onLoan: String!');
+    expect(lending).toContain('union _Entity = Book');
+
+    const catalog = printSDL(subgraphs.Catalog!, { federation: true });
+    expect(catalog).toContain('type Book @key(fields: "id")');
+    // Catalog owns Book, so its key is a real field, not an external reference.
+    expect(catalog).toContain('id: ID!\n');
+    expect(catalog).not.toContain('@external\n');
+  });
+
+  it('executes each subgraph independently', async () => {
+    const subgraphs = library(() =>
+      buildSemanticSubgraphs({ container: new Container(), federation: true }),
+    );
+
+    const catalog = await subgraphs.Catalog!.execute({ query: '{ book { id title } }' });
+    expect(catalog.errors).toBeUndefined();
+    expect(catalog.data?.book).toEqual({ id: 'b1', title: 'Title b1' });
+
+    const lending = await subgraphs.Lending!.execute({ query: '{ loan { book { id onLoan } } }' });
+    expect(lending.errors).toBeUndefined();
+    expect((lending.data as any).loan.book).toEqual({ id: 'b1', onLoan: 'b1 is available' });
+
+    // The stub does not expose the owning context's fields.
+    const leak = await subgraphs.Lending!.execute({ query: '{ loan { book { title } } }' });
+    expect(leak.errors?.[0]?.message).toContain('Cannot query field "title"');
+  });
+
+  it('resolves the shared entity by key from the owning subgraph', async () => {
+    const subgraphs = library(() =>
+      buildSemanticSubgraphs({ container: new Container(), federation: true }),
+    );
+    const result = await subgraphs.Catalog!.execute({
+      query:
+        '{ _entities(representations: [{ __typename: "Book", id: "b9" }]) { ... on Book { title } } }',
+    });
+    expect(result.errors).toBeUndefined();
+    expect((result.data as any)._entities).toEqual([{ title: 'Title b9' }]);
+  });
+
+  it('slices the same way whether one context or several are selected', () => {
+    const both = library(() => buildSemanticSchema({ container: new Container() }));
+    expect(both.contexts).toEqual(['Catalog', 'Lending']);
+    expect(both.graph.objects.some((object) => object.stub)).toBe(false);
+  });
+});


### PR DESCRIPTION
`contexts: [...]` already sliced a schema; what it could not do was produce a
slice that stands on its own, because a reference across the seam had nowhere
to land. Boundary stubs close that.

- a slice now includes stubs of boundary types owned by the contexts left out:
  the key, plus whatever this context contributes through @Extends
- everything else stays home — the owner's other fields, its @Action behaviour,
  its portals, and any type that is not a boundary type
- stubs nothing references are pruned, so a slice carries no dead types
- buildContextSubgraphs() / buildSemanticSubgraphs() emit one graph or one
  executable schema per context
- pairs with federation: a foreign key prints @external, and the gateway
  composes the slices back into one graph

The stub is the contract: two services generated from the same domain agree on
the shared type by construction. `boundaryStubs: false` restores the strict
behaviour where a cross-context reference is a build error.

Also fixes SemanticRegistry.getContexts(), which read a `context` field that
@SemanticType never sets and so returned nothing; it now reads the same
@BoundedContext metadata the builder does.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>