### PR TITLE
chore: static/free-function convention

### DIFF
--- a/docs/static-methods-convention.md
+++ b/docs/static-methods-convention.md
@@ -1,0 +1,38 @@
+# Static / free-function convention (#85)
+
+Prefer **static methods or free functions for pure work**; keep **instance methods** for stateful services, fluent builders, and domain behavior.
+
+This is **not** “make everything static” and **not** a static service locator.
+
+## When to use what
+
+| Prefer | For |
+| --- | --- |
+| `static of(...)` / `static create(...)` / `static builder(...)` | Alternate constructors and factories (AI style) |
+| Free functions | Pure helpers with no type ownership (`deepMerge`, `throwIfAborted`, `printTypeNode`, `chainWorkflow`) |
+| **Static** `@Lookup` | GraphQL entity loaders (required by the schema builder) |
+| Instance methods | DI-managed services, repositories, fluent builders with mutable state, GraphQL `@Field` / `@Action`, anything that needs `this` |
+
+## Examples already in tree
+
+- AI: `ChatAgent.create` / `fromBuilder`, `ChatResponse.of`, `Prompt.of`, `SimpleVectorStore.of` / `builder`, `GraphWorkflow.builder` / `of`, `PlannerExecutorWorkflow.of`, `A2ABus.create`
+- GraphQL: static `@Lookup` only; instance `@Field` / `@Action`
+- Config / utils: free functions for pure path/merge helpers
+
+## Anti-patterns
+
+- Moving container resolves into statics (“service locator”)
+- Making domain `@Field` methods static
+- Codemodding the whole monorepo without a clear win
+- Breaking public APIs for style only (use free-function aliases or `static of` alongside constructors)
+
+## Audit note (AI / GraphQL / config / repo)
+
+| Area | Finding |
+| --- | --- |
+| `di-framework-ai` | Factories largely follow `static of` / free functions. Fixed workflows historically used only constructors + free-function factories; aligned with `static of` where missing. Converters hold instance schema state — correctly instance. |
+| `di-framework-graphql` | Static `@Lookup` enforced; field resolvers instance. No high-confidence pure instance helpers to convert. |
+| `di-framework-config` | Pure helpers already free functions (`deepMerge`, `flattenEntries`, …). Source `load()` methods are intentionally instance (closure over options). |
+| `di-framework-repo` | Adapter/repository methods are stateful (connection, entity metadata) — leave instance. |
+
+**High-confidence conversions in the companion PR:** add `static of` on fixed AI workflows that already had free-function factories, for consistency with `ChatAgent` / `GraphWorkflow` / `PlannerExecutorWorkflow`.

--- a/packages/di-framework-ai/README.md
+++ b/packages/di-framework-ai/README.md
@@ -2,6 +2,8 @@
 
 Spring AI–aligned chat, tools, RAG, MCP, and agents for TypeScript. Portable model abstractions sit on top of OpenAI-compatible and Anthropic HTTP adapters (no vendor SDKs). Wire everything into `@di-framework/core` with annotations (`@AiService`, `@Agent`, `@Tool`, …) or `configureAi`.
 
+**Style:** prefer `static of` / `static builder` factories and free functions for pure helpers; keep instance methods for stateful clients and fluent builders. See [docs/static-methods-convention.md](../../docs/static-methods-convention.md).
+
 ## Features
 
 - **Annotation DX**: `@AiService` / `@Agent` assistants, `@Tool` / `@ToolSet` beans, `@WithMemory` / `@WithRag` / `@WithTools`, workflows (`@Chain`, `@Route`, …).

--- a/packages/di-framework-ai/src/agent/chain-workflow.ts
+++ b/packages/di-framework-ai/src/agent/chain-workflow.ts
@@ -38,6 +38,11 @@ export class ChainWorkflow {
     this.systemPrompts = systemPrompts;
   }
 
+  /** Factory alias (same as {@link chainWorkflow}). */
+  static of(chatClient: ChatClient, systemPrompts: readonly string[]): ChainWorkflow {
+    return new ChainWorkflow(chatClient, systemPrompts);
+  }
+
   /** Run the chain; return only the final string. */
   async chain(userInput: string, options?: WorkflowCallOptions): Promise<string> {
     const detailed = await this.chainDetailed(userInput, options);
@@ -72,5 +77,5 @@ export function chainWorkflow(
   chatClient: ChatClient,
   systemPrompts: readonly string[],
 ): ChainWorkflow {
-  return new ChainWorkflow(chatClient, systemPrompts);
+  return ChainWorkflow.of(chatClient, systemPrompts);
 }

--- a/packages/di-framework-ai/src/agent/evaluator-optimizer-workflow.ts
+++ b/packages/di-framework-ai/src/agent/evaluator-optimizer-workflow.ts
@@ -58,6 +58,11 @@ export class EvaluatorOptimizerWorkflow {
     this.chatClient = chatClient;
   }
 
+  /** Factory alias (same as {@link evaluatorOptimizerWorkflow}). */
+  static of(chatClient: ChatClient): EvaluatorOptimizerWorkflow {
+    return new EvaluatorOptimizerWorkflow(chatClient);
+  }
+
   async loop(task: string, options?: EvaluatorOptimizerWorkflowOptions): Promise<RefinedResponse> {
     const maxIterations = Math.max(1, options?.maxIterations ?? 5);
     const chainOfThought: GenerationRecord[] = [];
@@ -123,5 +128,5 @@ export class EvaluatorOptimizerWorkflow {
 }
 
 export function evaluatorOptimizerWorkflow(chatClient: ChatClient): EvaluatorOptimizerWorkflow {
-  return new EvaluatorOptimizerWorkflow(chatClient);
+  return EvaluatorOptimizerWorkflow.of(chatClient);
 }

--- a/packages/di-framework-ai/src/agent/orchestrator-workers-workflow.ts
+++ b/packages/di-framework-ai/src/agent/orchestrator-workers-workflow.ts
@@ -86,6 +86,11 @@ export class OrchestratorWorkersWorkflow {
     this.chatClient = chatClient;
   }
 
+  /** Factory alias (same as {@link orchestratorWorkersWorkflow}). */
+  static of(chatClient: ChatClient): OrchestratorWorkersWorkflow {
+    return new OrchestratorWorkersWorkflow(chatClient);
+  }
+
   async process(
     taskDescription: string,
     options?: OrchestratorWorkersWorkflowOptions,
@@ -163,5 +168,5 @@ export class OrchestratorWorkersWorkflow {
 }
 
 export function orchestratorWorkersWorkflow(chatClient: ChatClient): OrchestratorWorkersWorkflow {
-  return new OrchestratorWorkersWorkflow(chatClient);
+  return OrchestratorWorkersWorkflow.of(chatClient);
 }

--- a/packages/di-framework-ai/src/agent/parallelization-workflow.ts
+++ b/packages/di-framework-ai/src/agent/parallelization-workflow.ts
@@ -30,6 +30,11 @@ export class ParallelizationWorkflow {
     this.chatClient = chatClient;
   }
 
+  /** Factory alias (same as {@link parallelizationWorkflow}). */
+  static of(chatClient: ChatClient): ParallelizationWorkflow {
+    return new ParallelizationWorkflow(chatClient);
+  }
+
   async parallel(
     systemPrompt: string,
     inputs: readonly string[],
@@ -53,5 +58,5 @@ export class ParallelizationWorkflow {
 }
 
 export function parallelizationWorkflow(chatClient: ChatClient): ParallelizationWorkflow {
-  return new ParallelizationWorkflow(chatClient);
+  return ParallelizationWorkflow.of(chatClient);
 }

--- a/packages/di-framework-ai/src/agent/routing-workflow.ts
+++ b/packages/di-framework-ai/src/agent/routing-workflow.ts
@@ -62,6 +62,11 @@ export class RoutingWorkflow {
     this.chatClient = chatClient;
   }
 
+  /** Factory alias (same as {@link routingWorkflow}). */
+  static of(chatClient: ChatClient): RoutingWorkflow {
+    return new RoutingWorkflow(chatClient);
+  }
+
   async route(input: string, routes: RouteMap, options?: RoutingWorkflowOptions): Promise<string> {
     const detailed = await this.routeDetailed(input, routes, options);
     return detailed.result;
@@ -148,5 +153,5 @@ async function invokeRoute(
 }
 
 export function routingWorkflow(chatClient: ChatClient): RoutingWorkflow {
-  return new RoutingWorkflow(chatClient);
+  return RoutingWorkflow.of(chatClient);
 }

--- a/packages/di-framework-ai/tests/agent.test.ts
+++ b/packages/di-framework-ai/tests/agent.test.ts
@@ -66,6 +66,13 @@ describe('ChainWorkflow', () => {
       /at least one/,
     );
   });
+
+  test('static of matches constructor factory', async () => {
+    const model = new ScriptedChatModel([{ respond: 'ok' }]);
+    const client = ChatClient.create(model);
+    const viaOf = ChainWorkflow.of(client, ['step']);
+    expect(await viaOf.chain('in')).toBe('ok');
+  });
 });
 
 class ConcurrentFakeModel {

--- a/packages/di-framework-graphql/README.md
+++ b/packages/di-framework-graphql/README.md
@@ -4,6 +4,8 @@ Radically object-oriented, decorator-driven GraphQL for [di-framework](https://g
 
 Your domain classes **are** the schema. There is no SDL document to keep in sync, no resolver map, and no field-by-field mapping layer — decorators declare semantic *exposure* (`@Field`, `@Action`), *ownership* (`@BoundedContext`) and *boundaries* (`@SemanticType({ boundary: true })`), and the schema falls out of that.
 
+**Style:** `@Lookup` loaders must be **static**; `@Field` / `@Action` stay **instance** methods on domain objects. Pure schema helpers may be free functions. See [docs/static-methods-convention.md](../../docs/static-methods-convention.md).
+
 ## Features
 
 - **Objects, not resolvers**: behaviour lives on the class that owns the invariant. `@Action` on an entity becomes a root mutation that loads the entity first, so the rule cannot be routed around.


### PR DESCRIPTION
## Summary

- Document convention: `docs/static-methods-convention.md` (+ short pointers in AI and GraphQL READMEs).
- Audit note for AI / GraphQL / config / repo.
- High-confidence cleanup: `static of` on fixed AI workflows (`Chain`, `Routing`, `Parallelization`, `OrchestratorWorkers`, `EvaluatorOptimizer`), free functions delegate to it.

Closes #85

## Test plan

- [x] agent tests (including `ChainWorkflow.of`)
- [ ] full CI