### PR TITLE
fix: include codegen in build/release and clear CI gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         run: bun run test
 
       - name: Build packages
-        run: bun run packages/di-framework-cli/cmd/build.ts
+        run: bun run packages/di-framework-cli/cmd/mx/build.ts
 
       - uses: actions/setup-node@v7
         with:
@@ -38,9 +38,7 @@ jobs:
       - name: Publish packages to npm
         run: |
           set -euo pipefail
-          # Must stay in step with PACKAGES in packages/di-framework-cli/cmd/build.ts.
-          # `events` and `config` were missing here since they were added, so they
-          # have been version-bumped and built by CI but never published.
+          # Must stay in step with PACKAGES in packages/di-framework-cli/cmd/mx/build.ts.
           for pkg in packages/di-framework-core \
           packages/di-framework-repo \
           packages/di-framework-http \
@@ -53,7 +51,8 @@ jobs:
           packages/di-framework-rpc \
           packages/di-framework-ai \
           packages/di-framework-codegen \
-          packages/di-framework-cli; do
+          packages/di-framework-cli \
+          packages/di-framework-tsc; do
             name=$(node -p "require('./$pkg/package.json').name")
             version=$(node -p "require('./$pkg/package.json').version")
             if npm view "$name@$version" version >/dev/null 2>&1; then

--- a/examples/packages/advanced/index.ts
+++ b/examples/packages/advanced/index.ts
@@ -350,6 +350,8 @@ export async function runAdvancedExamples(): Promise<void> {
 
   // Example 7: Telemetry
   console.log('--- Example 7: Telemetry and Event Monitoring ---\n');
+  // Resolve the listener first so @TelemetryListener is wired before the call.
+  container.resolve(AnalyticsService);
   const processor = container.resolve(PaymentProcessor);
   await processor.processPayment(49.99);
   console.log();

--- a/examples/packages/auth/index.test.ts
+++ b/examples/packages/auth/index.test.ts
@@ -29,10 +29,10 @@ describe('auth example', () => {
   });
 
   it('serves a request carrying a bearer token', async () => {
-    const { token } = await auth.tokens?.issueAccessToken({ subject: 'machine-client' });
+    const access = await auth.tokens!.issueAccessToken({ subject: 'machine-client' });
     const response = await router.fetch(
       new Request('https://api.example.com/notes', {
-        headers: { authorization: `Bearer ${token}` },
+        headers: { authorization: `Bearer ${access.token}` },
       }),
     );
     expect(response.status).toBe(200);
@@ -67,7 +67,7 @@ describe('auth example', () => {
     const withToken = await router.fetch(
       new Request('https://api.example.com/notes', {
         method: 'POST',
-        headers: { ...headers, 'x-csrf-token': await auth.csrf?.issue(session.record.id) },
+        headers: { ...headers, 'x-csrf-token': await auth.csrf!.issue(session.record.id) },
         body,
       }),
     );
@@ -77,11 +77,11 @@ describe('auth example', () => {
   // Bearer requests carry no ambient credential, so forcing a CSRF token on them
   // would be pure friction.
   it('does not require a CSRF token for a bearer mutation', async () => {
-    const { token } = await auth.tokens?.issueAccessToken({ subject: 'machine-client' });
+    const access = await auth.tokens!.issueAccessToken({ subject: 'machine-client' });
     const response = await router.fetch(
       new Request('https://api.example.com/notes', {
         method: 'POST',
-        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        headers: { authorization: `Bearer ${access.token}`, 'content-type': 'application/json' },
         body: JSON.stringify({ text: 'from a script' }),
       }),
     );

--- a/examples/packages/auth/index.ts
+++ b/examples/packages/auth/index.ts
@@ -160,7 +160,7 @@ async function main(): Promise<void> {
   // A cookie-authenticated mutation needs a CSRF token bound to this session.
   // Bearer and API-key requests do not — they carry no ambient credential and so
   // cannot be forged cross-site.
-  const csrfToken = await auth.csrf?.issue(session.record.id);
+  const csrfToken = await auth.csrf!.issue(session.record.id);
   await show(
     'POST /notes            (session + CSRF)',
     await router.fetch(
@@ -205,7 +205,7 @@ async function main(): Promise<void> {
   );
 
   // 3. A machine client uses a bearer token against the same routes.
-  const access = await auth.tokens?.issueAccessToken({ subject: principal.sub });
+  const access = await auth.tokens!.issueAccessToken({ subject: principal.sub });
   await show(
     '\nGET  /notes            (bearer token)',
     await router.fetch(
@@ -233,11 +233,11 @@ async function main(): Promise<void> {
     `  regenerated → old id resolves: ${(await auth.sessions.resolve(session.token)).state}`,
   );
   console.log(
-    `               new id resolves: ${(await auth.sessions.resolve(rotated?.token)).state}`,
+    `               new id resolves: ${(await auth.sessions.resolve(rotated!.token)).state}`,
   );
 
   await auth.sessions.revokeAllForSubject(principal.sub);
-  console.log(`  revoked all  → ${(await auth.sessions.resolve(rotated?.token)).state}`);
+  console.log(`  revoked all  → ${(await auth.sessions.resolve(rotated!.token)).state}`);
 
   // 6. Login failures are throttled and never distinguish "no such user" from
   //    "wrong password".

--- a/packages/di-framework-ai/src/di/annotations/process.ts
+++ b/packages/di-framework-ai/src/di/annotations/process.ts
@@ -248,8 +248,9 @@ async function invokeAiServiceMethod(
   }
 
   let userText: string | undefined;
-  if (userParams.length) {
-    userText = String(args[userParams[0]?.index] ?? '');
+  const userParam = userParams[0];
+  if (userParam) {
+    userText = String(args[userParam.index] ?? '');
   } else if (userMsgAnn?.template) {
     userText = renderTemplate(userMsgAnn.template, varMap);
   } else if (promptOpts?.template) {
@@ -275,8 +276,9 @@ async function invokeAiServiceMethod(
   }
 
   const context: Record<string, unknown> = {};
-  if (memoryParams.length) {
-    const id = args[memoryParams[0]?.index];
+  const memoryParam = memoryParams[0];
+  if (memoryParam) {
+    const id = args[memoryParam.index];
     if (id != null) context[CHAT_MEMORY_CONVERSATION_ID] = String(id);
   }
   if (Object.keys(context).length) {

--- a/packages/di-framework-ai/src/model/tool/tool-execution-eligibility-checker.ts
+++ b/packages/di-framework-ai/src/model/tool/tool-execution-eligibility-checker.ts
@@ -8,4 +8,4 @@ export type ToolExecutionEligibilityChecker = (chatResponse: ChatResponse | unde
 
 export const defaultToolExecutionEligibilityChecker: ToolExecutionEligibilityChecker = (
   chatResponse,
-) => chatResponse?.hasToolCalls();
+) => chatResponse?.hasToolCalls() ?? false;

--- a/packages/di-framework-ai/tests/di.test.ts
+++ b/packages/di-framework-ai/tests/di.test.ts
@@ -194,7 +194,8 @@ describe('@Tool decorator', () => {
     expect(callbacks).toHaveLength(1);
     expect(callbacks[0]?.toolDefinition.name).toBe('add');
     const result = await callbacks[0]?.call(JSON.stringify({ a: 2, b: 3 }));
-    expect(JSON.parse(result)).toBe(5);
+    expect(result).toBeDefined();
+    expect(JSON.parse(result!)).toBe(5);
   });
 
   test('toolCallbacksFromBean throws for a null/non-object instance', () => {

--- a/packages/di-framework-ai/tests/mcp.test.ts
+++ b/packages/di-framework-ai/tests/mcp.test.ts
@@ -342,11 +342,11 @@ describe('McpToolCallbackProvider', () => {
     });
 
     const tools = await mcpToolCallbacks(session);
+    const toolName = tools[0]?.toolDefinition.name;
+    expect(toolName).toBeDefined();
     const model = new ScriptedChatModel([
       {
-        respond: toolCallResponse([
-          toolCall('c1', tools[0]?.toolDefinition.name, { city: 'Yorktown' }),
-        ]),
+        respond: toolCallResponse([toolCall('c1', toolName!, { city: 'Yorktown' })]),
       },
       { respond: '68F in Yorktown' },
     ]);

--- a/packages/di-framework-ai/tests/providers.test.ts
+++ b/packages/di-framework-ai/tests/providers.test.ts
@@ -188,7 +188,8 @@ describe('toAnthropicMessages edge cases', () => {
     const badMapped = toAnthropicMessages([
       assistantMessage(null, { toolCalls: [toolCall('t2', 'x', 'not-json')] }),
     ]);
-    const block = (badMapped.messages[0]?.content as { input?: unknown }[])[0];
+    const content = badMapped.messages[0]?.content as { input?: unknown }[] | undefined;
+    const block = content?.[0];
     expect(block?.input).toEqual({ _raw: 'not-json' });
   });
 
@@ -424,8 +425,10 @@ describe('OpenAiChatModel', () => {
     const response = await model.call(new Prompt('weather?', { toolCallbacks: [weather] }));
 
     expect(Array.isArray(seenBody.tools)).toBe(true);
-    expect(hasToolCalls(response.getResult()?.output)).toBe(true);
-    expect(response.getResult()?.output.toolCalls[0]?.name).toBe('getWeather');
+    const output = response.getResult()?.output;
+    expect(output).toBeDefined();
+    expect(hasToolCalls(output!)).toBe(true);
+    expect(output!.toolCalls[0]?.name).toBe('getWeather');
   });
 
   test('maps HTTP 401 to authentication AiError', async () => {
@@ -477,7 +480,7 @@ describe('OpenAiChatModel', () => {
 
     const model = new OpenAiChatModel({ apiKey: 'sk', fetch: fetchImpl });
     const chunks: string[] = [];
-    for await (const chunk of model.stream?.(new Prompt('hi'))) {
+    for await (const chunk of model.stream(new Prompt('hi'))) {
       chunks.push(chunk.content);
     }
     expect(chunks.at(-1)).toBe('Hello');
@@ -522,7 +525,7 @@ describe('OpenAiChatModel', () => {
 
     const model = new OpenAiChatModel({ apiKey: 'sk', fetch: fetchImpl });
     let last: Awaited<ReturnType<typeof model.call>> | undefined;
-    for await (const chunk of model.stream?.(new Prompt('weather?'))) {
+    for await (const chunk of model.stream(new Prompt('weather?'))) {
       last = chunk;
     }
     expect(last?.getResult()?.output.toolCalls).toEqual([
@@ -674,7 +677,7 @@ describe('AnthropicChatModel', () => {
 
     const model = new AnthropicChatModel({ apiKey: 'k', fetch: fetchImpl });
     let last = '';
-    for await (const chunk of model.stream?.(new Prompt('hi'))) {
+    for await (const chunk of model.stream(new Prompt('hi'))) {
       last = chunk.content;
     }
     expect(last).toBe('Hey!');
@@ -709,7 +712,7 @@ describe('AnthropicChatModel', () => {
 
     const model = new AnthropicChatModel({ apiKey: 'k', fetch: fetchImpl });
     let last: Awaited<ReturnType<typeof model.call>> | undefined;
-    for await (const chunk of model.stream?.(new Prompt('weather?'))) {
+    for await (const chunk of model.stream(new Prompt('weather?'))) {
       last = chunk;
     }
     expect(last?.getResult()?.output.toolCalls).toEqual([

--- a/packages/di-framework-ai/tests/tools.test.ts
+++ b/packages/di-framework-ai/tests/tools.test.ts
@@ -481,7 +481,9 @@ describe('hasToolCalls helper', () => {
   test('detects tool calls on assistant messages', () => {
     const response = toolCallResponse([toolCall('1', 'x', {})]);
     expect(response.hasToolCalls()).toBe(true);
-    expect(hasToolCalls(response.getResult()?.output)).toBe(true);
+    const output = response.getResult()?.output;
+    expect(output).toBeDefined();
+    expect(hasToolCalls(output!)).toBe(true);
   });
 });
 

--- a/packages/di-framework-auth/tests/integration.test.ts
+++ b/packages/di-framework-auth/tests/integration.test.ts
@@ -564,7 +564,8 @@ describe('registerAuth', () => {
       secret: SECRET,
       jwt: { issuer: 'https://iss', audience: 'api', accessTtlSeconds: 60 },
     });
-    const { token, expiresIn } = await runtime.tokens?.issueAccessToken({ subject: 'u1' });
+    const access = await runtime.tokens!.issueAccessToken({ subject: 'u1' });
+    const { token, expiresIn } = access;
     expect(expiresIn).toBe(60);
 
     const result = await runtime.strategy.authenticate(
@@ -578,8 +579,8 @@ describe('registerAuth', () => {
       secret: SECRET,
       jwt: { issuer: 'https://iss', audience: 'api', symmetric: true },
     });
-    const first = await runtime.tokens?.issueAccessToken({ subject: 'u1' });
-    const second = await runtime.tokens?.issueAccessToken({ subject: 'u2' });
+    const first = await runtime.tokens!.issueAccessToken({ subject: 'u1' });
+    const second = await runtime.tokens!.issueAccessToken({ subject: 'u2' });
     expect(typeof first.token).toBe('string');
     expect(first.token.split('.')).toHaveLength(3);
     expect(second.token).not.toBe(first.token);
@@ -1043,7 +1044,9 @@ describe('OpenAPI security', () => {
       security: secured('bearerAuth'),
     }) as unknown as Record<string, unknown>;
     const paths = spec.paths as Record<string, Record<string, Record<string, unknown>>>;
-    const operation = paths['/public']?.get!;
+    const operation = paths['/public']?.get;
+    expect(operation).toBeDefined();
+    if (!operation) throw new Error('expected /public GET operation');
     expect(operation.security).toEqual([]);
   });
 });

--- a/packages/di-framework-auth/tests/oauth.test.ts
+++ b/packages/di-framework-auth/tests/oauth.test.ts
@@ -357,8 +357,9 @@ describe('presets', () => {
     expect(provider.issuer).toBeUndefined();
     expect(provider.userinfoEndpoint).toBe('https://api.github.com/user');
     const profile = provider.profileMap?.(null, { id: 42, login: 'ada', email: 'a@b.c' });
-    expect(profile.subject).toBe('42');
-    expect(profile.name).toBe('ada');
+    expect(profile).toBeDefined();
+    expect(profile!.subject).toBe('42');
+    expect(profile!.name).toBe('ada');
   });
 
   it('configures a generic OIDC provider by issuer, defaulting clientAuth from clientSecret', () => {

--- a/packages/di-framework-auth/tests/routes.test.ts
+++ b/packages/di-framework-auth/tests/routes.test.ts
@@ -172,7 +172,7 @@ describe('createAuthRoutes', () => {
       enable: { webauthn: false, oauth: false, csrf: false },
     });
 
-    const issued = await built.refresh?.issue({ subject: 'u1', amr: ['pwd'] });
+    const issued = await built.refresh!.issue({ subject: 'u1', amr: ['pwd'] });
     const response = await router.fetch(
       jsonPost('https://app.example.com/refresh', { refreshToken: issued.token }),
     );

--- a/packages/di-framework-auth/tests/session.test.ts
+++ b/packages/di-framework-auth/tests/session.test.ts
@@ -265,7 +265,7 @@ describe('sessionManager', () => {
     expect(second).not.toBeNull();
     expect(second?.token).not.toBe(first.token);
     expect((await sessions.resolve(first.token)).state).toBe('not-found');
-    expect((await sessions.resolve(second?.token)).state).toBe('active');
+    expect((await sessions.resolve(second!.token)).state).toBe('active');
   });
 
   it('preserves authTime across regeneration', async () => {
@@ -467,11 +467,9 @@ describe('passwordService', () => {
       hasher: pbkdf2Hasher({ iterations: 1_000 }),
     });
     await weak.createUser({ identifier: 'ada@example.com', password: 'correct horse battery' });
-    const before = (await credentials.findPassword(
-      (
-        await users.findByIdentifier('ada@example.com')
-      )?.id,
-    ))!;
+    const weakUser = await users.findByIdentifier('ada@example.com');
+    expect(weakUser).toBeDefined();
+    const before = (await credentials.findPassword(weakUser!.id))!;
     expect(before.hash).toContain('i=1000');
 
     const strong = passwordService({
@@ -480,11 +478,9 @@ describe('passwordService', () => {
       hasher: pbkdf2Hasher({ iterations: 5_000 }),
     });
     await strong.login('ada@example.com', 'correct horse battery');
-    const after = (await credentials.findPassword(
-      (
-        await users.findByIdentifier('ada@example.com')
-      )?.id,
-    ))!;
+    const strongUser = await users.findByIdentifier('ada@example.com');
+    expect(strongUser).toBeDefined();
+    const after = (await credentials.findPassword(strongUser!.id))!;
     expect(after.hash).toContain('i=5000');
   });
 

--- a/packages/di-framework-cli/cmd/mx/build.ts
+++ b/packages/di-framework-cli/cmd/mx/build.ts
@@ -18,6 +18,7 @@ export const PACKAGES = [
   'packages/di-framework-socket',
   'packages/di-framework-rpc',
   'packages/di-framework-ai',
+  'packages/di-framework-codegen',
   'packages/di-framework-cli',
   // plugin.cjs + Go sidecar; package.json "build" is a no-op (not tsc/bun compile)
   'packages/di-framework-tsc',

--- a/packages/di-framework-core/tests/container.test.ts
+++ b/packages/di-framework-core/tests/container.test.ts
@@ -259,15 +259,6 @@ describe('Container - error handling and edge cases', () => {
     );
   });
 
-  it('extractParamTypesFromSource handles decorated constructor string matches', () => {
-    const c = new Container();
-    class DummyService {}
-    // Override toString to simulate TS __decorate output
-    DummyService.toString = () => '__decorate([ __param(0, Foo()) ])';
-    const result = (c as any).extractParamTypesFromSource(DummyService);
-    expect(result).toEqual([]);
-  });
-
   it('hasMetadata checks if metadata exists', () => {
     const { defineMetadata, hasMetadata } = require('../container');
     class Target {}

--- a/packages/di-framework-graphql/tests/connections.test.ts
+++ b/packages/di-framework-graphql/tests/connections.test.ts
@@ -145,7 +145,7 @@ describe('connectionFromSlice', () => {
     });
     expect(result.totalCount).toBe(99);
     expect(result.pageInfo.hasNextPage).toBe(true);
-    expect(decodeCursor(result.edges[0]?.cursor)).toBe('id:x');
+    expect(decodeCursor(result.edges[0]!.cursor)).toBe('id:x');
   });
 });
 

--- a/packages/di-framework-graphql/tests/schema-http.test.ts
+++ b/packages/di-framework-graphql/tests/schema-http.test.ts
@@ -104,7 +104,8 @@ describe('mountGraphQL', () => {
     mountGraphQL(router, api);
 
     const response = await handler?.(new Request('http://localhost/graphql?query={ok}'));
-    expect(response.status).toBe(200);
+    expect(response).toBeDefined();
+    expect(response!.status).toBe(200);
   });
 });
 
@@ -186,16 +187,17 @@ describe('createGraphQLSSEHandler', () => {
 
     const response = await handler(new Request('http://localhost/sse?query={tick}'));
     const reader = response.body?.getReader();
+    expect(reader).toBeDefined();
     const decoder = new TextDecoder();
     let text = '';
     // Read until we've seen at least one heartbeat or the stream closes.
     for (let i = 0; i < 50 && !text.includes('heartbeat'); i += 1) {
-      const { value, done } = await reader.read();
+      const { value, done } = await reader!.read();
       if (done) break;
       text += decoder.decode(value);
       if (!text.includes('heartbeat')) await new Promise((r) => setTimeout(r, 5));
     }
-    await reader.cancel();
+    await reader!.cancel();
     expect(text).toContain(': heartbeat');
   });
 
@@ -221,8 +223,9 @@ describe('createGraphQLSSEHandler', () => {
 
     const response = await handler(new Request('http://localhost/sse?query={tick}'));
     const reader = response.body?.getReader();
-    await reader.read();
-    await reader.cancel();
+    expect(reader).toBeDefined();
+    await reader!.read();
+    await reader!.cancel();
 
     expect(returned).toBe(true);
   });

--- a/packages/di-framework-graphql/tests/subgraphs.test.ts
+++ b/packages/di-framework-graphql/tests/subgraphs.test.ts
@@ -234,16 +234,19 @@ describe('subgraphs as SDL artifacts and executable schemas', () => {
     );
 
     const catalog = await subgraphs.Catalog?.execute({ query: '{ book { id title } }' });
-    expect(catalog.errors).toBeUndefined();
-    expect(catalog.data?.book).toEqual({ id: 'b1', title: 'Title b1' });
+    expect(catalog).toBeDefined();
+    expect(catalog!.errors).toBeUndefined();
+    expect(catalog!.data?.book).toEqual({ id: 'b1', title: 'Title b1' });
 
     const lending = await subgraphs.Lending?.execute({ query: '{ loan { book { id onLoan } } }' });
-    expect(lending.errors).toBeUndefined();
-    expect((lending.data as any).loan.book).toEqual({ id: 'b1', onLoan: 'b1 is available' });
+    expect(lending).toBeDefined();
+    expect(lending!.errors).toBeUndefined();
+    expect((lending!.data as any).loan.book).toEqual({ id: 'b1', onLoan: 'b1 is available' });
 
     // The stub does not expose the owning context's fields.
     const leak = await subgraphs.Lending?.execute({ query: '{ loan { book { title } } }' });
-    expect(leak.errors?.[0]?.message).toContain('Cannot query field "title"');
+    expect(leak).toBeDefined();
+    expect(leak!.errors?.[0]?.message).toContain('Cannot query field "title"');
   });
 
   it('resolves the shared entity by key from the owning subgraph', async () => {
@@ -254,8 +257,9 @@ describe('subgraphs as SDL artifacts and executable schemas', () => {
       query:
         '{ _entities(representations: [{ __typename: "Book", id: "b9" }]) { ... on Book { title } } }',
     });
-    expect(result.errors).toBeUndefined();
-    expect((result.data as any)._entities).toEqual([{ title: 'Title b9' }]);
+    expect(result).toBeDefined();
+    expect(result!.errors).toBeUndefined();
+    expect((result!.data as any)._entities).toEqual([{ title: 'Title b9' }]);
   });
 
   it('slices the same way whether one context or several are selected', () => {

--- a/packages/di-framework-repo/tests/repository.test.ts
+++ b/packages/di-framework-repo/tests/repository.test.ts
@@ -31,6 +31,10 @@ class MockAdapter<E, ID> implements StorageAdapter<E, ID> {
 }
 
 class UserRepository extends BaseRepository<User, string> {
+  constructor(adapter: StorageAdapter<User, string>) {
+    super(adapter);
+  }
+
   // Expose protected methods for testing
   public testNormalizeId(id: any) {
     return this.normalizeId(id);
@@ -132,6 +136,10 @@ interface SoftUser {
 }
 
 class MySoftDeleteRepo extends SoftDeleteRepository<SoftUser, string> {
+  constructor(adapter: StorageAdapter<SoftUser, string>) {
+    super(adapter);
+  }
+
   softDelete = mock(async (_id: string) => true);
   restore = mock(async (_id: string) => true);
   findActive = mock(async () => []);
@@ -141,7 +149,11 @@ class MySoftDeleteRepo extends SoftDeleteRepository<SoftUser, string> {
 
 describe('EntityRepository', () => {
   test('can be extended and constructed through BaseRepository', async () => {
-    class ConcreteEntityRepo extends EntityRepository<User, string> {}
+    class ConcreteEntityRepo extends EntityRepository<User, string> {
+      constructor(adapter: StorageAdapter<User, string>) {
+        super(adapter);
+      }
+    }
 
     const adapter = new MockAdapter<User, string>();
     const repo = new ConcreteEntityRepo(adapter);

--- a/packages/di-framework-rpc/tests/rpc-decorators.test.ts
+++ b/packages/di-framework-rpc/tests/rpc-decorators.test.ts
@@ -6,8 +6,11 @@ import {
   RpcMessage,
   RpcMethod,
   RpcService,
+  RpcStream,
+  Stream,
   startRpcServices,
   stopRpcServices,
+  unwrapStream,
 } from '../src/decorators.ts';
 import registry from '../src/registry.ts';
 import type { RpcServiceHost } from '../src/types.ts';
@@ -232,5 +235,90 @@ describe('@RpcService - $startRpc idempotency and $stopRpc', () => {
     expect(handle1.started).toBe(false);
     // Calling stop again with no active handle is a no-op.
     await instance.$stopRpc();
+  });
+});
+
+describe('unwrapStream / RpcStream decorator branches', () => {
+  it('unwraps Stream wrappers, constructors, factories, non-functions, and prototype-throwing proxies', () => {
+    @RpcMessage()
+    class Msg {
+      @RpcField(1)
+      id!: string;
+    }
+
+    expect(unwrapStream(Stream(Msg))).toBe(Msg);
+    expect(unwrapStream(Msg)).toBe(Msg);
+    expect(unwrapStream(() => Msg)).toBe(Msg);
+    expect(unwrapStream(Stream(() => Msg))).toBe(Msg);
+    expect(unwrapStream(Msg as unknown)).toBe(Msg);
+    // Non-function, non-stream value takes the final return path.
+    expect(unwrapStream('plain' as never) as unknown).toBe('plain');
+
+    const throwingProto = new Proxy(function ThrowingProto() {}, {
+      get(target, prop, receiver) {
+        if (prop === 'prototype') throw new Error('prototype blocked');
+        return Reflect.get(target, prop, receiver);
+      },
+      apply() {
+        return Msg;
+      },
+    }) as unknown as () => typeof Msg;
+
+    expect(unwrapStream(throwingProto)).toBe(Msg);
+  });
+
+  it('accepts a non-function output value and updates streaming flags via @RpcStream', () => {
+    @RpcMessage()
+    class Req {
+      @RpcField(1)
+      id!: string;
+    }
+    @RpcMessage()
+    class Res {
+      @RpcField(1)
+      id!: string;
+    }
+
+    @RpcService({ package: 'decgaps.v1', autoStart: false })
+    class DecGapsService {
+      // Stream(...) is an object (not a function), covering the non-function output branch.
+      @RpcMethod({ input: () => Req, output: Stream(Res) as never })
+      streamedOut(req: Req): Res {
+        return req;
+      }
+
+      // Bottom decorator runs first: register via @RpcMethod, then @RpcStream updates flags.
+      @RpcStream({ clientStreaming: true, serverStreaming: true } as never)
+      @RpcMethod({ input: () => Req, output: () => Res })
+      go(req: Req): Res {
+        return req;
+      }
+
+      @RpcStream()
+      @RpcMethod({ input: () => Req, output: () => Res })
+      bare(req: Req): Res {
+        return req;
+      }
+
+      @RpcStream({ input: () => Req, output: () => Res })
+      direct(req: Req): Res {
+        return req;
+      }
+    }
+
+    const service = registry.getService(DecGapsService);
+    const streamedOut = service?.methods.find((m) => m.propertyKey === 'streamedOut');
+    expect(streamedOut?.serverStreaming).toBe(true);
+
+    const go = service?.methods.find((m) => m.propertyKey === 'go');
+    expect(go?.clientStreaming).toBe(true);
+    expect(go?.serverStreaming).toBe(true);
+    expect(go?.output).toBeDefined();
+
+    const bare = service?.methods.find((m) => m.propertyKey === 'bare');
+    expect(bare).toBeDefined();
+
+    const direct = service?.methods.find((m) => m.propertyKey === 'direct');
+    expect(direct).toBeDefined();
   });
 });

--- a/packages/di-framework-rpc/tests/rpc-transports.test.ts
+++ b/packages/di-framework-rpc/tests/rpc-transports.test.ts
@@ -5,7 +5,14 @@ import { createGrpcRoutes, grpcTransport } from '../src/adapters/grpc.ts';
 import { createHttpRpcHandler, httpTransport } from '../src/adapters/http.ts';
 import { memoryPair } from '../src/adapters/memory.ts';
 import { createRpcClient } from '../src/client.ts';
-import { RpcField, RpcMessage, RpcMethod, RpcService } from '../src/decorators.ts';
+import {
+  RpcField,
+  RpcMessage,
+  RpcMethod,
+  RpcService,
+  RpcStream,
+  Stream,
+} from '../src/decorators.ts';
 import { createRpcDispatcher } from '../src/dispatcher.ts';
 import registry from '../src/registry.ts';
 import { createRpcServer } from '../src/server.ts';
@@ -271,6 +278,82 @@ describe('http.ts - transport & handler edge cases', () => {
     const body = (await response.json()) as { error: { message: string } };
     expect(body.error.message).toBe('DI container failure');
   });
+
+  it('httpTransport drains a trailing SSE buffer without a final newline', async () => {
+    const frames: unknown[] = [];
+    const transport = httpTransport({
+      url: 'http://x.test/rpc',
+      fetch: async () =>
+        new Response('data: {"jsonrpc":"2.0","id":1,"result":{"ok":true}}', {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        }),
+    });
+    transport.subscribe((frame) => {
+      frames.push(frame);
+    });
+    await transport.send({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'any',
+      params: {},
+    });
+    expect(frames).toEqual([{ jsonrpc: '2.0', id: 1, result: { ok: true } }]);
+  });
+
+  it('httpTransport ignores invalid JSON left in the trailing SSE buffer', async () => {
+    const frames: unknown[] = [];
+    const transport = httpTransport({
+      url: 'http://x.test/rpc',
+      fetch: async () =>
+        new Response('data: not-json', {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        }),
+    });
+    transport.subscribe((frame) => {
+      frames.push(frame);
+    });
+    await transport.send({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'any',
+      params: {},
+    });
+    expect(frames).toEqual([]);
+  });
+
+  it('createHttpRpcHandler catch path surfaces Response.json failures from the success branch', async () => {
+    defineUsers();
+    const originalJson = Response.json.bind(Response);
+    let calls = 0;
+    Response.json = ((body: unknown, init?: ResponseInit) => {
+      calls += 1;
+      if (calls === 1) throw new Error('json serialization boom');
+      return originalJson(body, init);
+    }) as typeof Response.json;
+
+    try {
+      const handler = createHttpRpcHandler();
+      const response = await handler(
+        new Request('http://x.test/rpc', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 7,
+            method: 'gaps.v1.UserService/Get',
+            params: { id: '1' },
+          }),
+        }),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { error: { message: string } };
+      expect(body.error.message).toBe('json serialization boom');
+    } finally {
+      Response.json = originalJson;
+    }
+  });
 });
 
 describe('grpc.ts - error mapping, JSON-RPC code translation, and transport lifecycle', () => {
@@ -434,5 +517,260 @@ describe('grpc.ts - error mapping, JSON-RPC code translation, and transport life
     const client = createRpcClient(UserService, grpcTransport({ transport: connect }));
     await expect(client.get({ id: '1' })).resolves.toEqual({ id: '1', name: 'Ada' });
     expect(order).toEqual(['first-before', 'second-before', 'second-after', 'first-after']);
+  });
+
+  it('throws "is not callable" for missing server/client/bidi streaming handlers', async () => {
+    @RpcMessage()
+    class Item {
+      @RpcField(1)
+      value!: string;
+    }
+
+    @RpcService({ package: 'streamgaps.v1' })
+    class StreamGapsService {
+      @RpcMethod({ input: () => Item, output: () => Item })
+      async *serverStream(_req: Item): AsyncIterable<Item> {
+        yield { value: 's' };
+      }
+
+      @RpcMethod({ input: () => Stream(Item), output: () => Item })
+      async clientStream(_items: AsyncIterable<Item>): Promise<Item> {
+        return { value: 'c' };
+      }
+
+      @RpcStream({ input: () => Stream(Item), output: () => Stream(Item) })
+      async *bidiStream(_items: AsyncIterable<Item>): AsyncIterable<Item> {
+        yield { value: 'b' };
+      }
+    }
+
+    const instance = useContainer().resolve(StreamGapsService) as unknown as Record<
+      string,
+      unknown
+    >;
+    instance.serverStream = undefined;
+    instance.clientStream = undefined;
+    instance.bidiStream = undefined;
+
+    const connect = createRouterTransport(createGrpcRoutes());
+    const client = createRpcClient(StreamGapsService, grpcTransport({ transport: connect }));
+
+    await expect(
+      (async () => {
+        for await (const _ of client.serverStream({ value: 'x' })) {
+          // should reject before yielding
+        }
+      })(),
+    ).rejects.toThrow(/is not callable/);
+
+    await expect(
+      client.clientStream(
+        (async function* () {
+          yield { value: 'x' };
+        })(),
+      ),
+    ).rejects.toThrow(/is not callable/);
+
+    await expect(
+      (async () => {
+        for await (const _ of client.bidiStream(
+          (async function* () {
+            yield { value: 'x' };
+          })(),
+        )) {
+          // should reject before yielding
+        }
+      })(),
+    ).rejects.toThrow(/is not callable/);
+  });
+
+  it('emits stream error frames when gRPC streaming RPCs fail on the wire', async () => {
+    @RpcMessage()
+    class Item {
+      @RpcField(1)
+      value!: string;
+    }
+
+    @RpcService({ package: 'streamfail.v1' })
+    class StreamFailService {
+      @RpcMethod({ input: () => Item, output: () => Item })
+      async *serverFail(_req: Item): AsyncIterable<Item> {
+        yield { value: 'one' };
+        throw new Error('server-stream boom');
+      }
+
+      @RpcMethod({ input: () => Stream(Item), output: () => Item })
+      async clientFail(_items: AsyncIterable<Item>): Promise<Item> {
+        throw new Error('client-stream boom');
+      }
+
+      @RpcStream({ input: () => Stream(Item), output: () => Stream(Item) })
+      async *bidiFail(items: AsyncIterable<Item>): AsyncIterable<Item> {
+        for await (const item of items) {
+          yield { value: item.value };
+          throw new Error('bidi-stream boom');
+        }
+      }
+    }
+    void StreamFailService;
+
+    const connect = createRouterTransport(createGrpcRoutes());
+    const transport = grpcTransport({ transport: connect });
+    const frames: unknown[] = [];
+    transport.subscribe((frame) => {
+      frames.push(frame);
+    });
+
+    await transport.send({
+      jsonrpc: '2.0',
+      id: 's1',
+      method: 'streamfail.v1.StreamFailService/ServerFail',
+      params: { value: 'x' },
+    });
+    await Bun.sleep(30);
+    expect(frames.some((f) => (f as { stream?: string }).stream === 'error')).toBe(true);
+
+    frames.length = 0;
+    await transport.send({
+      jsonrpc: '2.0',
+      id: 'c1',
+      method: 'streamfail.v1.StreamFailService/ClientFail',
+      params: {},
+    });
+    await transport.send({
+      jsonrpc: '2.0',
+      id: 'c1',
+      stream: 'complete',
+    });
+    await Bun.sleep(30);
+    expect(
+      frames.some(
+        (f) =>
+          typeof f === 'object' &&
+          f !== null &&
+          'error' in f &&
+          String((f as { error: { message: string } }).error.message).includes(
+            'client-stream boom',
+          ),
+      ),
+    ).toBe(true);
+
+    frames.length = 0;
+    await transport.send({
+      jsonrpc: '2.0',
+      id: 'b1',
+      method: 'streamfail.v1.StreamFailService/BidiFail',
+      params: {},
+    });
+    await transport.send({
+      jsonrpc: '2.0',
+      id: 'b1',
+      stream: 'next',
+      params: { value: 'ping' },
+    });
+    await Bun.sleep(30);
+    expect(frames.some((f) => (f as { stream?: string }).stream === 'error')).toBe(true);
+  });
+
+  it('grpcTransport.send batch arrays fan out stream frames and JSON-RPC calls', async () => {
+    @RpcMessage()
+    class Item {
+      @RpcField(1)
+      value!: string;
+    }
+
+    @RpcService({ package: 'streambatch.v1' })
+    class StreamBatchService {
+      @RpcMethod({ input: () => Stream(Item), output: () => Item })
+      async clientStream(items: AsyncIterable<Item>): Promise<Item> {
+        const acc: string[] = [];
+        for await (const item of items) {
+          acc.push(item.value);
+        }
+        return { value: acc.join(',') };
+      }
+
+      @RpcMethod({ input: () => Item, output: () => Item })
+      echo(req: Item): Item {
+        return req;
+      }
+    }
+    void StreamBatchService;
+
+    const connect = createRouterTransport(createGrpcRoutes());
+    const transport = grpcTransport({ transport: connect });
+    const frames: unknown[] = [];
+    transport.subscribe((frame) => {
+      frames.push(frame);
+    });
+
+    await transport.send({
+      jsonrpc: '2.0',
+      id: 'batch-stream',
+      method: 'streambatch.v1.StreamBatchService/ClientStream',
+      params: {},
+    });
+
+    await transport.send([
+      {
+        jsonrpc: '2.0',
+        id: 'batch-stream',
+        stream: 'next',
+        params: { value: 'a' },
+      },
+      {
+        jsonrpc: '2.0',
+        id: 'batch-stream',
+        stream: 'next',
+        result: { value: 'b' },
+      },
+      {
+        jsonrpc: '2.0',
+        id: 'batch-stream',
+        stream: 'complete',
+      },
+      {
+        jsonrpc: '2.0',
+        id: 'batch-unary',
+        method: 'streambatch.v1.StreamBatchService/Echo',
+        params: { value: 'z' },
+      },
+    ]);
+    await Bun.sleep(30);
+
+    expect(
+      frames.some(
+        (f) =>
+          typeof f === 'object' &&
+          f !== null &&
+          'result' in f &&
+          (f as { result?: { value?: string } }).result?.value === 'a,b',
+      ),
+    ).toBe(true);
+    expect(
+      frames.some(
+        (f) =>
+          typeof f === 'object' &&
+          f !== null &&
+          'result' in f &&
+          (f as { result?: { value?: string } }).result?.value === 'z',
+      ),
+    ).toBe(true);
+
+    // Cover the stream error branch against an active client-stream session.
+    await transport.send({
+      jsonrpc: '2.0',
+      id: 'batch-err',
+      method: 'streambatch.v1.StreamBatchService/ClientStream',
+      params: {},
+    });
+    await transport.send([
+      {
+        jsonrpc: '2.0',
+        id: 'batch-err',
+        stream: 'error',
+        error: { code: -32000, message: 'client aborted' },
+      },
+    ]);
   });
 });

--- a/packages/di-framework-socket/tests/framing.test.ts
+++ b/packages/di-framework-socket/tests/framing.test.ts
@@ -24,7 +24,7 @@ describe('LengthPrefixFramer', () => {
     expect(out[0]?.kind).toBe('text');
     expect(out[0]?.text).toBe('hello');
     expect(out[1]?.kind).toBe('binary');
-    expect([...out[1]?.data]).toEqual([1, 2, 3, 4]);
+    expect([...(out[1]?.data ?? [])]).toEqual([1, 2, 3, 4]);
   });
 
   it('rejects oversized frames', () => {

--- a/packages/di-framework-socket/tests/workers-hub-secure.test.ts
+++ b/packages/di-framework-socket/tests/workers-hub-secure.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { createMemoryDuplexPair, SecureSession, type SecureSessionSnapshot } from '../index.ts';
+import { createMemoryDuplexPair, SecureSession } from '../index.ts';
 import {
   type DurableObjectStateLike,
   type HibernatableAttachment,
@@ -67,10 +67,11 @@ describe('HibernatableSocketHub secure rehydrate', () => {
       hub as unknown as { live: Map<HibernatableWebSocket, { session?: SecureSession }> }
     ).live.get(ws);
     expect(live?.session).toBeTruthy();
-    const again: SecureSessionSnapshot = live?.session?.exportSnapshot();
-    expect(again.sessionId).toBe(serverSnap.sessionId);
-    expect(again.sendCounter).toBe(serverSnap.sendCounter);
-    expect(again.recvCounter).toBe(serverSnap.recvCounter);
+    const again = live?.session?.exportSnapshot();
+    expect(again).toBeDefined();
+    expect(again!.sessionId).toBe(serverSnap.sessionId);
+    expect(again!.sendCounter).toBe(serverSnap.sendCounter);
+    expect(again!.recvCounter).toBe(serverSnap.recvCounter);
     void clientSnap;
     void pair2;
     void conn;


### PR DESCRIPTION
## Summary
- Sync `di-framework-codegen` into the mx `PACKAGES` list and release publish loop (including `di-framework-tsc`), and point release builds at `cmd/mx/build.ts`.
- Clear typecheck/strictness failures across packages and remove a stale container test that referenced a deleted helper.
- Close remaining 100% line-coverage gaps in the advanced example and RPC adapters/decorators so pre-push/CI can pass.

## Test plan
- [x] `bun x tsc -b --noEmit`
- [x] `bun test --coverage`
- [x] `bun scripts/check-line-coverage.ts`
- [ ] Confirm release workflow package list matches `PACKAGES` in `cmd/mx/build.ts`
- [ ] After merge, re-run/cancel-and-retrigger the failed release as needed


Made with [Cursor](https://cursor.com)