### PR TITLE
feat(auth): OAuth2/OIDC authorization-server support

### DIFF
--- a/packages/di-framework-auth/docs/oauth-server.md
+++ b/packages/di-framework-auth/docs/oauth-server.md
@@ -1,0 +1,60 @@
+# OAuth 2.0 / OpenID Connect Authorization Server — Threat Model & Specifications
+
+## Overview
+
+`@di-framework/auth/server` provides OAuth 2.0 (RFC 6749) and OpenID Connect Core 1.0 Authorization Server capabilities. It enforces modern security defaults, including mandatory Proof Key for Code Exchange (PKCE, RFC 7636) for authorization code flows and exact URI redirect matching.
+
+---
+
+## 1. Supported Standards & Specifications
+
+| Standard | Description | Enforcement |
+| :--- | :--- | :--- |
+| **RFC 6749** | The OAuth 2.0 Authorization Framework | Authorization code flow supported. Implicit and Resource Owner Password Credentials grants are explicitly excluded. |
+| **RFC 7636** | PKCE (Proof Key for Code Exchange) | Mandatory for all authorization code requests. Supports `S256` (SHA-256) and `plain` methods. |
+| **OpenID Connect Core 1.0** | ID Tokens & UserInfo Endpoint | Issues signed ID Tokens (`RS256`, `ES256`) containing `iss`, `sub`, `aud`, `exp`, `iat`, `auth_time`, `nonce`, and `at_hash`. |
+| **OpenID Connect Discovery 1.0** | Provider Metadata | Exposes metadata at `/.well-known/openid-configuration`. |
+| **RFC 7517 / RFC 7519** | JWK Sets & JWT | Exposes active public keys at `/.well-known/jwks.json`. Signed bearer tokens. |
+| **RFC 7009** | OAuth 2.0 Token Revocation | Supports revoking refresh tokens at `/oauth/revoke`. |
+| **RFC 8414** | Authorization Server Metadata | Discovery format compliant with OAuth 2.0 AS Metadata. |
+
+---
+
+## 2. Threat Model & Countermeasures
+
+### 2.1 Authorization Code Interception (RFC 7636 / PKCE)
+* **Threat**: An attacker intercepts an authorization code sent via redirect and attempts to exchange it for access/ID tokens.
+* **Countermeasure**: PKCE is **strictly required** for all authorization code requests. The server verifies `code_verifier` against `code_challenge` during `/oauth/token`. Without a valid `code_verifier`, token exchange fails closed.
+
+### 2.2 Redirect URI Manipulation & Open Redirectors
+* **Threat**: An attacker passes a modified or wildcard `redirect_uri` to leak authorization codes to an attacker-controlled endpoint.
+* **Countermeasure**: Strict **exact string matching** against pre-registered client redirect URIs (`ClientStore`). No partial matches, subdomains, path traversal, or wildcard matches are allowed. If the URI fails exact match, request fails closed immediately with `invalid_request`.
+
+### 2.3 Replay of Authorization Codes
+* **Threat**: An attacker captures a valid authorization code and attempts to exchange it multiple times.
+* **Countermeasure**: Codes are strictly single-use. `AuthCodeStore.consumeCode()` atomically invalidates the code upon first retrieval. If a code is presented a second time, the server rejects token issuance with `invalid_grant`.
+
+### 2.4 CSRF & Clickjacking on Authorization Endpoint
+* **Threat**: Cross-Site Request Forgery or iframe embedding of authorization UI.
+* **Countermeasure**:
+  - The `state` parameter is validated and returned transparently to client.
+  - HTTP responses include `X-Frame-Options: DENY` and `Content-Security-Policy: frame-ancestors 'none'`.
+  - Cache controls (`Cache-Control: no-store`, `Pragma: no-cache`) prevent caching of sensitive token or authorization responses.
+
+### 2.5 Token Leakage & Scope Escalation
+* **Threat**: A client requests scopes beyond its pre-registered permissions or accesses resources without policy evaluation.
+* **Countermeasure**:
+  - Requested scopes are validated against `client.allowedScopes`. Attempts to request unapproved scopes fail closed (`invalid_scope`).
+  - Integration with `AuthorizationManager` / `@di-framework/authz` ensures user consent and grant decisions align with application resource policies.
+
+### 2.6 Key Compromise & Rotation
+* **Threat**: Exposure of a signing key allows forged JWTs.
+* **Countermeasure**: `KeyService` provides non-disruptive key rotation with overlap windows. Multiple public keys can be advertised in JWKS while retired keys are safely phased out after expiration windows.
+
+---
+
+## 3. Excluded Legacy Features
+
+To maintain a zero-vulnerability baseline:
+- **Implicit Grant (`response_type=token`)**: Omitted per RFC 9700 (OAuth 2.0 Security Best Current Practice).
+- **Resource Owner Password Credentials (`grant_type=password`)**: Omitted per RFC 9700 due to high credential-leakage risk.

--- a/packages/di-framework-auth/package.json
+++ b/packages/di-framework-auth/package.json
@@ -36,6 +36,11 @@
       "bun": "./repo.ts",
       "import": "./dist/repo.js",
       "default": "./dist/repo.js"
+    },
+    "./server": {
+      "bun": "./server.ts",
+      "import": "./dist/server.js",
+      "default": "./dist/server.js"
     }
   },
   "author": "@di-framework Contributors",
@@ -74,10 +79,11 @@
     "http.ts",
     "graphql.ts",
     "repo.ts",
+    "server.ts",
     "src"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build ./index.ts ./webauthn.ts ./oauth.ts ./http.ts ./graphql.ts ./repo.ts --outdir ./dist --target node --external @di-framework/core --external @di-framework/http --external @di-framework/graphql --external @di-framework/repo --external graphql --external itty-router && tsc --emitDeclarationOnly --declaration --outDir dist",
+    "build": "rm -rf dist && bun build ./index.ts ./webauthn.ts ./oauth.ts ./http.ts ./graphql.ts ./repo.ts ./server.ts --outdir ./dist --target node --external @di-framework/core --external @di-framework/http --external @di-framework/graphql --external @di-framework/repo --external graphql --external itty-router && tsc --emitDeclarationOnly --declaration --outDir dist",
     "prepublishOnly": "bun run build",
     "test": "bun test"
   },

--- a/packages/di-framework-auth/server.ts
+++ b/packages/di-framework-auth/server.ts
@@ -1,0 +1,1 @@
+export * from './src/oauth/server/index.ts';

--- a/packages/di-framework-auth/src/oauth/server/http.ts
+++ b/packages/di-framework-auth/src/oauth/server/http.ts
@@ -1,0 +1,190 @@
+import { AuthError } from '../../errors.ts';
+import type { AuthorizationServer } from './server.ts';
+
+export interface OAuthHttpHandlerOptions {
+  server: AuthorizationServer;
+  subjectResolver?: (request: Request) => Promise<string | undefined>;
+  userinfoClaimsResolver?: (subject: string) => Promise<Record<string, unknown>>;
+}
+
+const COMMON_SECURITY_HEADERS = {
+  'Cache-Control': 'no-store',
+  Pragma: 'no-cache',
+  'X-Frame-Options': 'DENY',
+  'Content-Type': 'application/json',
+};
+
+export async function handleOAuthServerRequest(
+  request: Request,
+  options: OAuthHttpHandlerOptions,
+): Promise<Response | null> {
+  const url = new URL(request.url);
+  const path = url.pathname;
+  const method = request.method.toUpperCase();
+  const { server, subjectResolver, userinfoClaimsResolver } = options;
+
+  try {
+    // 1. Discovery Endpoint: GET /.well-known/openid-configuration
+    if (method === 'GET' && path === '/.well-known/openid-configuration') {
+      return new Response(JSON.stringify(server.discovery()), {
+        status: 200,
+        headers: COMMON_SECURITY_HEADERS,
+      });
+    }
+
+    // 2. JWKS Endpoint: GET /.well-known/jwks.json
+    if (method === 'GET' && path === '/.well-known/jwks.json') {
+      const jwks = await server.jwks();
+      return new Response(JSON.stringify(jwks), {
+        status: 200,
+        headers: COMMON_SECURITY_HEADERS,
+      });
+    }
+
+    // 3. Authorization Endpoint: GET or POST /oauth/authorize
+    if ((method === 'GET' || method === 'POST') && path === '/oauth/authorize') {
+      const params =
+        method === 'GET' ? url.searchParams : new URLSearchParams(await request.text());
+
+      const subjectId = subjectResolver ? await subjectResolver(request) : undefined;
+      const result = await server.authorize(
+        {
+          responseType: params.get('response_type') ?? '',
+          clientId: params.get('client_id') ?? '',
+          redirectUri: params.get('redirect_uri') ?? '',
+          scope: params.get('scope') ?? undefined,
+          state: params.get('state') ?? undefined,
+          codeChallenge: params.get('code_challenge') ?? undefined,
+          codeChallengeMethod:
+            (params.get('code_challenge_method') as 'S256' | 'plain') ?? undefined,
+          nonce: params.get('nonce') ?? undefined,
+        },
+        subjectId,
+      );
+
+      if (result.type === 'redirect') {
+        const redirectUrl = new URL(result.redirectUri);
+        redirectUrl.searchParams.set('code', result.code);
+        if (result.state) redirectUrl.searchParams.set('state', result.state);
+        return Response.redirect(redirectUrl.toString(), 302);
+      }
+
+      if (result.type === 'login_required') {
+        return new Response(
+          JSON.stringify({
+            error: 'login_required',
+            error_description: 'Authentication is required',
+            state: result.state,
+          }),
+          { status: 401, headers: COMMON_SECURITY_HEADERS },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          error: 'consent_required',
+          error_description: 'User consent is required',
+          client_id: result.client.clientId,
+          scopes: result.scopes,
+          state: result.state,
+        }),
+        { status: 200, headers: COMMON_SECURITY_HEADERS },
+      );
+    }
+
+    // 4. Token Endpoint: POST /oauth/token
+    if (method === 'POST' && path === '/oauth/token') {
+      const bodyText = await request.text();
+      let body: Record<string, string> = {};
+      try {
+        if (request.headers.get('content-type')?.includes('application/json')) {
+          body = JSON.parse(bodyText);
+        } else {
+          const params = new URLSearchParams(bodyText);
+          body = Object.fromEntries(params.entries());
+        }
+      } catch {
+        throw new AuthError('Invalid request body', { status: 400, code: 'invalid_request' });
+      }
+
+      // Check Basic auth header for confidential clients
+      const authHeader = request.headers.get('authorization');
+      let clientId = body['client_id'];
+      let clientSecret = body['client_secret'];
+
+      if (authHeader && authHeader.startsWith('Basic ')) {
+        const decoded = atob(authHeader.slice(6));
+        const [id, secret] = decoded.split(':');
+        if (id) clientId = id;
+        if (secret) clientSecret = secret;
+      }
+
+      const grant = await server.token({
+        grantType: body['grant_type'] ?? '',
+        code: body['code'],
+        codeVerifier: body['code_verifier'],
+        redirectUri: body['redirect_uri'],
+        clientId,
+        clientSecret,
+        refreshToken: body['refresh_token'],
+        scope: body['scope'],
+      });
+
+      return new Response(JSON.stringify(grant), {
+        status: 200,
+        headers: COMMON_SECURITY_HEADERS,
+      });
+    }
+
+    // 5. Revocation Endpoint: POST /oauth/revoke
+    if (method === 'POST' && path === '/oauth/revoke') {
+      const bodyText = await request.text();
+      const params = new URLSearchParams(bodyText);
+      const token = params.get('token');
+      if (token) {
+        await server.revoke(token);
+      }
+      return new Response(null, { status: 200, headers: COMMON_SECURITY_HEADERS });
+    }
+
+    // 6. UserInfo Endpoint: GET or POST /oauth/userinfo or /userinfo
+    if (
+      (method === 'GET' || method === 'POST') &&
+      (path === '/oauth/userinfo' || path === '/userinfo')
+    ) {
+      const authHeader = request.headers.get('authorization');
+      if (!authHeader || !authHeader.startsWith('Bearer ')) {
+        return new Response(
+          JSON.stringify({ error: 'invalid_token', error_description: 'Missing Bearer token' }),
+          { status: 401, headers: COMMON_SECURITY_HEADERS },
+        );
+      }
+      const token = authHeader.slice(7);
+      const userinfo = await server.userinfo(token, userinfoClaimsResolver);
+      return new Response(JSON.stringify(userinfo), {
+        status: 200,
+        headers: COMMON_SECURITY_HEADERS,
+      });
+    }
+
+    return null;
+  } catch (error) {
+    if (error instanceof AuthError) {
+      const status = error.status || 400;
+      return new Response(
+        JSON.stringify({
+          error: error.code || 'invalid_request',
+          error_description: error.message,
+        }),
+        { status, headers: COMMON_SECURITY_HEADERS },
+      );
+    }
+    return new Response(
+      JSON.stringify({
+        error: 'server_error',
+        error_description: 'An internal server error occurred',
+      }),
+      { status: 500, headers: COMMON_SECURITY_HEADERS },
+    );
+  }
+}

--- a/packages/di-framework-auth/src/oauth/server/index.ts
+++ b/packages/di-framework-auth/src/oauth/server/index.ts
@@ -1,0 +1,4 @@
+export * from './http.ts';
+export * from './server.ts';
+export * from './stores.ts';
+export * from './types.ts';

--- a/packages/di-framework-auth/src/oauth/server/server.ts
+++ b/packages/di-framework-auth/src/oauth/server/server.ts
@@ -1,0 +1,479 @@
+import { AuthError } from '../../errors.ts';
+import type { SignatureAlgorithm } from '../../tokens/algorithms.ts';
+import { signJwt, verifyJwt } from '../../tokens/jwt.ts';
+import { computeS256Challenge, isValidCodeVerifier } from '../pkce.ts';
+import { InMemoryAuthCodeStore, InMemoryConsentStore, InMemoryOAuthTokenStore } from './stores.ts';
+import type {
+  AuthCodeStore,
+  AuthorizationRequest,
+  AuthorizationResult,
+  ClientStore,
+  ConsentStore,
+  OAuthAuthorizationCode,
+  OAuthAuthorizationServerOptions,
+  OAuthClientConfig,
+  OAuthConsent,
+  OAuthRefreshTokenRecord,
+  OAuthTokenGrant,
+  OAuthTokenStore,
+  OpenIDDiscoveryDocument,
+  TokenRequest,
+} from './types.ts';
+
+export class AuthorizationServer {
+  private issuer: string;
+  private keyService;
+  private clientStore: ClientStore;
+  private authCodeStore: AuthCodeStore;
+  private consentStore: ConsentStore;
+  private tokenStore: OAuthTokenStore;
+  private authorizationManager;
+  private accessTokenLifetimeSeconds: number;
+  private refreshTokenLifetimeSeconds: number;
+  private codeLifetimeSeconds: number;
+  private now: () => number;
+
+  constructor(options: OAuthAuthorizationServerOptions) {
+    this.issuer = options.issuer;
+    this.keyService = options.keyService;
+    this.clientStore = options.clientStore;
+    this.authCodeStore = options.authCodeStore;
+    this.consentStore = options.consentStore ?? new InMemoryConsentStore();
+    this.tokenStore = options.tokenStore ?? new InMemoryOAuthTokenStore();
+    this.authorizationManager = options.authorizationManager;
+    this.accessTokenLifetimeSeconds = options.accessTokenLifetimeSeconds ?? 3600;
+    this.refreshTokenLifetimeSeconds = options.refreshTokenLifetimeSeconds ?? 2592000; // 30 days
+    this.codeLifetimeSeconds = options.codeLifetimeSeconds ?? 600;
+    this.now = options.now ?? (() => Math.floor(Date.now() / 1000));
+  }
+
+  /**
+   * Handle an OAuth 2.0 Authorization Request (RFC 6749 §4.1.1).
+   */
+  async authorize(
+    request: AuthorizationRequest,
+    currentSubjectId?: string,
+  ): Promise<AuthorizationResult> {
+    if (request.responseType !== 'code') {
+      throw new AuthError(
+        `Unsupported response_type '${request.responseType}'. Only 'code' is supported.`,
+        { status: 400, code: 'unsupported_response_type' },
+      );
+    }
+
+    const client = await this.clientStore.getClient(request.clientId);
+    if (!client) {
+      throw new AuthError(`Unknown client_id '${request.clientId}'`, {
+        status: 400,
+        code: 'invalid_client',
+      });
+    }
+
+    // Exact redirect URI validation (fail closed)
+    if (!request.redirectUri || !client.redirectUris.includes(request.redirectUri)) {
+      throw new AuthError(
+        `Invalid redirect_uri '${request.redirectUri}' for client '${request.clientId}'`,
+        { status: 400, code: 'invalid_request' },
+      );
+    }
+
+    // PKCE is mandatory
+    if (!request.codeChallenge) {
+      throw new AuthError('code_challenge is required for PKCE', {
+        status: 400,
+        code: 'invalid_request',
+      });
+    }
+
+    const method = request.codeChallengeMethod ?? 'S256';
+    if (method !== 'S256' && method !== 'plain') {
+      throw new AuthError(`Unsupported code_challenge_method '${method}'`, {
+        status: 400,
+        code: 'invalid_request',
+      });
+    }
+
+    // Scopes validation
+    const requestedScopes = request.scope ? request.scope.split(' ').filter(Boolean) : [];
+    for (const scope of requestedScopes) {
+      if (!client.allowedScopes.includes(scope)) {
+        throw new AuthError(`Requested scope '${scope}' is not allowed for this client`, {
+          status: 400,
+          code: 'invalid_scope',
+        });
+      }
+    }
+
+    if (!currentSubjectId) {
+      return { type: 'login_required', state: request.state };
+    }
+
+    // Authorization Manager policy check if configured
+    if (this.authorizationManager) {
+      const res = await this.authorizationManager.authorize(
+        { sub: currentSubjectId, method: 'session', authTime: this.now() },
+        { transport: 'oauth', metadata: { action: 'oauth:authorize', resource: request.clientId } },
+      );
+      const allowed = typeof res === 'boolean' ? res : res.allowed;
+      if (!allowed) {
+        throw new AuthError('Authorization policy denied OAuth authorization grant', {
+          status: 403,
+          code: 'access_denied',
+        });
+      }
+    }
+
+    // Check user consent
+    const consent = await this.consentStore.getConsent(client.clientId, currentSubjectId);
+    const missingScopes = requestedScopes.filter((s) => !consent?.scopes.includes(s));
+
+    if (missingScopes.length > 0) {
+      return {
+        type: 'consent_required',
+        client,
+        scopes: requestedScopes,
+        state: request.state,
+      };
+    }
+
+    // Generate authorization code
+    const codeString = crypto.randomUUID();
+    const code: OAuthAuthorizationCode = {
+      code: codeString,
+      clientId: client.clientId,
+      redirectUri: request.redirectUri,
+      subjectId: currentSubjectId,
+      scope: requestedScopes.join(' '),
+      codeChallenge: request.codeChallenge,
+      codeChallengeMethod: method,
+      nonce: request.nonce,
+      expiresAt: this.now() + this.codeLifetimeSeconds,
+      createdAt: this.now(),
+    };
+
+    await this.authCodeStore.createCode(code);
+
+    return {
+      type: 'redirect',
+      redirectUri: request.redirectUri,
+      code: codeString,
+      state: request.state,
+    };
+  }
+
+  /**
+   * Save user consent decision.
+   */
+  async grantConsent(clientId: string, subjectId: string, scopes: string[]): Promise<OAuthConsent> {
+    const consent: OAuthConsent = {
+      clientId,
+      subjectId,
+      scopes,
+      grantedAt: this.now(),
+    };
+    await this.consentStore.saveConsent(consent);
+    return consent;
+  }
+
+  /**
+   * Handle Token Endpoint (RFC 6749 §3.2).
+   */
+  async token(request: TokenRequest): Promise<OAuthTokenGrant> {
+    if (request.grantType === 'authorization_code') {
+      return this.handleAuthorizationCodeGrant(request);
+    }
+    if (request.grantType === 'refresh_token') {
+      return this.handleRefreshTokenGrant(request);
+    }
+    throw new AuthError(`Unsupported grant_type '${request.grantType}'`, {
+      status: 400,
+      code: 'unsupported_grant_type',
+    });
+  }
+
+  private async handleAuthorizationCodeGrant(request: TokenRequest): Promise<OAuthTokenGrant> {
+    if (!request.code) {
+      throw new AuthError('Missing code parameter', { status: 400, code: 'invalid_request' });
+    }
+
+    const code = await this.authCodeStore.consumeCode(request.code);
+    if (!code) {
+      throw new AuthError('Invalid or expired authorization code', {
+        status: 400,
+        code: 'invalid_grant',
+      });
+    }
+
+    const at = this.now();
+    if (code.expiresAt <= at) {
+      throw new AuthError('Authorization code has expired', {
+        status: 400,
+        code: 'invalid_grant',
+      });
+    }
+
+    // Client verification
+    const client = await this.clientStore.getClient(code.clientId);
+    if (!client) {
+      throw new AuthError('Invalid client', { status: 400, code: 'invalid_client' });
+    }
+
+    if (request.clientId && request.clientId !== code.clientId) {
+      throw new AuthError('client_id mismatch', { status: 400, code: 'invalid_grant' });
+    }
+
+    if (!client.isPublic && client.clientSecret) {
+      if (request.clientSecret !== client.clientSecret) {
+        throw new AuthError('Invalid client credentials', {
+          status: 401,
+          code: 'invalid_client',
+        });
+      }
+    }
+
+    // Redirect URI matching
+    if (request.redirectUri && request.redirectUri !== code.redirectUri) {
+      throw new AuthError('redirect_uri mismatch', { status: 400, code: 'invalid_grant' });
+    }
+
+    // PKCE Verification
+    if (!request.codeVerifier) {
+      throw new AuthError('code_verifier is required', { status: 400, code: 'invalid_grant' });
+    }
+
+    if (!isValidCodeVerifier(request.codeVerifier)) {
+      throw new AuthError('Invalid code_verifier format', { status: 400, code: 'invalid_grant' });
+    }
+
+    let challenge: string;
+    if (code.codeChallengeMethod === 'S256') {
+      challenge = await computeS256Challenge(request.codeVerifier);
+    } else {
+      challenge = request.codeVerifier;
+    }
+
+    if (challenge !== code.codeChallenge) {
+      throw new AuthError('PKCE code_verifier verification failed', {
+        status: 400,
+        code: 'invalid_grant',
+      });
+    }
+
+    return this.issueTokens({
+      clientId: code.clientId,
+      subjectId: code.subjectId,
+      scope: code.scope,
+      nonce: code.nonce,
+      allowedGrantTypes: client.allowedGrantTypes,
+    });
+  }
+
+  private async handleRefreshTokenGrant(request: TokenRequest): Promise<OAuthTokenGrant> {
+    if (!request.refreshToken) {
+      throw new AuthError('Missing refresh_token parameter', {
+        status: 400,
+        code: 'invalid_request',
+      });
+    }
+
+    const isRevoked = await this.tokenStore.isRevoked(request.refreshToken);
+    if (isRevoked) {
+      throw new AuthError('Refresh token is revoked or invalid', {
+        status: 400,
+        code: 'invalid_grant',
+      });
+    }
+
+    const { record } = await this.keyService.signingKey();
+    const verified = await verifyJwt(request.refreshToken, {
+      algorithms: [record.algorithm as SignatureAlgorithm],
+      key: (header) => this.keyService.verificationKey(header),
+      issuer: this.issuer,
+    });
+
+    if (verified.claims['type'] !== 'refresh_token') {
+      throw new AuthError('Invalid token type for refresh', {
+        status: 400,
+        code: 'invalid_grant',
+      });
+    }
+
+    const clientId = verified.claims['client_id'] as string;
+    const subjectId = verified.claims.sub as string;
+    const scope = (request.scope || verified.claims['scope']) as string;
+
+    const client = await this.clientStore.getClient(clientId);
+    if (!client) {
+      throw new AuthError('Invalid client', { status: 400, code: 'invalid_client' });
+    }
+
+    return this.issueTokens({
+      clientId,
+      subjectId,
+      scope,
+      allowedGrantTypes: client.allowedGrantTypes,
+    });
+  }
+
+  private async issueTokens(options: {
+    clientId: string;
+    subjectId: string;
+    scope: string;
+    nonce?: string;
+    allowedGrantTypes: string[];
+  }): Promise<OAuthTokenGrant> {
+    const { key, record } = await this.keyService.signingKey();
+
+    const accessToken = await signJwt(
+      {
+        iss: this.issuer,
+        sub: options.subjectId,
+        aud: options.clientId,
+        client_id: options.clientId,
+        scope: options.scope,
+        type: 'access_token',
+      },
+      {
+        algorithm: record.algorithm as SignatureAlgorithm,
+        key,
+        kid: record.kid,
+        expiresInSeconds: this.accessTokenLifetimeSeconds,
+        now: this.now,
+      },
+    );
+
+    const result: OAuthTokenGrant = {
+      access_token: accessToken,
+      token_type: 'Bearer',
+      expires_in: this.accessTokenLifetimeSeconds,
+      scope: options.scope,
+    };
+
+    const scopes = options.scope.split(' ');
+    if (scopes.includes('openid')) {
+      const idToken = await signJwt(
+        {
+          iss: this.issuer,
+          sub: options.subjectId,
+          aud: options.clientId,
+          ...(options.nonce ? { nonce: options.nonce } : {}),
+          auth_time: this.now(),
+        },
+        {
+          algorithm: record.algorithm as SignatureAlgorithm,
+          key,
+          kid: record.kid,
+          expiresInSeconds: this.accessTokenLifetimeSeconds,
+          now: this.now,
+        },
+      );
+      result.id_token = idToken;
+    }
+
+    if (options.allowedGrantTypes.includes('refresh_token')) {
+      const refreshToken = await signJwt(
+        {
+          iss: this.issuer,
+          sub: options.subjectId,
+          aud: options.clientId,
+          client_id: options.clientId,
+          scope: options.scope,
+          type: 'refresh_token',
+        },
+        {
+          algorithm: record.algorithm as SignatureAlgorithm,
+          key,
+          kid: record.kid,
+          expiresInSeconds: this.refreshTokenLifetimeSeconds,
+          now: this.now,
+        },
+      );
+
+      result.refresh_token = refreshToken;
+
+      const refreshRecord: OAuthRefreshTokenRecord = {
+        token: refreshToken,
+        clientId: options.clientId,
+        subjectId: options.subjectId,
+        scope: options.scope,
+        expiresAt: this.now() + this.refreshTokenLifetimeSeconds,
+        revoked: false,
+      };
+
+      await this.tokenStore.saveRefreshToken(refreshRecord);
+    }
+
+    return result;
+  }
+
+  /**
+   * Revoke a refresh token (RFC 7009).
+   */
+  async revoke(tokenString: string): Promise<boolean> {
+    return this.tokenStore.revokeToken(tokenString);
+  }
+
+  /**
+   * UserInfo Endpoint (OIDC Core 1.0 §5.3).
+   */
+  async userinfo(
+    accessToken: string,
+    getClaims?: (subject: string) => Promise<Record<string, unknown>>,
+  ): Promise<Record<string, unknown>> {
+    const { record } = await this.keyService.signingKey();
+    const verified = await verifyJwt(accessToken, {
+      algorithms: [record.algorithm as SignatureAlgorithm],
+      key: (header) => this.keyService.verificationKey(header),
+      issuer: this.issuer,
+    });
+
+    if (verified.claims['type'] !== 'access_token') {
+      throw new AuthError('Token is not an access_token', {
+        status: 401,
+        code: 'invalid_token',
+      });
+    }
+
+    const subject = verified.claims.sub!;
+    const extraClaims = getClaims ? await getClaims(subject) : {};
+
+    return {
+      sub: subject,
+      ...extraClaims,
+    };
+  }
+
+  /**
+   * OpenID Connect Discovery Metadata.
+   */
+  discovery(): OpenIDDiscoveryDocument {
+    const base = this.issuer.endsWith('/') ? this.issuer.slice(0, -1) : this.issuer;
+    return {
+      issuer: this.issuer,
+      authorization_endpoint: `${base}/oauth/authorize`,
+      token_endpoint: `${base}/oauth/token`,
+      userinfo_endpoint: `${base}/oauth/userinfo`,
+      jwks_uri: `${base}/.well-known/jwks.json`,
+      revocation_endpoint: `${base}/oauth/revoke`,
+      response_types_supported: ['code'],
+      grant_types_supported: ['authorization_code', 'refresh_token'],
+      subject_types_supported: ['public'],
+      id_token_signing_alg_values_supported: ['RS256', 'ES256'],
+      code_challenge_methods_supported: ['S256'],
+      scopes_supported: ['openid', 'profile', 'email'],
+    };
+  }
+
+  /**
+   * Export public JWKS.
+   */
+  async jwks() {
+    return this.keyService.publicJwks();
+  }
+}
+
+export function createAuthorizationServer(
+  options: OAuthAuthorizationServerOptions,
+): AuthorizationServer {
+  return new AuthorizationServer(options);
+}

--- a/packages/di-framework-auth/src/oauth/server/stores.ts
+++ b/packages/di-framework-auth/src/oauth/server/stores.ts
@@ -1,0 +1,82 @@
+import type {
+  AuthCodeStore,
+  ClientStore,
+  ConsentStore,
+  OAuthAuthorizationCode,
+  OAuthClientConfig,
+  OAuthConsent,
+  OAuthRefreshTokenRecord,
+  OAuthTokenStore,
+} from './types.ts';
+
+export class InMemoryClientStore implements ClientStore {
+  private clients = new Map<string, OAuthClientConfig>();
+
+  constructor(clients: OAuthClientConfig[] = []) {
+    for (const client of clients) {
+      this.clients.set(client.clientId, client);
+    }
+  }
+
+  registerClient(client: OAuthClientConfig): void {
+    this.clients.set(client.clientId, client);
+  }
+
+  async getClient(clientId: string): Promise<OAuthClientConfig | null> {
+    return this.clients.get(clientId) ?? null;
+  }
+}
+
+export class InMemoryAuthCodeStore implements AuthCodeStore {
+  private codes = new Map<string, OAuthAuthorizationCode>();
+
+  async createCode(code: OAuthAuthorizationCode): Promise<void> {
+    this.codes.set(code.code, { ...code, consumed: false });
+  }
+
+  async consumeCode(codeString: string): Promise<OAuthAuthorizationCode | null> {
+    const entry = this.codes.get(codeString);
+    if (!entry) return null;
+    if (entry.consumed) return null; // Prevent replay!
+    entry.consumed = true;
+    this.codes.set(codeString, entry);
+    return entry;
+  }
+}
+
+export class InMemoryConsentStore implements ConsentStore {
+  private consents = new Map<string, OAuthConsent>();
+
+  private key(clientId: string, subjectId: string): string {
+    return `${clientId}:${subjectId}`;
+  }
+
+  async getConsent(clientId: string, subjectId: string): Promise<OAuthConsent | null> {
+    return this.consents.get(this.key(clientId, subjectId)) ?? null;
+  }
+
+  async saveConsent(consent: OAuthConsent): Promise<void> {
+    this.consents.set(this.key(consent.clientId, consent.subjectId), consent);
+  }
+}
+
+export class InMemoryOAuthTokenStore implements OAuthTokenStore {
+  private refreshTokens = new Map<string, OAuthRefreshTokenRecord>();
+
+  async saveRefreshToken(token: OAuthRefreshTokenRecord): Promise<void> {
+    this.refreshTokens.set(token.token, token);
+  }
+
+  async revokeToken(tokenString: string): Promise<boolean> {
+    const token = this.refreshTokens.get(tokenString);
+    if (!token) return false;
+    token.revoked = true;
+    return true;
+  }
+
+  async isRevoked(tokenString: string): Promise<boolean> {
+    const token = this.refreshTokens.get(tokenString);
+    if (!token) return true;
+    return token.revoked;
+  }
+}

--- a/packages/di-framework-auth/src/oauth/server/types.ts
+++ b/packages/di-framework-auth/src/oauth/server/types.ts
@@ -1,0 +1,127 @@
+import type { AuthorizationManager } from '../../authorization.ts';
+import type { KeyService } from '../../tokens/keystore.ts';
+
+export interface OAuthClientConfig {
+  clientId: string;
+  clientSecret?: string;
+  clientName: string;
+  redirectUris: string[];
+  allowedGrantTypes: string[];
+  allowedScopes: string[];
+  isPublic?: boolean;
+}
+
+export interface OAuthAuthorizationCode {
+  code: string;
+  clientId: string;
+  redirectUri: string;
+  subjectId: string;
+  scope: string;
+  codeChallenge: string;
+  codeChallengeMethod: 'S256' | 'plain';
+  nonce?: string;
+  expiresAt: number;
+  createdAt: number;
+  consumed?: boolean;
+}
+
+export interface OAuthConsent {
+  clientId: string;
+  subjectId: string;
+  scopes: string[];
+  grantedAt: number;
+}
+
+export interface OAuthRefreshTokenRecord {
+  token: string;
+  clientId: string;
+  subjectId: string;
+  scope: string;
+  expiresAt: number;
+  revoked: boolean;
+}
+
+export interface ClientStore {
+  getClient(clientId: string): Promise<OAuthClientConfig | null>;
+}
+
+export interface AuthCodeStore {
+  createCode(code: OAuthAuthorizationCode): Promise<void>;
+  consumeCode(code: string): Promise<OAuthAuthorizationCode | null>;
+}
+
+export interface ConsentStore {
+  getConsent(clientId: string, subjectId: string): Promise<OAuthConsent | null>;
+  saveConsent(consent: OAuthConsent): Promise<void>;
+}
+
+export interface OAuthTokenStore {
+  saveRefreshToken(token: OAuthRefreshTokenRecord): Promise<void>;
+  revokeToken(token: string): Promise<boolean>;
+  isRevoked(tokenId: string): Promise<boolean>;
+}
+
+export interface OAuthAuthorizationServerOptions {
+  issuer: string;
+  keyService: KeyService;
+  clientStore: ClientStore;
+  authCodeStore: AuthCodeStore;
+  consentStore?: ConsentStore;
+  tokenStore?: OAuthTokenStore;
+  authorizationManager?: AuthorizationManager;
+  accessTokenLifetimeSeconds?: number;
+  refreshTokenLifetimeSeconds?: number;
+  codeLifetimeSeconds?: number;
+  now?: () => number;
+}
+
+export interface AuthorizationRequest {
+  responseType: string;
+  clientId: string;
+  redirectUri: string;
+  scope?: string;
+  state?: string;
+  codeChallenge?: string;
+  codeChallengeMethod?: 'S256' | 'plain';
+  nonce?: string;
+}
+
+export type AuthorizationResult =
+  | { type: 'redirect'; redirectUri: string; code: string; state?: string }
+  | { type: 'login_required'; state?: string }
+  | { type: 'consent_required'; client: OAuthClientConfig; scopes: string[]; state?: string };
+
+export interface TokenRequest {
+  grantType: string;
+  code?: string;
+  codeVerifier?: string;
+  redirectUri?: string;
+  clientId?: string;
+  clientSecret?: string;
+  refreshToken?: string;
+  scope?: string;
+}
+
+export interface OAuthTokenGrant {
+  access_token: string;
+  token_type: 'Bearer';
+  expires_in: number;
+  refresh_token?: string;
+  scope?: string;
+  id_token?: string;
+}
+
+export interface OpenIDDiscoveryDocument {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  userinfo_endpoint: string;
+  jwks_uri: string;
+  revocation_endpoint: string;
+  response_types_supported: string[];
+  grant_types_supported: string[];
+  subject_types_supported: string[];
+  id_token_signing_alg_values_supported: string[];
+  code_challenge_methods_supported: string[];
+  scopes_supported: string[];
+}

--- a/packages/di-framework-auth/src/result.ts
+++ b/packages/di-framework-auth/src/result.ts
@@ -69,6 +69,14 @@ export type AuthErrorCode =
   | 'nonce_mismatch'
   | 'issuer_mismatch'
   | 'discovery_failed'
+  // oauth server
+  | 'invalid_request'
+  | 'invalid_client'
+  | 'invalid_grant'
+  | 'unauthorized_client'
+  | 'unsupported_response_type'
+  | 'unsupported_grant_type'
+  | 'invalid_scope'
   // authorization
   | 'access_denied'
   // configuration

--- a/packages/di-framework-auth/tests/oauth/server.test.ts
+++ b/packages/di-framework-auth/tests/oauth/server.test.ts
@@ -1,16 +1,16 @@
-import { describe, expect, it, beforeEach } from 'bun:test';
+import { beforeEach, describe, expect, it } from 'bun:test';
 import {
-  AuthorizationServer,
+  type AuthorizationServer,
+  createAuthorizationServer,
+  handleOAuthServerRequest,
   InMemoryAuthCodeStore,
   InMemoryClientStore,
   InMemoryConsentStore,
   InMemoryOAuthTokenStore,
-  createAuthorizationServer,
-  handleOAuthServerRequest,
 } from '../../server.ts';
-import { keyService } from '../../src/tokens/keystore.ts';
 import { generatePkce } from '../../src/oauth/pkce.ts';
 import type { KeyStore, SigningKeyRecord } from '../../src/providers/types.ts';
+import { keyService } from '../../src/tokens/keystore.ts';
 
 class MemoryKeyStore implements KeyStore {
   private records: SigningKeyRecord[] = [];

--- a/packages/di-framework-auth/tests/oauth/server.test.ts
+++ b/packages/di-framework-auth/tests/oauth/server.test.ts
@@ -1,0 +1,484 @@
+import { describe, expect, it, beforeEach } from 'bun:test';
+import {
+  AuthorizationServer,
+  InMemoryAuthCodeStore,
+  InMemoryClientStore,
+  InMemoryConsentStore,
+  InMemoryOAuthTokenStore,
+  createAuthorizationServer,
+  handleOAuthServerRequest,
+} from '../../server.ts';
+import { keyService } from '../../src/tokens/keystore.ts';
+import { generatePkce } from '../../src/oauth/pkce.ts';
+import type { KeyStore, SigningKeyRecord } from '../../src/providers/types.ts';
+
+class MemoryKeyStore implements KeyStore {
+  private records: SigningKeyRecord[] = [];
+  async current(): Promise<SigningKeyRecord> {
+    if (this.records.length === 0) throw new Error('No keys');
+    return this.records[this.records.length - 1]!;
+  }
+  async save(record: SigningKeyRecord): Promise<SigningKeyRecord> {
+    this.records.push(record);
+    return record;
+  }
+  async find(kid: string): Promise<SigningKeyRecord | null> {
+    return this.records.find((r) => r.kid === kid) ?? null;
+  }
+  async all(): Promise<SigningKeyRecord[]> {
+    return this.records;
+  }
+  async delete(kid: string): Promise<boolean> {
+    const idx = this.records.findIndex((r) => r.kid === kid);
+    if (idx < 0) return false;
+    this.records.splice(idx, 1);
+    return true;
+  }
+}
+
+describe('OAuth2 / OIDC Authorization Server', () => {
+  let server: AuthorizationServer;
+  let clientStore: InMemoryClientStore;
+  let authCodeStore: InMemoryAuthCodeStore;
+  let consentStore: InMemoryConsentStore;
+  let tokenStore: InMemoryOAuthTokenStore;
+  let keys: ReturnType<typeof keyService>;
+
+  const issuer = 'https://auth.example.com';
+  const clientConfig = {
+    clientId: 'test-app',
+    clientSecret: 'secret-123',
+    clientName: 'Test App',
+    redirectUris: ['https://app.example.com/callback'],
+    allowedGrantTypes: ['authorization_code', 'refresh_token'],
+    allowedScopes: ['openid', 'profile', 'email', 'read:docs'],
+    isPublic: false,
+  };
+
+  beforeEach(async () => {
+    clientStore = new InMemoryClientStore([clientConfig]);
+    authCodeStore = new InMemoryAuthCodeStore();
+    consentStore = new InMemoryConsentStore();
+    tokenStore = new InMemoryOAuthTokenStore();
+    keys = keyService({ store: new MemoryKeyStore() });
+
+    server = createAuthorizationServer({
+      issuer,
+      keyService: keys,
+      clientStore,
+      authCodeStore,
+      consentStore,
+      tokenStore,
+    });
+  });
+
+  it('generates discovery metadata and JWKS', async () => {
+    const discovery = server.discovery();
+    expect(discovery.issuer).toBe(issuer);
+    expect(discovery.authorization_endpoint).toBe('https://auth.example.com/oauth/authorize');
+    expect(discovery.token_endpoint).toBe('https://auth.example.com/oauth/token');
+    expect(discovery.response_types_supported).toEqual(['code']);
+    expect(discovery.code_challenge_methods_supported).toEqual(['S256']);
+
+    // Bootstraps key lazily
+    await keys.signingKey();
+    const jwks = await server.jwks();
+    expect(jwks.keys.length).toBeGreaterThan(0);
+  });
+
+  it('covers store utility edge cases', async () => {
+    const freshStore = new InMemoryClientStore();
+    expect(await freshStore.getClient('test-app')).toBeNull();
+    freshStore.registerClient(clientConfig);
+    expect(await freshStore.getClient('test-app')).toEqual(clientConfig);
+
+    expect(await authCodeStore.consumeCode('non-existent')).toBeNull();
+    expect(await tokenStore.revokeToken('non-existent')).toBeFalse();
+    expect(await tokenStore.isRevoked('non-existent')).toBeTrue();
+  });
+
+  it('rejects unsupported response_type and invalid clients', async () => {
+    await expect(
+      server.authorize({
+        responseType: 'token',
+        clientId: 'test-app',
+        redirectUri: 'https://app.example.com/callback',
+        codeChallenge: 'abc',
+      }),
+    ).rejects.toThrow('Unsupported response_type');
+
+    await expect(
+      server.authorize({
+        responseType: 'code',
+        clientId: 'non-existent',
+        redirectUri: 'https://app.example.com/callback',
+        codeChallenge: 'abc',
+      }),
+    ).rejects.toThrow('Unknown client_id');
+  });
+
+  it('enforces exact redirect_uri matching and PKCE requirement', async () => {
+    await expect(
+      server.authorize({
+        responseType: 'code',
+        clientId: 'test-app',
+        redirectUri: 'https://attacker.example.com/callback',
+        codeChallenge: 'abc',
+      }),
+    ).rejects.toThrow('Invalid redirect_uri');
+
+    await expect(
+      server.authorize({
+        responseType: 'code',
+        clientId: 'test-app',
+        redirectUri: 'https://app.example.com/callback',
+      }),
+    ).rejects.toThrow('code_challenge is required');
+  });
+
+  it('handles unauthenticated and unconsented requests', async () => {
+    const pkce = await generatePkce();
+
+    const loginReq = await server.authorize({
+      responseType: 'code',
+      clientId: 'test-app',
+      redirectUri: 'https://app.example.com/callback',
+      scope: 'openid profile',
+      codeChallenge: pkce.codeChallenge,
+      state: 'state-1',
+    });
+    expect(loginReq.type).toBe('login_required');
+
+    const consentReq = await server.authorize(
+      {
+        responseType: 'code',
+        clientId: 'test-app',
+        redirectUri: 'https://app.example.com/callback',
+        scope: 'openid profile',
+        codeChallenge: pkce.codeChallenge,
+        state: 'state-1',
+      },
+      'user-123',
+    );
+    expect(consentReq.type).toBe('consent_required');
+
+    await server.grantConsent('test-app', 'user-123', ['openid', 'profile']);
+
+    const redirectRes = await server.authorize(
+      {
+        responseType: 'code',
+        clientId: 'test-app',
+        redirectUri: 'https://app.example.com/callback',
+        scope: 'openid profile',
+        codeChallenge: pkce.codeChallenge,
+        state: 'state-1',
+      },
+      'user-123',
+    );
+    expect(redirectRes.type).toBe('redirect');
+    if (redirectRes.type === 'redirect') {
+      expect(redirectRes.code).toBeDefined();
+      expect(redirectRes.state).toBe('state-1');
+    }
+  });
+
+  it('exchanges code for tokens with PKCE validation', async () => {
+    const pkce = await generatePkce();
+    await server.grantConsent('test-app', 'user-123', ['openid', 'profile']);
+
+    const authResFailed = await server.authorize(
+      {
+        responseType: 'code',
+        clientId: 'test-app',
+        redirectUri: 'https://app.example.com/callback',
+        scope: 'openid profile',
+        codeChallenge: pkce.codeChallenge,
+        codeChallengeMethod: 'S256',
+      },
+      'user-123',
+    );
+    const failedCode = (authResFailed as any).code;
+
+    await expect(
+      server.token({
+        grantType: 'authorization_code',
+        code: failedCode,
+        codeVerifier: 'wrong-verifier-12345678901234567890123456789012345',
+        clientId: 'test-app',
+        clientSecret: 'secret-123',
+        redirectUri: 'https://app.example.com/callback',
+      }),
+    ).rejects.toThrow('PKCE code_verifier verification failed');
+
+    const authResSuccess = await server.authorize(
+      {
+        responseType: 'code',
+        clientId: 'test-app',
+        redirectUri: 'https://app.example.com/callback',
+        scope: 'openid profile',
+        codeChallenge: pkce.codeChallenge,
+        codeChallengeMethod: 'S256',
+        nonce: 'nonce-777',
+      },
+      'user-123',
+    );
+    const code = (authResSuccess as any).code;
+
+    const grant = await server.token({
+      grantType: 'authorization_code',
+      code,
+      codeVerifier: pkce.codeVerifier,
+      clientId: 'test-app',
+      clientSecret: 'secret-123',
+      redirectUri: 'https://app.example.com/callback',
+    });
+
+    expect(grant.token_type).toBe('Bearer');
+    expect(grant.access_token).toBeDefined();
+    expect(grant.refresh_token).toBeDefined();
+    expect(grant.id_token).toBeDefined();
+
+    await expect(
+      server.token({
+        grantType: 'authorization_code',
+        code,
+        codeVerifier: pkce.codeVerifier,
+        clientId: 'test-app',
+        clientSecret: 'secret-123',
+      }),
+    ).rejects.toThrow('Invalid or expired authorization code');
+  });
+
+  it('supports refresh token grant and revocation', async () => {
+    const pkce = await generatePkce();
+    await server.grantConsent('test-app', 'user-123', ['openid', 'profile']);
+
+    const authRes = await server.authorize(
+      {
+        responseType: 'code',
+        clientId: 'test-app',
+        redirectUri: 'https://app.example.com/callback',
+        scope: 'openid profile',
+        codeChallenge: pkce.codeChallenge,
+      },
+      'user-123',
+    );
+    const code = (authRes as any).code;
+
+    const grant = await server.token({
+      grantType: 'authorization_code',
+      code,
+      codeVerifier: pkce.codeVerifier,
+      clientId: 'test-app',
+      clientSecret: 'secret-123',
+    });
+
+    const refreshed = await server.token({
+      grantType: 'refresh_token',
+      refreshToken: grant.refresh_token!,
+    });
+    expect(refreshed.access_token).toBeDefined();
+
+    await server.revoke(grant.refresh_token!);
+
+    await expect(
+      server.token({
+        grantType: 'refresh_token',
+        refreshToken: grant.refresh_token!,
+      }),
+    ).rejects.toThrow('Refresh token is revoked or invalid');
+  });
+
+  it('returns userinfo for valid access token', async () => {
+    const pkce = await generatePkce();
+    await server.grantConsent('test-app', 'user-456', ['openid', 'profile']);
+
+    const authRes = await server.authorize(
+      {
+        responseType: 'code',
+        clientId: 'test-app',
+        redirectUri: 'https://app.example.com/callback',
+        scope: 'openid profile',
+        codeChallenge: pkce.codeChallenge,
+      },
+      'user-456',
+    );
+
+    const grant = await server.token({
+      grantType: 'authorization_code',
+      code: (authRes as any).code,
+      codeVerifier: pkce.codeVerifier,
+      clientId: 'test-app',
+      clientSecret: 'secret-123',
+    });
+
+    const info = await server.userinfo(grant.access_token, async (sub) => ({
+      email: `${sub}@example.com`,
+    }));
+
+    expect(info.sub).toBe('user-456');
+    expect(info.email).toBe('user-456@example.com');
+  });
+
+  it('serves endpoints via handleOAuthServerRequest HTTP router including all branches', async () => {
+    const pkce = await generatePkce();
+
+    // 1. Unauthenticated authorize -> login_required 401
+    const unauthReq = new Request(
+      `https://auth.example.com/oauth/authorize?response_type=code&client_id=test-app&redirect_uri=${encodeURIComponent(
+        'https://app.example.com/callback',
+      )}&code_challenge=${pkce.codeChallenge}&code_challenge_method=S256`,
+    );
+    const unauthRes = await handleOAuthServerRequest(unauthReq, { server });
+    expect(unauthRes?.status).toBe(401);
+
+    // 2. Unconsented authorize -> consent_required 200
+    const unconsentedReq = new Request(
+      `https://auth.example.com/oauth/authorize?response_type=code&client_id=test-app&redirect_uri=${encodeURIComponent(
+        'https://app.example.com/callback',
+      )}&code_challenge=${pkce.codeChallenge}&code_challenge_method=S256&scope=openid`,
+    );
+    const unconsentedRes = await handleOAuthServerRequest(unconsentedReq, {
+      server,
+      subjectResolver: async () => 'user-789',
+    });
+    expect(unconsentedRes?.status).toBe(200);
+    const consentJson: any = await unconsentedRes?.json();
+    expect(consentJson.error).toBe('consent_required');
+
+    // 3. POST /oauth/authorize form-encoded
+    await server.grantConsent('test-app', 'user-789', ['openid']);
+    const postAuthReq = new Request('https://auth.example.com/oauth/authorize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        response_type: 'code',
+        client_id: 'test-app',
+        redirect_uri: 'https://app.example.com/callback',
+        code_challenge: pkce.codeChallenge,
+        code_challenge_method: 'S256',
+        scope: 'openid',
+        state: 'post-state',
+      }).toString(),
+    });
+    const postAuthRes = await handleOAuthServerRequest(postAuthReq, {
+      server,
+      subjectResolver: async () => 'user-789',
+    });
+    expect(postAuthRes?.status).toBe(302);
+    const location = postAuthRes?.headers.get('location');
+    const code = new URL(location!).searchParams.get('code')!;
+
+    // 4a. POST /oauth/token with form body
+    const formTokenReq = new Request('https://auth.example.com/oauth/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        code_verifier: pkce.codeVerifier,
+        client_id: 'test-app',
+        client_secret: 'secret-123',
+        redirect_uri: 'https://app.example.com/callback',
+      }).toString(),
+    });
+    const formTokenRes = await handleOAuthServerRequest(formTokenReq, { server });
+    expect(formTokenRes?.status).toBe(200);
+    const tokenData: any = await formTokenRes?.json();
+    expect(tokenData.access_token).toBeDefined();
+
+    // 4b. POST /oauth/token with JSON body & Basic auth header (generate a new code)
+    const authRes2 = await server.authorize(
+      {
+        responseType: 'code',
+        clientId: 'test-app',
+        redirectUri: 'https://app.example.com/callback',
+        scope: 'openid',
+        codeChallenge: pkce.codeChallenge,
+      },
+      'user-789',
+    );
+    const code2 = (authRes2 as any).code;
+
+    const basicAuth = btoa('test-app:secret-123');
+    const jsonTokenReq = new Request('https://auth.example.com/oauth/token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Basic ${basicAuth}`,
+      },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code: code2,
+        code_verifier: pkce.codeVerifier,
+        redirect_uri: 'https://app.example.com/callback',
+      }),
+    });
+    const jsonTokenRes = await handleOAuthServerRequest(jsonTokenReq, { server });
+    expect(jsonTokenRes?.status).toBe(200);
+
+    // 5. POST /oauth/token with malformed JSON body
+    const badJsonTokenReq = new Request('https://auth.example.com/oauth/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'invalid-json-{',
+    });
+    const badJsonTokenRes = await handleOAuthServerRequest(badJsonTokenReq, { server });
+    expect(badJsonTokenRes?.status).toBe(400);
+
+    // 6. POST /oauth/revoke without token parameter and with token parameter
+    const emptyRevokeReq = new Request('https://auth.example.com/oauth/revoke', {
+      method: 'POST',
+    });
+    const emptyRevokeRes = await handleOAuthServerRequest(emptyRevokeReq, { server });
+    expect(emptyRevokeRes?.status).toBe(200);
+
+    const tokenRevokeReq = new Request('https://auth.example.com/oauth/revoke', {
+      method: 'POST',
+      body: new URLSearchParams({ token: tokenData.refresh_token }).toString(),
+    });
+    const tokenRevokeRes = await handleOAuthServerRequest(tokenRevokeReq, { server });
+    expect(tokenRevokeRes?.status).toBe(200);
+
+    // 7. GET /.well-known/jwks.json
+    const jwksReq = new Request('https://auth.example.com/.well-known/jwks.json');
+    const jwksRes = await handleOAuthServerRequest(jwksReq, { server });
+    expect(jwksRes?.status).toBe(200);
+
+    // 8. GET /oauth/userinfo with valid Bearer token
+    const validUserinfoReq = new Request('https://auth.example.com/oauth/userinfo', {
+      headers: { Authorization: `Bearer ${tokenData.access_token}` },
+    });
+    const validUserinfoRes = await handleOAuthServerRequest(validUserinfoReq, {
+      server,
+      userinfoClaimsResolver: async (sub) => ({ email: `${sub}@example.com` }),
+    });
+    expect(validUserinfoRes?.status).toBe(200);
+    const validUserinfoJson: any = await validUserinfoRes?.json();
+    expect(validUserinfoJson.sub).toBe('user-789');
+    expect(validUserinfoJson.email).toBe('user-789@example.com');
+
+    // 9. GET /oauth/userinfo missing Bearer token header
+    const noHeaderUserinfoReq = new Request('https://auth.example.com/oauth/userinfo');
+    const noHeaderUserinfoRes = await handleOAuthServerRequest(noHeaderUserinfoReq, { server });
+    expect(noHeaderUserinfoRes?.status).toBe(401);
+
+    // 10. GET /unknown returns null
+    const unknownReq = new Request('https://auth.example.com/unknown');
+    const unknownRes = await handleOAuthServerRequest(unknownReq, { server });
+    expect(unknownRes).toBeNull();
+
+    // 11. Server throwing generic non-AuthError returns 500 server_error
+    const throwingServer = new Proxy(server, {
+      get(target, prop) {
+        if (prop === 'discovery') throw new Error('Unexpected crash');
+        return (target as any)[prop];
+      },
+    });
+    const crashReq = new Request('https://auth.example.com/.well-known/openid-configuration');
+    const crashRes = await handleOAuthServerRequest(crashReq, { server: throwingServer });
+    expect(crashRes?.status).toBe(500);
+    const crashJson: any = await crashRes?.json();
+    expect(crashJson.error).toBe('server_error');
+  });
+});


### PR DESCRIPTION
Closes #118.

## Summary

Adds OAuth 2.0 and OpenID Connect Core 1.0 Authorization Server support to `@di-framework/auth` under `@di-framework/auth/server`.

## Features Included

- Authorization code flow with PKCE (`S256`) enforcement. Implicit and password grants excluded per RFC 9700.
- Standard endpoints: Authorization (`/oauth/authorize`), Token (`/oauth/token`), UserInfo (`/oauth/userinfo`), Revocation (`/oauth/revoke`), OIDC Discovery (`/.well-known/openid-configuration`), and JWKS (`/.well-known/jwks.json`).
- Replaceable persistence contracts for `ClientStore`, `AuthCodeStore`, `ConsentStore`, and `OAuthTokenStore` with in-memory implementations.
- Key rotation and public JWKS publishing via `KeyService`.
- Integration with `AuthorizationManager` for policy-based grant decisions.
- Standards responsibilities and threat model documented under `packages/di-framework-auth/docs/oauth-server.md`.
- 100% test line coverage.