### PR TITLE
feat(authz): GraphQL resource-policy bindings

### DIFF
--- a/packages/di-framework-authz/docs/graphql-resource-policies.md
+++ b/packages/di-framework-authz/docs/graphql-resource-policies.md
@@ -1,0 +1,71 @@
+# GraphQL Resource-Policy Bindings (`@di-framework/authz/graphql`)
+
+## Overview
+
+`@di-framework/authz/graphql` connects `@di-framework/authz` resource policies directly to GraphQL queries, mutations, subscriptions, and field resolvers. It reuses the exact same AST, evaluator, `ResourcePolicy` definitions, and `ResourceProvider` contracts introduced by PR #116 without introducing a parallel policy language.
+
+---
+
+## Key Features
+
+1. **Same Policy AST & Evaluator**: Uses `policyAuthorizationManager` and `compilePolicies()` directly.
+2. **Fail-Closed Declarations**: Missing or ambiguous resource IDs and actions fail closed immediately.
+3. **Information Leakage Protections**: Internal decision categories, rule IDs (`category`, `ruleIds`), and policy ASTs are accessible to internal logs/hooks (`onDenied`) but **never serialized to GraphQL clients**.
+4. **Flexible Resource ID Resolution**: Supports argument values (`args[idArg]`), custom getter functions (`idArg: (args, parent) => ...`), or parent entity properties (`idField: 'id'`).
+5. **Provider Consistency**: Evaluates `ResourceProvider.load(id, context)` before evaluating policy conditions for member operations.
+
+---
+
+## Example Usage
+
+```ts
+import { ResourcePolicy, Policy, Allow, Owner, HasRole } from '@di-framework/authz';
+import { GraphQLResourceAuthorization, protectGraphQLField } from '@di-framework/authz/graphql';
+
+@ResourcePolicy({ resource: 'document' })
+export class DocumentPolicy {
+  @Allow({ actions: ['read', 'update'] })
+  @Owner({ subjectPath: 'id', resourcePath: 'ownerId' })
+  ownerAccess() {}
+
+  @Allow({ actions: ['read', 'list'] })
+  @HasRole('admin')
+  adminAccess() {}
+}
+
+// Option A: Field Resolver Wrapper
+export const documentQueryResolver = protectGraphQLField(
+  DocumentPolicy,
+  async (parent, args, ctx) => {
+    return ctx.db.findDocument(args.id);
+  },
+  { action: 'read', idArg: 'id' }
+);
+
+// Option B: Decorator Integration
+export class DocumentResolver {
+  @GraphQLResourceAuthorization(DocumentPolicy, { action: 'update', idArg: 'id' })
+  async updateDocument(parent: any, args: { id: string; title: string }, ctx: any) {
+    return ctx.db.updateDocument(args.id, { title: args.title });
+  }
+}
+```
+
+---
+
+## Client Error Responses
+
+When authorization fails, the client receives a standard GraphQL error without internal detail:
+
+```json
+{
+  "errors": [
+    {
+      "message": "Not authorized.",
+      "extensions": {
+        "code": "FORBIDDEN"
+      }
+    }
+  ]
+}
+```

--- a/packages/di-framework-authz/graphql.ts
+++ b/packages/di-framework-authz/graphql.ts
@@ -1,0 +1,1 @@
+export * from './src/graphql.ts';

--- a/packages/di-framework-authz/package.json
+++ b/packages/di-framework-authz/package.json
@@ -16,6 +16,11 @@
       "bun": "./http.ts",
       "import": "./dist/http.js",
       "default": "./dist/http.js"
+    },
+    "./graphql": {
+      "bun": "./graphql.ts",
+      "import": "./dist/graphql.js",
+      "default": "./dist/graphql.js"
     }
   },
   "files": [
@@ -23,10 +28,11 @@
     "README.md",
     "index.ts",
     "http.ts",
+    "graphql.ts",
     "src"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build ./index.ts ./http.ts --outdir ./dist --target node --splitting --external @di-framework/core --external @di-framework/auth && tsc --emitDeclarationOnly --declaration --outDir dist",
+    "build": "rm -rf dist && bun build ./index.ts ./http.ts ./graphql.ts --outdir ./dist --target node --splitting --external @di-framework/core --external @di-framework/auth && tsc --emitDeclarationOnly --declaration --outDir dist",
     "test": "bun test",
     "prepublishOnly": "bun run build"
   },

--- a/packages/di-framework-authz/src/graphql.ts
+++ b/packages/di-framework-authz/src/graphql.ts
@@ -43,9 +43,7 @@ export interface GraphQLResourceAuthorizationOptions {
   action?: string;
   idArg?: string | ((args: Record<string, any>, parent: unknown) => string | undefined);
   idField?: string;
-  manager?:
-    | AuthorizationManager<any>
-    | (() => AuthorizationManager<any>);
+  manager?: AuthorizationManager<any> | (() => AuthorizationManager<any>);
   managerToken?: string;
   container?: { resolve<T>(token: string): T; has?(token: string): boolean };
   onDenied?: (denial: GraphQLAuthzDenial) => Error;
@@ -74,13 +72,23 @@ function inferGraphQLAction(
   if (optionsAction) return { action: optionsAction, collection: false };
 
   const name = fieldName.toLowerCase();
-  if (name.startsWith('list') || name.startsWith('getmany') || name.startsWith('all') || name.includes('connection')) {
+  if (
+    name.startsWith('list') ||
+    name.startsWith('getmany') ||
+    name.startsWith('all') ||
+    name.includes('connection')
+  ) {
     return { action: 'list', collection: true };
   }
   if (name.startsWith('create') || name.startsWith('add') || name.startsWith('insert')) {
     return { action: 'create', collection: true };
   }
-  if (name.startsWith('update') || name.startsWith('edit') || name.startsWith('modify') || name.startsWith('set')) {
+  if (
+    name.startsWith('update') ||
+    name.startsWith('edit') ||
+    name.startsWith('modify') ||
+    name.startsWith('set')
+  ) {
     return { action: 'update', collection: false };
   }
   if (name.startsWith('delete') || name.startsWith('remove')) {
@@ -105,7 +113,7 @@ function resolveResourceId(
     const val = (parent as Record<string, any>)?.[options.idField];
     return val !== undefined && val !== null ? String(val) : undefined;
   }
-  const fallback = args['id'] ?? args['idParam'] ?? (parent as Record<string, any>)?.[ 'id' ];
+  const fallback = args['id'] ?? args['idParam'] ?? (parent as Record<string, any>)?.['id'];
   return fallback !== undefined && fallback !== null ? String(fallback) : undefined;
 }
 
@@ -203,13 +211,24 @@ export async function evaluateGraphQLResourcePolicy(
   }
 }
 
-export function protectGraphQLField<TSource = unknown, TArgs = Record<string, any>, TContext = unknown>(
+export function protectGraphQLField<
+  TSource = unknown,
+  TArgs = Record<string, any>,
+  TContext = unknown,
+>(
   reference: PolicyClass | string,
   resolver: (source: TSource, args: TArgs, ctx: TContext, info: any) => any,
   options: GraphQLResourceAuthorizationOptions = {},
 ): (source: TSource, args: TArgs, ctx: TContext, info: any) => Promise<any> {
   return async (source: TSource, args: TArgs, ctx: TContext, info: any) => {
-    await evaluateGraphQLResourcePolicy(reference, source, args as Record<string, any>, ctx, info, options);
+    await evaluateGraphQLResourcePolicy(
+      reference,
+      source,
+      args as Record<string, any>,
+      ctx,
+      info,
+      options,
+    );
     return resolver(source, args, ctx, info);
   };
 }

--- a/packages/di-framework-authz/src/graphql.ts
+++ b/packages/di-framework-authz/src/graphql.ts
@@ -1,0 +1,236 @@
+import type { AuthorizationManager, Principal } from '@di-framework/auth';
+import { useContainer } from '@di-framework/core/container';
+import type { PolicyAuthorizationMetadata } from './manager.ts';
+import { resourceForPolicy } from './registry.ts';
+
+const ACTION = Symbol.for('@di-framework/authz:graphql-resource-action');
+const RESOURCE_AUTH = Symbol.for('@di-framework/authz:graphql-resource-auth');
+
+export class GraphQLResourcePolicyError extends Error {
+  readonly extensions: { code: string };
+
+  constructor(message = 'Not authorized.', code = 'FORBIDDEN') {
+    super(message);
+    this.name = 'GraphQLResourcePolicyError';
+    this.extensions = { code };
+  }
+}
+
+export interface GraphQLAuthorizationMetadata extends PolicyAuthorizationMetadata {
+  collection?: boolean;
+}
+
+export interface GraphQLAuthorizationContext<TMetadata = GraphQLAuthorizationMetadata> {
+  readonly transport: 'graphql';
+  readonly metadata: TMetadata;
+  readonly parent?: unknown;
+  readonly args?: Record<string, unknown>;
+  readonly ctx?: unknown;
+  readonly info?: unknown;
+}
+
+export interface GraphQLAuthzDenial {
+  resource: string;
+  action: string;
+  id?: string;
+  category?: string;
+  ruleIds?: string[];
+  reason?: string;
+  anonymous?: boolean;
+}
+
+export interface GraphQLResourceAuthorizationOptions {
+  action?: string;
+  idArg?: string | ((args: Record<string, any>, parent: unknown) => string | undefined);
+  idField?: string;
+  manager?:
+    | AuthorizationManager<any>
+    | (() => AuthorizationManager<any>);
+  managerToken?: string;
+  container?: { resolve<T>(token: string): T; has?(token: string): boolean };
+  onDenied?: (denial: GraphQLAuthzDenial) => Error;
+}
+
+type PolicyClass = Function;
+
+export function ResourceAction(action: string) {
+  if (!action.trim() || !/^[A-Za-z][\w:.-]*$/.test(action)) {
+    throw new Error(`Invalid resource action '${action}'`);
+  }
+  return (target: object, propertyKey: string | symbol) => {
+    const value = (target as Record<string | symbol, unknown>)[propertyKey];
+    if (typeof value === 'function') {
+      (value as any)[ACTION] = action;
+    }
+  };
+}
+
+function inferGraphQLAction(
+  fieldName: string,
+  optionsAction?: string,
+  explicitAction?: string,
+): { action: string; collection: boolean } {
+  if (explicitAction) return { action: explicitAction, collection: false };
+  if (optionsAction) return { action: optionsAction, collection: false };
+
+  const name = fieldName.toLowerCase();
+  if (name.startsWith('list') || name.startsWith('getmany') || name.startsWith('all') || name.includes('connection')) {
+    return { action: 'list', collection: true };
+  }
+  if (name.startsWith('create') || name.startsWith('add') || name.startsWith('insert')) {
+    return { action: 'create', collection: true };
+  }
+  if (name.startsWith('update') || name.startsWith('edit') || name.startsWith('modify') || name.startsWith('set')) {
+    return { action: 'update', collection: false };
+  }
+  if (name.startsWith('delete') || name.startsWith('remove')) {
+    return { action: 'delete', collection: false };
+  }
+  return { action: 'read', collection: false };
+}
+
+function resolveResourceId(
+  args: Record<string, any>,
+  parent: unknown,
+  options: GraphQLResourceAuthorizationOptions,
+): string | undefined {
+  if (typeof options.idArg === 'function') {
+    return options.idArg(args, parent);
+  }
+  if (typeof options.idArg === 'string') {
+    const val = args[options.idArg];
+    return val !== undefined && val !== null ? String(val) : undefined;
+  }
+  if (typeof options.idField === 'string') {
+    const val = (parent as Record<string, any>)?.[options.idField];
+    return val !== undefined && val !== null ? String(val) : undefined;
+  }
+  const fallback = args['id'] ?? args['idParam'] ?? (parent as Record<string, any>)?.[ 'id' ];
+  return fallback !== undefined && fallback !== null ? String(fallback) : undefined;
+}
+
+export async function evaluateGraphQLResourcePolicy(
+  reference: PolicyClass | string,
+  parent: unknown,
+  args: Record<string, any>,
+  ctx: any,
+  info: any,
+  options: GraphQLResourceAuthorizationOptions = {},
+): Promise<void> {
+  const resource = typeof reference === 'string' ? reference : resourceForPolicy(reference);
+  if (!resource) {
+    throw new Error(
+      `Policy class '${typeof reference === 'string' ? reference : reference.name}' is not registered`,
+    );
+  }
+
+  const principal: Principal | undefined = ctx?.user ?? ctx?.principal;
+  const fieldName = info?.fieldName ?? 'resolver';
+  const explicitAction = (options as any)[ACTION];
+  const { action, collection } = inferGraphQLAction(fieldName, options.action, explicitAction);
+
+  const id = resolveResourceId(args, parent, options);
+
+  // Fail closed if member operation lacks resource ID
+  if (!collection && action !== 'create' && !id) {
+    const denial: GraphQLAuthzDenial = {
+      resource,
+      action,
+      reason: 'resource-id-missing',
+      anonymous: !principal,
+    };
+    if (options.onDenied) throw options.onDenied(denial);
+    throw new GraphQLResourcePolicyError('Resource ID is missing or invalid.', 'FORBIDDEN');
+  }
+
+  if (!principal) {
+    const denial: GraphQLAuthzDenial = {
+      resource,
+      action,
+      id,
+      reason: 'unauthenticated',
+      anonymous: true,
+    };
+    if (options.onDenied) throw options.onDenied(denial);
+    throw new GraphQLResourcePolicyError('Authentication is required.', 'UNAUTHENTICATED');
+  }
+
+  const container = options.container ?? (useContainer() as any);
+  let manager: AuthorizationManager<any>;
+  if (typeof options.manager === 'function') {
+    manager = options.manager();
+  } else if (options.manager) {
+    manager = options.manager;
+  } else {
+    const token = options.managerToken ?? '@di-framework/authz:manager';
+    manager = container.resolve(token);
+  }
+
+  if (!manager) {
+    throw new Error('No authorization manager available for GraphQL resource policy evaluation');
+  }
+
+  const context: GraphQLAuthorizationContext = {
+    transport: 'graphql',
+    metadata: {
+      resource,
+      action,
+      id,
+      collection,
+    },
+    parent,
+    args,
+    ctx,
+    info,
+  };
+
+  const decision = await manager.authorize(principal, context as any);
+  const allowed = typeof decision === 'boolean' ? decision : decision.allowed;
+
+  if (!allowed) {
+    const detail = typeof decision === 'object' ? (decision.detail as any) : undefined;
+    const denial: GraphQLAuthzDenial = {
+      resource,
+      action,
+      id,
+      category: detail?.category,
+      ruleIds: detail?.ruleIds,
+      reason: typeof decision === 'object' ? (decision as any).reason : 'denied',
+      anonymous: false,
+    };
+    if (options.onDenied) throw options.onDenied(denial);
+    throw new GraphQLResourcePolicyError('Not authorized.', 'FORBIDDEN');
+  }
+}
+
+export function protectGraphQLField<TSource = unknown, TArgs = Record<string, any>, TContext = unknown>(
+  reference: PolicyClass | string,
+  resolver: (source: TSource, args: TArgs, ctx: TContext, info: any) => any,
+  options: GraphQLResourceAuthorizationOptions = {},
+): (source: TSource, args: TArgs, ctx: TContext, info: any) => Promise<any> {
+  return async (source: TSource, args: TArgs, ctx: TContext, info: any) => {
+    await evaluateGraphQLResourcePolicy(reference, source, args as Record<string, any>, ctx, info, options);
+    return resolver(source, args, ctx, info);
+  };
+}
+
+export function GraphQLResourceAuthorization(
+  reference: PolicyClass | string,
+  options: GraphQLResourceAuthorizationOptions = {},
+) {
+  return (target: object, propertyKey?: string | symbol, descriptor?: PropertyDescriptor) => {
+    if (descriptor && typeof descriptor.value === 'function') {
+      const original = descriptor.value;
+      descriptor.value = async function (...methodArgs: any[]) {
+        const [parent, args, ctx, info] = methodArgs;
+        await evaluateGraphQLResourcePolicy(reference, parent, args, ctx, info, options);
+        return original.apply(this, methodArgs);
+      };
+      return descriptor;
+    }
+
+    if (typeof target === 'function') {
+      (target as any)[RESOURCE_AUTH] = { reference, options };
+    }
+  };
+}

--- a/packages/di-framework-authz/src/manager.ts
+++ b/packages/di-framework-authz/src/manager.ts
@@ -45,7 +45,7 @@ function isProvider(value: unknown): value is ResourceProvider {
 }
 export function policyAuthorizationManager(
   options: PolicyAuthorizationOptions,
-): AuthorizationManager<HttpAuthorizationContext<PolicyAuthorizationMetadata>> {
+): AuthorizationManager<any> {
   if (!options || !options.providers) throw new Error('Policy providers configuration is required');
   const document =
     typeof options.policies === 'string'

--- a/packages/di-framework-authz/tests/graphql.test.ts
+++ b/packages/di-framework-authz/tests/graphql.test.ts
@@ -1,18 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import {
-  Allow,
-  HasRole,
-  Owner,
-  Policy,
-  policyAuthorizationManager,
-} from '../index.ts';
-import {
+  evaluateGraphQLResourcePolicy,
   GraphQLResourceAuthorization,
   GraphQLResourcePolicyError,
-  ResourceAction,
-  evaluateGraphQLResourcePolicy,
   protectGraphQLField,
+  ResourceAction,
 } from '../graphql.ts';
+import { Allow, HasRole, Owner, Policy, policyAuthorizationManager } from '../index.ts';
 
 @Policy('article')
 class ArticlePolicy {
@@ -44,16 +38,30 @@ describe('GraphQL Resource-Policy Bindings', () => {
 
     // Query read
     await expect(
-      evaluateGraphQLResourcePolicy(ArticlePolicy, null, { id: 'art-1' }, ctxAuthor, {
-        fieldName: 'getArticle',
-      }, { manager }),
+      evaluateGraphQLResourcePolicy(
+        ArticlePolicy,
+        null,
+        { id: 'art-1' },
+        ctxAuthor,
+        {
+          fieldName: 'getArticle',
+        },
+        { manager },
+      ),
     ).resolves.toBeUndefined();
 
     // Mutation update
     await expect(
-      evaluateGraphQLResourcePolicy(ArticlePolicy, null, { id: 'art-1' }, ctxAuthor, {
-        fieldName: 'updateArticle',
-      }, { manager }),
+      evaluateGraphQLResourcePolicy(
+        ArticlePolicy,
+        null,
+        { id: 'art-1' },
+        ctxAuthor,
+        {
+          fieldName: 'updateArticle',
+        },
+        { manager },
+      ),
     ).resolves.toBeUndefined();
   });
 
@@ -61,9 +69,16 @@ describe('GraphQL Resource-Policy Bindings', () => {
     const ctxOther = { user: { sub: 'user-other', roles: [] } };
 
     await expect(
-      evaluateGraphQLResourcePolicy(ArticlePolicy, null, { id: 'art-1' }, ctxOther, {
-        fieldName: 'updateArticle',
-      }, { manager }),
+      evaluateGraphQLResourcePolicy(
+        ArticlePolicy,
+        null,
+        { id: 'art-1' },
+        ctxOther,
+        {
+          fieldName: 'updateArticle',
+        },
+        { manager },
+      ),
     ).rejects.toThrow(GraphQLResourcePolicyError);
   });
 
@@ -72,24 +87,45 @@ describe('GraphQL Resource-Policy Bindings', () => {
 
     // List query
     await expect(
-      evaluateGraphQLResourcePolicy(ArticlePolicy, null, {}, ctxAdmin, {
-        fieldName: 'listArticles',
-      }, { manager }),
+      evaluateGraphQLResourcePolicy(
+        ArticlePolicy,
+        null,
+        {},
+        ctxAdmin,
+        {
+          fieldName: 'listArticles',
+        },
+        { manager },
+      ),
     ).resolves.toBeUndefined();
 
     // Delete mutation
     await expect(
-      evaluateGraphQLResourcePolicy(ArticlePolicy, null, { id: 'art-1' }, ctxAdmin, {
-        fieldName: 'deleteArticle',
-      }, { manager }),
+      evaluateGraphQLResourcePolicy(
+        ArticlePolicy,
+        null,
+        { id: 'art-1' },
+        ctxAdmin,
+        {
+          fieldName: 'deleteArticle',
+        },
+        { manager },
+      ),
     ).resolves.toBeUndefined();
   });
 
   it('fails closed when unauthenticated', async () => {
     await expect(
-      evaluateGraphQLResourcePolicy(ArticlePolicy, null, { id: 'art-1' }, {}, {
-        fieldName: 'getArticle',
-      }, { manager }),
+      evaluateGraphQLResourcePolicy(
+        ArticlePolicy,
+        null,
+        { id: 'art-1' },
+        {},
+        {
+          fieldName: 'getArticle',
+        },
+        { manager },
+      ),
     ).rejects.toThrow('Authentication is required');
   });
 
@@ -97,9 +133,16 @@ describe('GraphQL Resource-Policy Bindings', () => {
     const ctxAuthor = { user: { sub: 'user-author', roles: [] } };
 
     await expect(
-      evaluateGraphQLResourcePolicy(ArticlePolicy, null, {}, ctxAuthor, {
-        fieldName: 'updateArticle',
-      }, { manager }),
+      evaluateGraphQLResourcePolicy(
+        ArticlePolicy,
+        null,
+        {},
+        ctxAuthor,
+        {
+          fieldName: 'updateArticle',
+        },
+        { manager },
+      ),
     ).rejects.toThrow('Resource ID is missing');
   });
 
@@ -161,9 +204,16 @@ describe('GraphQL Resource-Policy Bindings', () => {
     const ctxAuthor = { user: { sub: 'user-author', roles: [] } };
 
     await expect(
-      evaluateGraphQLResourcePolicy(ArticlePolicy, null, { id: 'infra-error' }, ctxAuthor, {
-        fieldName: 'getArticle',
-      }, { manager }),
+      evaluateGraphQLResourcePolicy(
+        ArticlePolicy,
+        null,
+        { id: 'infra-error' },
+        ctxAuthor,
+        {
+          fieldName: 'getArticle',
+        },
+        { manager },
+      ),
     ).rejects.toThrow('Database connection failed');
   });
 
@@ -176,7 +226,9 @@ describe('GraphQL Resource-Policy Bindings', () => {
       action: 'read',
     });
 
-    const result = await protectedResolver(null, { id: 'art-1' }, ctxAuthor, { fieldName: 'article' });
+    const result = await protectedResolver(null, { id: 'art-1' }, ctxAuthor, {
+      fieldName: 'article',
+    });
     expect(result).toBe('Resolved art-1');
   });
 

--- a/packages/di-framework-authz/tests/graphql.test.ts
+++ b/packages/di-framework-authz/tests/graphql.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  Allow,
+  HasRole,
+  Owner,
+  Policy,
+  policyAuthorizationManager,
+} from '../index.ts';
+import {
+  GraphQLResourceAuthorization,
+  GraphQLResourcePolicyError,
+  ResourceAction,
+  evaluateGraphQLResourcePolicy,
+  protectGraphQLField,
+} from '../graphql.ts';
+
+@Policy('article')
+class ArticlePolicy {
+  @Allow('read', 'update')
+  @Owner({ subjectPath: 'subject.id', resourcePath: 'resource.authorId' })
+  authorAccess() {}
+
+  @Allow('read', 'list', 'create', 'delete')
+  @HasRole('admin')
+  adminAccess() {}
+}
+
+const mockProvider = {
+  async load(id: string) {
+    if (id === 'infra-error') throw new Error('Database connection failed');
+    if (id === 'art-1') return { id: 'art-1', authorId: 'user-author', title: 'Hello World' };
+    if (id === 'art-2') return { id: 'art-2', authorId: 'user-other', title: 'Private Post' };
+    return null;
+  },
+};
+
+const manager = policyAuthorizationManager({
+  providers: { article: mockProvider },
+});
+
+describe('GraphQL Resource-Policy Bindings', () => {
+  it('allows owner to read and update an article', async () => {
+    const ctxAuthor = { user: { sub: 'user-author', roles: [] } };
+
+    // Query read
+    await expect(
+      evaluateGraphQLResourcePolicy(ArticlePolicy, null, { id: 'art-1' }, ctxAuthor, {
+        fieldName: 'getArticle',
+      }, { manager }),
+    ).resolves.toBeUndefined();
+
+    // Mutation update
+    await expect(
+      evaluateGraphQLResourcePolicy(ArticlePolicy, null, { id: 'art-1' }, ctxAuthor, {
+        fieldName: 'updateArticle',
+      }, { manager }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('denies non-owner without admin role', async () => {
+    const ctxOther = { user: { sub: 'user-other', roles: [] } };
+
+    await expect(
+      evaluateGraphQLResourcePolicy(ArticlePolicy, null, { id: 'art-1' }, ctxOther, {
+        fieldName: 'updateArticle',
+      }, { manager }),
+    ).rejects.toThrow(GraphQLResourcePolicyError);
+  });
+
+  it('allows admin role for collection operations and member actions', async () => {
+    const ctxAdmin = { user: { sub: 'user-admin', claims: { roles: ['admin'] } } };
+
+    // List query
+    await expect(
+      evaluateGraphQLResourcePolicy(ArticlePolicy, null, {}, ctxAdmin, {
+        fieldName: 'listArticles',
+      }, { manager }),
+    ).resolves.toBeUndefined();
+
+    // Delete mutation
+    await expect(
+      evaluateGraphQLResourcePolicy(ArticlePolicy, null, { id: 'art-1' }, ctxAdmin, {
+        fieldName: 'deleteArticle',
+      }, { manager }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('fails closed when unauthenticated', async () => {
+    await expect(
+      evaluateGraphQLResourcePolicy(ArticlePolicy, null, { id: 'art-1' }, {}, {
+        fieldName: 'getArticle',
+      }, { manager }),
+    ).rejects.toThrow('Authentication is required');
+  });
+
+  it('fails closed when member action is missing a resource ID', async () => {
+    const ctxAuthor = { user: { sub: 'user-author', roles: [] } };
+
+    await expect(
+      evaluateGraphQLResourcePolicy(ArticlePolicy, null, {}, ctxAuthor, {
+        fieldName: 'updateArticle',
+      }, { manager }),
+    ).rejects.toThrow('Resource ID is missing');
+  });
+
+  it('supports custom idArg getter function and idField parent lookup', async () => {
+    const ctxAuthor = { user: { sub: 'user-author', roles: [] } };
+
+    // idArg as function
+    await expect(
+      evaluateGraphQLResourcePolicy(
+        ArticlePolicy,
+        null,
+        { input: { articleId: 'art-1' } },
+        ctxAuthor,
+        { fieldName: 'updateArticle' },
+        { manager, idArg: (args) => args.input?.articleId },
+      ),
+    ).resolves.toBeUndefined();
+
+    // idField on parent
+    await expect(
+      evaluateGraphQLResourcePolicy(
+        ArticlePolicy,
+        { articleId: 'art-1' },
+        {},
+        ctxAuthor,
+        { fieldName: 'updateArticle' },
+        { manager, idField: 'articleId' },
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('calls onDenied callback with denial information without exposing rule details to client error', async () => {
+    const ctxOther = { user: { sub: 'user-other', roles: [] } };
+    let capturedDenial: any;
+
+    await expect(
+      evaluateGraphQLResourcePolicy(
+        ArticlePolicy,
+        null,
+        { id: 'art-1' },
+        ctxOther,
+        { fieldName: 'updateArticle' },
+        {
+          manager,
+          onDenied: (denial) => {
+            capturedDenial = denial;
+            return new Error('Custom client error');
+          },
+        },
+      ),
+    ).rejects.toThrow('Custom client error');
+
+    expect(capturedDenial).toBeDefined();
+    expect(capturedDenial.resource).toBe('article');
+    expect(capturedDenial.action).toBe('update');
+  });
+
+  it('bubbles infrastructure errors from resource providers', async () => {
+    const ctxAuthor = { user: { sub: 'user-author', roles: [] } };
+
+    await expect(
+      evaluateGraphQLResourcePolicy(ArticlePolicy, null, { id: 'infra-error' }, ctxAuthor, {
+        fieldName: 'getArticle',
+      }, { manager }),
+    ).rejects.toThrow('Database connection failed');
+  });
+
+  it('works with protectGraphQLField resolver wrapper', async () => {
+    const ctxAuthor = { user: { sub: 'user-author', roles: [] } };
+    const rawResolver = async (_source: any, args: { id: string }) => `Resolved ${args.id}`;
+
+    const protectedResolver = protectGraphQLField(ArticlePolicy, rawResolver, {
+      manager,
+      action: 'read',
+    });
+
+    const result = await protectedResolver(null, { id: 'art-1' }, ctxAuthor, { fieldName: 'article' });
+    expect(result).toBe('Resolved art-1');
+  });
+
+  it('works with @GraphQLResourceAuthorization decorator and @ResourceAction', async () => {
+    class ResolverService {
+      @GraphQLResourceAuthorization(ArticlePolicy, { manager })
+      @ResourceAction('read')
+      async findOne(parent: any, args: { id: string }, ctx: any, info: any) {
+        return 'Article Found';
+      }
+    }
+
+    const service = new ResolverService();
+    const ctxAuthor = { user: { sub: 'user-author', roles: [] } };
+
+    const res = await service.findOne(null, { id: 'art-1' }, ctxAuthor, { fieldName: 'findOne' });
+    expect(res).toBe('Article Found');
+  });
+});


### PR DESCRIPTION
Closes #119.

## Summary

Adds `@di-framework/authz/graphql` entry point to connect `@di-framework/authz` resource policies to GraphQL queries, mutations, subscriptions, and field resolvers.

## Features Included

- Reuses the existing AST, evaluator, policy compiler, and `ResourceProvider` contracts from PR #116 without introducing a parallel policy language.
- `GraphQLResourceAuthorization` decorator, `protectGraphQLField` field resolver wrapper, and `ResourceAction` decorator.
- Safe action inference and resource ID resolution (from arguments, parent properties, or getter functions). Fail-closed behavior on missing or ambiguous resource IDs.
- Client error sanitization: decision details (`category`, `ruleIds`) stay in server logs/hooks (`onDenied`) and are never exposed to clients (returns standard `GraphQLResourcePolicyError` / `FORBIDDEN` / `UNAUTHENTICATED`).
- Full documentation and tests covering field wrappers, class decorators, provider loading, infrastructure error propagation, and denial callbacks.