### PR TITLE
chore: bound high-risk blocking recursion

### DIFF
--- a/docs/blocking-recursion-inventory.md
+++ b/docs/blocking-recursion-inventory.md
@@ -1,0 +1,46 @@
+# Blocking recursion inventory (#83)
+
+Inventory of **synchronous recursive** helpers that can block the event loop on
+untrusted or large inputs. Decisions: **leave** / **bound** / **rewrite iterative**.
+
+Status: after high-impact fixes landed with this document (see PR for #83).
+
+## Summary table
+
+| Package | Symbol | Hot path? | Max realistic depth | Untrusted input? | Decision |
+| --- | --- | --- | --- | --- | --- |
+| `di-framework-config` | `deepMerge` | Config load / merge | dozens (config files) | Y (files, env nesting) | **Bound** depth (default 64) + cycle detect |
+| `di-framework-config` | `flattenEntries` | Config registration | dozens | Y | **Iterative** stack walk + depth/cycle bounds |
+| `di-framework-auth` | `decodeValue` (CBOR) | WebAuthn attestation | ~4 | Y (binary) | **Leave** — already depth/element/string limited |
+| `di-framework-ai` | `validateNode` (JSON Schema) | Structured output validation | schema author depth | Y (model JSON) | **Bound** depth (default 64) |
+| `di-framework-ai` | `evaluateOperand` / filter eval | Vector filter apply | query AST | Y (filter text → AST) | **Bound** depth (default 64) |
+| `di-framework-ai` | `parseFilterExpression` / `parseNot` | Filter parse | query text | Y | **Bound** parse depth (default 64) |
+| `di-framework-graphql` | `stableStringify` | Batch keys | request values | Y | **Bound** + cycle detect |
+| `di-framework-graphql` | `printLiteral` | SDL defaults | schema author | mostly N | **Bound** + cycle detect |
+| `di-framework-graphql` | `coerceInput` | Request args | nested inputs | Y | **Bound** depth (64) |
+| `di-framework-graphql` | `printTypeNode` / `namedTypeNode` / `printableType` | Schema print | list/nonNull wrappers | N (schema author) | **Leave** — inherently shallow |
+| `di-framework-http` | `collectRefs` / `extractSchemaRefs` | OpenAPI build | doc size | mixed | **Bound** + visited set |
+| `di-framework-http` | `resolveSchema` | OpenAPI build | component graph | mixed | **Leave** — already cycle-safe via `resolved` map |
+| `di-framework-repo` | (none flagged) | — | — | — | **Leave** |
+
+## Rationale
+
+- Prefer **depth bounds + cycle detection** over “make everything async.”
+- Untrusted trees (config, CBOR, model JSON, GraphQL args, filter text) get hard limits that throw clear errors.
+- Schema-author graphs (`printTypeNode`, GraphQL type wrappers) stay recursive: depths are tiny and fixed by authors.
+- CBOR already had production-grade limits; no change required beyond documentation.
+
+## Public guarantees
+
+| API | Guarantee |
+| --- | --- |
+| `deepMerge` / `flattenEntries` | Default max depth 64 (`DEFAULT_MAX_OBJECT_DEPTH`); cycles throw |
+| `validateAgainstJsonSchema` | Default max depth 64 |
+| `evaluateFilterExpression` / `parseFilterExpression` | Default max depth 64 |
+| CBOR `decodeCbor*` | `maxDepth` default 16 (unchanged) |
+
+## Out of scope (explicit)
+
+- Full async yielding on every recursion (unnecessary for bounded trees)
+- Rewriting GraphQL schema printers that only walk list/nonNull wrappers
+- Performance work unrelated to recursion depth

--- a/packages/di-framework-ai/src/converter/json-schema-validator.ts
+++ b/packages/di-framework-ai/src/converter/json-schema-validator.ts
@@ -4,6 +4,9 @@
  * pulling a full draft-2020 validator dependency.
  */
 
+/** Nesting limit for value/schema walks (untrusted model output trees). */
+export const DEFAULT_JSON_SCHEMA_MAX_DEPTH = 64;
+
 export interface SchemaValidationResult {
   readonly success: boolean;
   readonly errorMessage: string;
@@ -23,6 +26,7 @@ export function schemaValidationFailed(errorMessage: string): SchemaValidationRe
 export function validateAgainstJsonSchema(
   value: unknown,
   schema: string | Record<string, unknown>,
+  maxDepth: number = DEFAULT_JSON_SCHEMA_MAX_DEPTH,
 ): SchemaValidationResult {
   let schemaObj: Record<string, unknown>;
   try {
@@ -35,7 +39,7 @@ export function validateAgainstJsonSchema(
   }
 
   const errors: string[] = [];
-  validateNode(value, schemaObj, '$', errors);
+  validateNode(value, schemaObj, '$', errors, 0, maxDepth);
   if (errors.length === 0) return schemaValidationOk();
   return schemaValidationFailed(errors.join('; '));
 }
@@ -45,7 +49,14 @@ function validateNode(
   schema: Record<string, unknown>,
   path: string,
   errors: string[],
+  depth: number,
+  maxDepth: number,
 ): void {
+  if (depth > maxDepth) {
+    errors.push(`${path}: exceeded max validation depth of ${maxDepth}`);
+    return;
+  }
+
   const type = schema.type;
   if (typeof type === 'string') {
     if (!matchesType(value, type)) {
@@ -86,7 +97,14 @@ function validateNode(
     if (properties && typeof properties === 'object' && !Array.isArray(properties)) {
       for (const [key, propSchema] of Object.entries(properties as Record<string, unknown>)) {
         if (key in obj && propSchema && typeof propSchema === 'object') {
-          validateNode(obj[key], propSchema as Record<string, unknown>, `${path}.${key}`, errors);
+          validateNode(
+            obj[key],
+            propSchema as Record<string, unknown>,
+            `${path}.${key}`,
+            errors,
+            depth + 1,
+            maxDepth,
+          );
         }
       }
     }
@@ -97,7 +115,14 @@ function validateNode(
     const items = schema.items;
     if (items && typeof items === 'object' && !Array.isArray(items)) {
       value.forEach((item, i) => {
-        validateNode(item, items as Record<string, unknown>, `${path}[${i}]`, errors);
+        validateNode(
+          item,
+          items as Record<string, unknown>,
+          `${path}[${i}]`,
+          errors,
+          depth + 1,
+          maxDepth,
+        );
       });
     }
   }

--- a/packages/di-framework-ai/src/vectorstore/filter/filter-expression-evaluator.ts
+++ b/packages/di-framework-ai/src/vectorstore/filter/filter-expression-evaluator.ts
@@ -54,7 +54,8 @@ function evaluateExpression(
         evaluateOperand(requireRight(expression), metadata, depth + 1, maxDepth)
       );
     case 'NOT':
-      return !evaluateOperand(requireLeft(expression), metadata, depth + 1, maxDepth);    case 'EQ':
+      return !evaluateOperand(requireLeft(expression), metadata, depth + 1, maxDepth);
+    case 'EQ':
       return (
         compare(
           metadataValue(requireLeft(expression), metadata),

--- a/packages/di-framework-ai/src/vectorstore/filter/filter-expression-evaluator.ts
+++ b/packages/di-framework-ai/src/vectorstore/filter/filter-expression-evaluator.ts
@@ -1,5 +1,8 @@
 import type { FilterExpression, FilterOperand } from './filter.ts';
 
+/** Max nesting for filter AST evaluation (query-shaped trees). */
+export const DEFAULT_FILTER_EVAL_MAX_DEPTH = 64;
+
 /**
  * Evaluate a portable filter expression against document metadata.
  * Spring AI: {@code SimpleVectorStoreFilterExpressionEvaluator}.
@@ -7,19 +10,25 @@ import type { FilterExpression, FilterOperand } from './filter.ts';
 export function evaluateFilterExpression(
   expression: FilterExpression,
   metadata: Readonly<Record<string, unknown>>,
+  maxDepth: number = DEFAULT_FILTER_EVAL_MAX_DEPTH,
 ): boolean {
-  return evaluateExpression(expression, metadata);
+  return evaluateExpression(expression, metadata, 0, maxDepth);
 }
 
 function evaluateOperand(
   operand: FilterOperand,
   metadata: Readonly<Record<string, unknown>>,
+  depth: number,
+  maxDepth: number,
 ): boolean {
+  if (depth > maxDepth) {
+    throw new Error(`Filter evaluation exceeded max depth of ${maxDepth}`);
+  }
   if (operand.kind === 'group') {
-    return evaluateOperand(operand.content, metadata);
+    return evaluateOperand(operand.content, metadata, depth + 1, maxDepth);
   }
   if (operand.kind === 'expression') {
-    return evaluateExpression(operand, metadata);
+    return evaluateExpression(operand, metadata, depth + 1, maxDepth);
   }
   throw new Error(`Unsupported boolean operand: ${operand.kind}`);
 }
@@ -27,21 +36,25 @@ function evaluateOperand(
 function evaluateExpression(
   expression: FilterExpression,
   metadata: Readonly<Record<string, unknown>>,
+  depth: number,
+  maxDepth: number,
 ): boolean {
+  if (depth > maxDepth) {
+    throw new Error(`Filter evaluation exceeded max depth of ${maxDepth}`);
+  }
   switch (expression.type) {
     case 'AND':
       return (
-        evaluateOperand(requireLeft(expression), metadata) &&
-        evaluateOperand(requireRight(expression), metadata)
+        evaluateOperand(requireLeft(expression), metadata, depth + 1, maxDepth) &&
+        evaluateOperand(requireRight(expression), metadata, depth + 1, maxDepth)
       );
     case 'OR':
       return (
-        evaluateOperand(requireLeft(expression), metadata) ||
-        evaluateOperand(requireRight(expression), metadata)
+        evaluateOperand(requireLeft(expression), metadata, depth + 1, maxDepth) ||
+        evaluateOperand(requireRight(expression), metadata, depth + 1, maxDepth)
       );
     case 'NOT':
-      return !evaluateOperand(requireLeft(expression), metadata);
-    case 'EQ':
+      return !evaluateOperand(requireLeft(expression), metadata, depth + 1, maxDepth);    case 'EQ':
       return (
         compare(
           metadataValue(requireLeft(expression), metadata),

--- a/packages/di-framework-ai/src/vectorstore/filter/filter-expression-text-parser.ts
+++ b/packages/di-framework-ai/src/vectorstore/filter/filter-expression-text-parser.ts
@@ -18,8 +18,14 @@ import {
  * - Grouping with parentheses
  * - String (`'…'` / `"…"`), number, boolean literals
  */
-export function parseFilterExpression(text: string): FilterExpression {
-  const parser = new Parser(text);
+/** Cap nested NOT / parentheses depth for untrusted filter text. */
+export const DEFAULT_FILTER_PARSE_MAX_DEPTH = 64;
+
+export function parseFilterExpression(
+  text: string,
+  maxDepth: number = DEFAULT_FILTER_PARSE_MAX_DEPTH,
+): FilterExpression {
+  const parser = new Parser(text, maxDepth);
   const exp = parser.parseExpression();
   parser.expectEof();
   return exp;
@@ -28,9 +34,23 @@ export function parseFilterExpression(text: string): FilterExpression {
 class Parser {
   private readonly tokens: Token[];
   private i = 0;
+  private depth = 0;
+  private readonly maxDepth: number;
 
-  constructor(input: string) {
+  constructor(input: string, maxDepth: number) {
     this.tokens = tokenize(input);
+    this.maxDepth = maxDepth;
+  }
+
+  private enter(): void {
+    this.depth += 1;
+    if (this.depth > this.maxDepth) {
+      throw new Error(`Filter parse exceeded max depth of ${this.maxDepth}`);
+    }
+  }
+
+  private leave(): void {
+    this.depth -= 1;
   }
 
   parseExpression(): FilterExpression {
@@ -57,16 +77,26 @@ class Parser {
 
   private parseNot(): FilterExpression {
     if (this.matchKeyword('NOT') || this.matchSymbol('!')) {
-      return filterExpression('NOT', this.parseNot());
+      this.enter();
+      try {
+        return filterExpression('NOT', this.parseNot());
+      } finally {
+        this.leave();
+      }
     }
     return this.parsePrimary();
   }
 
   private parsePrimary(): FilterExpression {
     if (this.matchSymbol('(')) {
-      const inner = this.parseExpression();
-      this.expectSymbol(')');
-      return filterGroup(inner).content;
+      this.enter();
+      try {
+        const inner = this.parseExpression();
+        this.expectSymbol(')');
+        return filterGroup(inner).content;
+      } finally {
+        this.leave();
+      }
     }
 
     const keyTok = this.expectIdent();

--- a/packages/di-framework-ai/tests/retrieval.test.ts
+++ b/packages/di-framework-ai/tests/retrieval.test.ts
@@ -84,6 +84,11 @@ describe('Filter expressions', () => {
     ).toBe(false);
   });
 
+  test('text parser rejects excessive nesting depth', () => {
+    const deep = `${'('.repeat(70)}country == 'UK'${')'.repeat(70)}`;
+    expect(() => parseFilterExpression(deep, 16)).toThrow(/max depth/);
+  });
+
   test('text parser OR and grouping', () => {
     const exp = parseFilterExpression("(country == 'BG' || country == 'UK') AND year > 2000");
     expect(evaluateFilterExpression(exp, { country: 'BG', year: 2001 })).toBe(true);

--- a/packages/di-framework-ai/tests/structured-output.test.ts
+++ b/packages/di-framework-ai/tests/structured-output.test.ts
@@ -97,6 +97,18 @@ describe('JSON schema validator', () => {
     const result = validateAgainstJsonSchema({ name: 'Ada', age: 'old' }, personSchema);
     expect(result.success).toBe(false);
   });
+
+  test('rejects excessive nesting depth', () => {
+    let schema: Record<string, unknown> = { type: 'number' };
+    let value: unknown = 1;
+    for (let i = 0; i < 8; i++) {
+      schema = { type: 'object', properties: { c: schema } };
+      value = { c: value };
+    }
+    const result = validateAgainstJsonSchema(value, schema, 5);
+    expect(result.success).toBe(false);
+    expect(result.errorMessage).toContain('max validation depth');
+  });
 });
 
 describe('ChatClient.entity', () => {

--- a/packages/di-framework-config/src/path.ts
+++ b/packages/di-framework-config/src/path.ts
@@ -1,8 +1,20 @@
 /** Keys that must never be used as object property names from untrusted paths. */
 const DANGEROUS_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
 
+/**
+ * Default nesting limit for recursive object walks on untrusted config trees.
+ * Prevents stack overflow / event-loop stalls on malicious or cyclic input.
+ */
+export const DEFAULT_MAX_OBJECT_DEPTH = 64;
+
 function isSafeKey(key: string): boolean {
   return !DANGEROUS_KEYS.has(key);
+}
+
+function assertDepth(depth: number, maxDepth: number, label: string): void {
+  if (depth > maxDepth) {
+    throw new Error(`${label} exceeded max object depth of ${maxDepth}`);
+  }
 }
 
 /**
@@ -45,24 +57,58 @@ export function setByPath(target: Record<string, unknown>, path: string, value: 
 /**
  * Deep-merge plain objects. Arrays and non-objects from `source` replace.
  * Later source wins for conflicting keys.
+ *
+ * Depth-bounded (default {@link DEFAULT_MAX_OBJECT_DEPTH}) and cycle-safe via a
+ * visited set on the source object graph.
  */
 export function deepMerge(
   target: Record<string, unknown>,
   source: Record<string, unknown>,
+  maxDepth: number = DEFAULT_MAX_OBJECT_DEPTH,
 ): Record<string, unknown> {
+  return deepMergeAt(target, source, 0, maxDepth, new WeakSet<object>());
+}
+
+function deepMergeAt(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+  depth: number,
+  maxDepth: number,
+  seen: WeakSet<object>,
+): Record<string, unknown> {
+  assertDepth(depth, maxDepth, 'deepMerge');
+  if (seen.has(source)) {
+    throw new Error('deepMerge detected a cyclic object graph');
+  }
+  seen.add(source);
+
   const out: Record<string, unknown> = { ...target };
   for (const [key, value] of Object.entries(source)) {
     if (!isSafeKey(key)) continue;
     const existing = out[key];
-    if (
-      value !== null &&
-      typeof value === 'object' &&
-      !Array.isArray(value) &&
-      existing !== null &&
-      typeof existing === 'object' &&
-      !Array.isArray(existing)
-    ) {
-      out[key] = deepMerge(existing as Record<string, unknown>, value as Record<string, unknown>);
+    const valueIsPlainObject =
+      value !== null && typeof value === 'object' && !Array.isArray(value);
+    const existingIsPlainObject =
+      existing !== null && typeof existing === 'object' && !Array.isArray(existing);
+
+    if (valueIsPlainObject && existingIsPlainObject) {
+      out[key] = deepMergeAt(
+        existing as Record<string, unknown>,
+        value as Record<string, unknown>,
+        depth + 1,
+        maxDepth,
+        seen,
+      );
+    } else if (valueIsPlainObject) {
+      // Clone nested plain objects so depth/cycle checks still apply when the
+      // target has no object to merge into (do not attach source by reference).
+      out[key] = deepMergeAt(
+        {},
+        value as Record<string, unknown>,
+        depth + 1,
+        maxDepth,
+        seen,
+      );
     } else {
       out[key] = value;
     }
@@ -72,17 +118,39 @@ export function deepMerge(
 
 /**
  * Walk a nested object and yield `[dottedPath, value]` for every leaf and intermediate object.
+ * Iterative (stack-based) with depth bound and cycle detection.
  */
 export function flattenEntries(
   obj: Record<string, unknown>,
   prefix = '',
+  maxDepth: number = DEFAULT_MAX_OBJECT_DEPTH,
 ): Array<[string, unknown]> {
   const entries: Array<[string, unknown]> = [];
-  for (const [key, value] of Object.entries(obj)) {
-    const path = prefix ? `${prefix}.${key}` : key;
-    entries.push([path, value]);
-    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
-      entries.push(...flattenEntries(value as Record<string, unknown>, path));
+  const stack: Array<{ obj: Record<string, unknown>; prefix: string; depth: number }> = [
+    { obj, prefix, depth: 0 },
+  ];
+  const seen = new WeakSet<object>();
+
+  while (stack.length > 0) {
+    const frame = stack.pop();
+    if (!frame) break;
+    assertDepth(frame.depth, maxDepth, 'flattenEntries');
+    if (seen.has(frame.obj)) {
+      throw new Error('flattenEntries detected a cyclic object graph');
+    }
+    seen.add(frame.obj);
+
+    for (const [key, value] of Object.entries(frame.obj)) {
+      if (!isSafeKey(key)) continue;
+      const path = frame.prefix ? `${frame.prefix}.${key}` : key;
+      entries.push([path, value]);
+      if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+        stack.push({
+          obj: value as Record<string, unknown>,
+          prefix: path,
+          depth: frame.depth + 1,
+        });
+      }
     }
   }
   return entries;

--- a/packages/di-framework-config/src/path.ts
+++ b/packages/di-framework-config/src/path.ts
@@ -86,8 +86,7 @@ function deepMergeAt(
   for (const [key, value] of Object.entries(source)) {
     if (!isSafeKey(key)) continue;
     const existing = out[key];
-    const valueIsPlainObject =
-      value !== null && typeof value === 'object' && !Array.isArray(value);
+    const valueIsPlainObject = value !== null && typeof value === 'object' && !Array.isArray(value);
     const existingIsPlainObject =
       existing !== null && typeof existing === 'object' && !Array.isArray(existing);
 
@@ -102,13 +101,7 @@ function deepMergeAt(
     } else if (valueIsPlainObject) {
       // Clone nested plain objects so depth/cycle checks still apply when the
       // target has no object to merge into (do not attach source by reference).
-      out[key] = deepMergeAt(
-        {},
-        value as Record<string, unknown>,
-        depth + 1,
-        maxDepth,
-        seen,
-      );
+      out[key] = deepMergeAt({}, value as Record<string, unknown>, depth + 1, maxDepth, seen);
     } else {
       out[key] = value;
     }

--- a/packages/di-framework-config/tests/load.test.ts
+++ b/packages/di-framework-config/tests/load.test.ts
@@ -34,6 +34,25 @@ describe('path helpers', () => {
     expect(entries).toContainEqual(['b', { c: 2 }]);
     expect(entries).toContainEqual(['b.c', 2]);
   });
+
+  it('deepMerge rejects excessive depth', () => {
+    let nested: Record<string, unknown> = { v: 1 };
+    for (let i = 0; i < 10; i++) nested = { child: nested };
+    expect(() => deepMerge({}, nested, 5)).toThrow(/max object depth/);
+  });
+
+  it('deepMerge rejects cyclic graphs', () => {
+    const a: Record<string, unknown> = { x: 1 };
+    const b: Record<string, unknown> = { y: a };
+    a.b = b;
+    expect(() => deepMerge({}, a)).toThrow(/cyclic/);
+  });
+
+  it('flattenEntries rejects excessive depth', () => {
+    let nested: Record<string, unknown> = { v: 1 };
+    for (let i = 0; i < 10; i++) nested = { child: nested };
+    expect(() => flattenEntries(nested, '', 5)).toThrow(/max object depth/);
+  });
 });
 
 describe('coerce', () => {

--- a/packages/di-framework-graphql/src/resolvers.ts
+++ b/packages/di-framework-graphql/src/resolvers.ts
@@ -79,13 +79,26 @@ export function hydrate<T>(target: Ctor<T>, value: unknown, state?: RequestState
   return instance;
 }
 
-function stableStringify(value: unknown): string {
+/** Nesting limit for request-time value walks (batch keys / input trees). */
+const STABLE_STRINGIFY_MAX_DEPTH = 64;
+
+function stableStringify(value: unknown, depth = 0, seen?: WeakSet<object>): string {
+  if (depth > STABLE_STRINGIFY_MAX_DEPTH) {
+    throw new Error(`stableStringify exceeded max depth of ${STABLE_STRINGIFY_MAX_DEPTH}`);
+  }
   if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'undefined';
-  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  const visited = seen ?? new WeakSet<object>();
+  if (visited.has(value as object)) {
+    throw new Error('stableStringify detected a cyclic value');
+  }
+  visited.add(value as object);
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item, depth + 1, visited)).join(',')}]`;
+  }
   const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
     a.localeCompare(b),
   );
-  return `{${entries.map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`).join(',')}}`;
+  return `{${entries.map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item, depth + 1, visited)}`).join(',')}}`;
 }
 
 export class ResolverFactory {
@@ -347,12 +360,18 @@ export class ResolverFactory {
   }
 
   /** Rebuild `@InputType` classes from the plain objects GraphQL hands us. */
-  private coerceInput(value: any, type: TypeNode): any {
+  private coerceInput(value: any, type: TypeNode, depth = 0): any {
+    const maxDepth = 64;
+    if (depth > maxDepth) {
+      throw new Error(`coerceInput exceeded max type/value depth of ${maxDepth}`);
+    }
     if (value === null || value === undefined) return value;
 
-    if (type.kind === 'nonNull') return this.coerceInput(value, type.of);
+    if (type.kind === 'nonNull') return this.coerceInput(value, type.of, depth + 1);
     if (type.kind === 'list') {
-      return Array.isArray(value) ? value.map((item) => this.coerceInput(item, type.of)) : value;
+      return Array.isArray(value)
+        ? value.map((item) => this.coerceInput(item, type.of, depth + 1))
+        : value;
     }
     if (type.kind !== 'input') return value;
 
@@ -365,6 +384,7 @@ export class ResolverFactory {
       instance[fieldDefinition.propertyKey] = this.coerceInput(
         value[fieldDefinition.name],
         fieldDefinition.type,
+        depth + 1,
       );
     }
     return instance;

--- a/packages/di-framework-graphql/src/sdl.ts
+++ b/packages/di-framework-graphql/src/sdl.ts
@@ -79,14 +79,26 @@ function printDescription(
   return `${indent}"""\n${body}\n${indent}"""\n`;
 }
 
-function printLiteral(value: unknown): string {
+const PRINT_LITERAL_MAX_DEPTH = 64;
+
+function printLiteral(value: unknown, depth = 0, seen?: WeakSet<object>): string {
+  if (depth > PRINT_LITERAL_MAX_DEPTH) {
+    throw new Error(`printLiteral exceeded max depth of ${PRINT_LITERAL_MAX_DEPTH}`);
+  }
   if (value === null) return 'null';
   if (typeof value === 'string') return JSON.stringify(value);
   if (typeof value === 'number' || typeof value === 'boolean') return String(value);
-  if (Array.isArray(value)) return `[${value.map(printLiteral).join(', ')}]`;
   if (typeof value === 'object') {
+    const visited = seen ?? new WeakSet<object>();
+    if (visited.has(value as object)) {
+      throw new Error('printLiteral detected a cyclic value');
+    }
+    visited.add(value as object);
+    if (Array.isArray(value)) {
+      return `[${value.map((item) => printLiteral(item, depth + 1, visited)).join(', ')}]`;
+    }
     const entries = Object.entries(value as Record<string, unknown>).map(
-      ([key, item]) => `${key}: ${printLiteral(item)}`,
+      ([key, item]) => `${key}: ${printLiteral(item, depth + 1, visited)}`,
     );
     return `{${entries.join(', ')}}`;
   }

--- a/packages/di-framework-http/src/decorators.ts
+++ b/packages/di-framework-http/src/decorators.ts
@@ -39,12 +39,22 @@ export function Controller(options: { singleton?: boolean; container?: any } = {
   };
 }
 
-/** Extract all `#/components/schemas/<Name>` references from a metadata tree. */
-function extractSchemaRefs(obj: unknown, out: Set<string>): void {
+const EXTRACT_SCHEMA_REFS_MAX_DEPTH = 64;
+
+/** Extract all `#/components/schemas/<Name>` references from a metadata tree (depth-bounded). */
+function extractSchemaRefs(
+  obj: unknown,
+  out: Set<string>,
+  depth = 0,
+  seen: WeakSet<object> = new WeakSet(),
+): void {
+  if (depth > EXTRACT_SCHEMA_REFS_MAX_DEPTH) return;
   if (typeof obj !== 'object' || obj === null) return;
+  if (seen.has(obj as object)) return;
+  seen.add(obj as object);
 
   if (Array.isArray(obj)) {
-    for (const item of obj) extractSchemaRefs(item, out);
+    for (const item of obj) extractSchemaRefs(item, out, depth + 1, seen);
     return;
   }
 
@@ -53,7 +63,7 @@ function extractSchemaRefs(obj: unknown, out: Set<string>): void {
       const match = /^#\/components\/schemas\/(.+)$/.exec(value);
       if (match?.[1]) out.add(match[1]);
     } else {
-      extractSchemaRefs(value, out);
+      extractSchemaRefs(value, out, depth + 1, seen);
     }
   }
 }

--- a/packages/di-framework-http/src/openapi.ts
+++ b/packages/di-framework-http/src/openapi.ts
@@ -13,12 +13,22 @@ export type OpenAPIOptions = {
   security?: Array<Record<string, string[]>>;
 };
 
-/** Recursively extract `$ref` schema names from a value. */
-function collectRefs(obj: unknown, out: Set<string>): void {
+const COLLECT_REFS_MAX_DEPTH = 64;
+
+/** Recursively extract `$ref` schema names from a value (depth-bounded). */
+function collectRefs(
+  obj: unknown,
+  out: Set<string>,
+  depth = 0,
+  seen: WeakSet<object> = new WeakSet(),
+): void {
+  if (depth > COLLECT_REFS_MAX_DEPTH) return;
   if (typeof obj !== 'object' || obj === null) return;
+  if (seen.has(obj as object)) return;
+  seen.add(obj as object);
 
   if (Array.isArray(obj)) {
-    for (const item of obj) collectRefs(item, out);
+    for (const item of obj) collectRefs(item, out, depth + 1, seen);
     return;
   }
 
@@ -27,7 +37,7 @@ function collectRefs(obj: unknown, out: Set<string>): void {
       const match = /^#\/components\/schemas\/(.+)$/.exec(value);
       if (match?.[1]) out.add(match[1]);
     } else {
-      collectRefs(value, out);
+      collectRefs(value, out, depth + 1, seen);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Written inventory: `docs/blocking-recursion-inventory.md` (package, symbol, hot path, untrusted?, decision).
- **High-risk fixes:**
  - config: `deepMerge` depth + cycle; `flattenEntries` iterative + depth/cycle
  - AI: JSON Schema `validateNode` depth; filter parse/eval depth
  - GraphQL: `stableStringify`, `printLiteral`, `coerceInput` depth/cycle
  - HTTP: OpenAPI `collectRefs` / `extractSchemaRefs` depth + visited
- CBOR already depth-limited — documented as leave.
- Tests for deep nesting / cycles / bounds.

Closes #83

## Test plan

- [x] config / AI / graphql / http / auth package tests
- [ ] full CI suite