### PR TITLE
dom crypto type facade for socket

### DIFF
--- a/packages/di-framework-socket/src/security/webcrypto.ts
+++ b/packages/di-framework-socket/src/security/webcrypto.ts
@@ -23,6 +23,34 @@ export interface Algorithm {
 
 export type AlgorithmIdentifier = string | Algorithm;
 
+/** Mirrors the DOM lib's `BufferSource`, which `lib: ["ESNext"]` does not supply. */
+export type BufferSource = ArrayBufferView | ArrayBuffer;
+
+/**
+ * Mirrors the DOM lib's `JsonWebKey` (RFC 7517), which `lib: ["ESNext"]` does not
+ * supply. Structurally compatible, so a consumer whose tsconfig includes `DOM`
+ * can pass its own `JsonWebKey` here.
+ */
+export interface JsonWebKey {
+  alg?: string;
+  crv?: string;
+  d?: string;
+  dp?: string;
+  dq?: string;
+  e?: string;
+  ext?: boolean;
+  k?: string;
+  key_ops?: string[];
+  kty?: string;
+  n?: string;
+  p?: string;
+  q?: string;
+  qi?: string;
+  use?: string;
+  x?: string;
+  y?: string;
+}
+
 export interface SubtleLike {
   digest(algorithm: AlgorithmIdentifier, data: BufferSource): Promise<ArrayBuffer>;
   importKey(


### PR DESCRIPTION
This pull request adds TypeScript type definitions to improve compatibility with cryptographic APIs in environments without the DOM library. The main changes are the introduction of `BufferSource` and `JsonWebKey` types, which mirror their DOM lib counterparts, allowing the code to work in environments targeting only ESNext.

### Type definitions for Web Crypto compatibility:

* Added a `BufferSource` type alias (`ArrayBufferView | ArrayBuffer`) to mirror the DOM library's definition, ensuring cryptographic functions can accept the correct data types even when the DOM types are unavailable.
* Introduced a `JsonWebKey` interface that structurally matches the DOM library's definition (RFC 7517), allowing seamless use of JWKs in environments without the DOM lib and compatibility with consumers who include the DOM types.