### PR TITLE
feat(cli): wire @di-framework/tsc into init by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ class AuditService {
 | --- | --- |
 | [`@di-framework/core`](packages/di-framework-core) | DI container and decorators |
 | [`@di-framework/cli`](packages/di-framework-cli) | App CLI: `init`, `build`, `check` |
-| [`@di-framework/tsc`](packages/di-framework-tsc) | Optional `ttsc` runtime parameter checks |
+| [`@di-framework/tsc`](packages/di-framework-tsc) | `ttsc` runtime parameter checks (wired by `init`) |
 | [`@di-framework/repo`](packages/di-framework-repo) | Data access / repositories |
 | [`@di-framework/http`](packages/di-framework-http) | HTTP routing and OpenAPI |
 | [`@di-framework/graphql`](packages/di-framework-graphql) | GraphQL schema from domain objects |
@@ -67,9 +67,9 @@ bun x @di-framework/cli <command>
 
 | Command | Description |
 | --- | --- |
-| `init` | Scaffold a new application |
-| `check` | Typecheck the current app |
-| `build` | Build the current app |
+| `init` | Scaffold a new application (`@di-framework/tsc` + `ttsc` by default) |
+| `check` | Typecheck via `check` script or `tsc --noEmit` |
+| `build` | Build via `build` script or `ttsc` / `tsc` |
 
 **Maintainers** (this monorepo)
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ bun x @di-framework/cli <command>
 | Command | Description |
 | --- | --- |
 | `init` | Scaffold a new application (`@di-framework/tsc` + `ttsc` by default) |
-| `check` | Typecheck via `check` script or `tsc --noEmit` |
-| `build` | Build via `build` script or `ttsc` / `tsc` |
+| `check` | Typecheck with `ttsc --noEmit` or `tsc --noEmit` |
+| `build` | Emit with `ttsc --emit` or `tsc` |
 
 **Maintainers** (this monorepo)
 

--- a/bun.lock
+++ b/bun.lock
@@ -130,6 +130,18 @@
         "@di-framework/http": "workspace:*",
       },
     },
+    "examples/packages/init-tsc-inspect": {
+      "name": "init-tsc-inspect",
+      "version": "0.0.1",
+      "dependencies": {
+        "@di-framework/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@di-framework/cli": "workspace:*",
+        "@di-framework/tsc": "workspace:*",
+        "@types/bun": "latest",
+      },
+    },
     "examples/packages/services": {
       "name": "di-services-example",
       "version": "0.0.0",
@@ -380,9 +392,9 @@
       "bin": {
         "dtsc": "bin/dtsc.cjs",
       },
-      "peerDependencies": {
+      "dependencies": {
         "ttsc": ">=0.25.0",
-        "typescript": ">=7.0.0",
+        "typescript": "^7.0.0",
       },
     },
   },
@@ -811,6 +823,8 @@
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
+    "init-tsc-inspect": ["init-tsc-inspect@workspace:examples/packages/init-tsc-inspect"],
+
     "ip-address": ["ip-address@10.4.0", "", {}, "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
@@ -954,6 +968,8 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "@di-framework/config/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@di-framework/tsc/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 

--- a/docs/Writerside/topics/cli.md
+++ b/docs/Writerside/topics/cli.md
@@ -23,9 +23,9 @@ di-framework <command> [args...]
 
 | Command | Description |
 | --- | --- |
-| **`init [name]`** | Scaffold a new app (`package.json`, decorator-ready `tsconfig`, sample `src/index.ts`) |
-| **`build`** | Run the project’s `build` script, or `tsc -p tsconfig.json` if none |
-| **`check`** | Typecheck with the nearest `tsconfig.json` (`tsc --noEmit`) |
+| **`init [name]`** | Scaffold a new app (`package.json`, `tsconfig` with `@di-framework/tsc`, sample `src/index.ts`) |
+| **`build`** | Run the project’s `build` script, or `ttsc --emit` / `tsc -p tsconfig.json` if none |
+| **`check`** | Run the project’s `check` script, or `tsc --noEmit` against the nearest `tsconfig.json` |
 
 ```bash
 di-framework init my-api
@@ -34,6 +34,8 @@ cd my-api && bun install && bun run dev
 di-framework check
 di-framework build
 ```
+
+`init` installs TypeScript 7+, `ttsc`, and `@di-framework/tsc` by default, and sets `plugins: [{ "transform": "@di-framework/tsc" }]`. Runtime checks are injected on `ttsc --emit` (`build` / `start`). `dev` runs source with Bun (no emit). First `ttsc` build needs a Go toolchain — see [Runtime type checks](tsc.md).
 
 ### `init` options
 
@@ -67,4 +69,4 @@ Legacy top-level `test` / `typecheck` / `publish` still redirect to `mx` with a 
 
 - [Installation](installation.md) - Core package setup
 - [Quick Start](quick-start.md) - Basics after scaffolding
-- [Runtime type checks](tsc.md) - Optional `ttsc` transform (`@di-framework/tsc`)
+- [Runtime type checks](tsc.md) - `ttsc` transform (`@di-framework/tsc`; wired by `init`)

--- a/docs/Writerside/topics/cli.md
+++ b/docs/Writerside/topics/cli.md
@@ -24,8 +24,8 @@ di-framework <command> [args...]
 | Command | Description |
 | --- | --- |
 | **`init [name]`** | Scaffold a new app (`package.json`, `tsconfig` with `@di-framework/tsc`, sample `src/index.ts`) |
-| **`build`** | Run the project’s `build` script, or `ttsc --emit` / `tsc -p tsconfig.json` if none |
-| **`check`** | Run the project’s `check` script, or `tsc --noEmit` against the nearest `tsconfig.json` |
+| **`build`** | Emit with `ttsc --emit` when available, otherwise `tsc -p tsconfig.json` |
+| **`check`** | Typecheck with `ttsc --noEmit` when available, otherwise `tsc --noEmit` |
 
 ```bash
 di-framework init my-api
@@ -35,7 +35,7 @@ di-framework check
 di-framework build
 ```
 
-`init` installs TypeScript 7+, `ttsc`, and `@di-framework/tsc` by default, and sets `plugins: [{ "transform": "@di-framework/tsc" }]`. Runtime checks are injected on `ttsc --emit` (`build` / `start`). `dev` runs source with Bun (no emit). First `ttsc` build needs a Go toolchain — see [Runtime type checks](tsc.md).
+`init` installs `@di-framework/tsc` and `@di-framework/cli` by default, sets `plugins: [{ "transform": "@di-framework/tsc" }]`, and wires `"build"` / `"check"` to `di-framework` (`ttsc` and TypeScript 7+ come with `@di-framework/tsc`). Runtime checks are injected on `ttsc --emit` (`build` / `start`). `dev` runs source with Bun (no emit). First `ttsc` build needs a Go toolchain — see [Runtime type checks](tsc.md).
 
 ### `init` options
 

--- a/docs/Writerside/topics/installation.md
+++ b/docs/Writerside/topics/installation.md
@@ -16,7 +16,7 @@ bun x @di-framework/cli init my-api
 cd my-api && bun install && bun run dev
 ```
 
-That writes a decorator-ready `tsconfig.json`, `package.json`, and a sample `src/index.ts`. See [CLI](cli.md) for `check` / `build` and options.
+That writes a `tsconfig.json` with `@di-framework/tsc` (`plugins`), TypeScript 7+, `ttsc`, and sample `src/index.ts`. Runtime parameter checks are injected on `ttsc --emit` (`bun run build`). See [CLI](cli.md) for `check` / `build` and [Runtime type checks](tsc.md).
 
 ## Install the Package
 
@@ -54,6 +54,7 @@ Ensure your `tsconfig.json` has the following settings:
 }
 ```
 
+Apps from `di-framework init` also include `plugins: [{ "transform": "@di-framework/tsc" }]` and emit via `ttsc`. For manual setup of runtime parameter checks, see [Runtime type checks](tsc.md).
 ### SWC Configuration
 
 If you're using SWC, ensure your `.swcrc` has decorator support enabled:
@@ -129,7 +130,7 @@ The core package stands alone. Companion packages add data access, HTTP, GraphQL
 | Package | Docs |
 | --- | --- |
 | `@di-framework/cli` | [CLI](cli.md) |
-| `@di-framework/tsc` | [Runtime type checks](tsc.md) |
+| `@di-framework/tsc` | [Runtime type checks](tsc.md) (default in `init`) |
 | `@di-framework/repo` | [Repositories](repositories.md) |
 | `@di-framework/http` | [HTTP Router](http-router.md) |
 | `@di-framework/graphql` | [GraphQL](graphql.md) |

--- a/docs/Writerside/topics/installation.md
+++ b/docs/Writerside/topics/installation.md
@@ -16,7 +16,7 @@ bun x @di-framework/cli init my-api
 cd my-api && bun install && bun run dev
 ```
 
-That writes a `tsconfig.json` with `@di-framework/tsc` (`plugins`), TypeScript 7+, `ttsc`, and sample `src/index.ts`. Runtime parameter checks are injected on `ttsc --emit` (`bun run build`). See [CLI](cli.md) for `check` / `build` and [Runtime type checks](tsc.md).
+That writes a `tsconfig.json` with `@di-framework/tsc` (`plugins`), `@di-framework/cli`, and sample `src/index.ts` (`ttsc` and TypeScript 7+ come with `@di-framework/tsc`). Scripts call `di-framework build` / `di-framework check` (which run `ttsc`). Runtime parameter checks are injected on emit (`bun run build`). See [CLI](cli.md) for `check` / `build` and [Runtime type checks](tsc.md).
 
 ## Install the Package
 

--- a/docs/Writerside/topics/overview.md
+++ b/docs/Writerside/topics/overview.md
@@ -24,7 +24,7 @@ A lightweight, type-safe dependency injection framework for TypeScript, plus com
 - **RPC**: Decorator-generated JSON-RPC and per-method gRPC with a typed client via `@di-framework/rpc` — the same service over memory, HTTP, sockets, and Connect / gRPC.
 - **AI**: Annotation-driven chat, tools, RAG, MCP, and agents with `@di-framework/ai` (OpenAI-compatible and Anthropic HTTP adapters).
 - **App CLI**: Scaffold, typecheck, and build apps with `@di-framework/cli` (`init`, `check`, `build`); monorepo maintainers use `mx`.
-- **Runtime type checks**: Optional `ttsc` transform `@di-framework/tsc` injects parameter guards from TypeScript types at emit time.
+- **Runtime type checks**: `ttsc` transform `@di-framework/tsc` injects parameter guards from TypeScript types at emit time (`di-framework init` wires this by default).
 
 ## Why Use This Framework?
 
@@ -115,7 +115,7 @@ userService.getUser('123');
 - [Installation](installation.md) - Set up the framework in your project
 - [Quick Start](quick-start.md) - Learn the basics with simple examples
 - [CLI](cli.md) - App `init` / `check` / `build` and maintainer `mx`
-- [Runtime type checks](tsc.md) - Optional emit-time parameter guards (`@di-framework/tsc`)
+- [Runtime type checks](tsc.md) - Emit-time parameter guards (`@di-framework/tsc`; wired by `init`)
 - [HTTP Router](http-router.md) - Type-safe routes and OpenAPI generation
 - [GraphQL](graphql.md) - Domain classes as a GraphQL schema
 - [Events](events.md) - Bridge container events to Kafka / NATS / memory

--- a/docs/Writerside/topics/quick-start.md
+++ b/docs/Writerside/topics/quick-start.md
@@ -165,7 +165,7 @@ console.log(user);
 ## Next Steps
 
 - [CLI](cli.md) - App `init` / `check` / `build` and maintainer `mx`
-- [Runtime type checks](tsc.md) - Optional emit-time parameter guards
+- [Runtime type checks](tsc.md) - Emit-time parameter guards (`init` wires `@di-framework/tsc`)
 - [API Reference](api-reference.md) - Learn about all available APIs and options
 - [Advanced Usage](advanced-usage.md) - Explore advanced patterns like transient services and factory functions
 - [Best Practices](best-practices.md) - Learn recommended patterns and approaches

--- a/docs/Writerside/topics/tsc.md
+++ b/docs/Writerside/topics/tsc.md
@@ -6,6 +6,8 @@ Source stays plain TypeScript — no `assert()`, schemas, or decorators. On emit
 
 > MVP: function declarations with required identifier params; primitives + plain object/interface props. See [Limitations](#limitations).
 
+`di-framework init` wires this by default (TypeScript 7+, `ttsc`, `@di-framework/tsc`, and `plugins` in `tsconfig`). Use the steps below for an existing app.
+
 ## Installation
 
 ```bash

--- a/docs/Writerside/topics/tsc.md
+++ b/docs/Writerside/topics/tsc.md
@@ -6,15 +6,15 @@ Source stays plain TypeScript — no `assert()`, schemas, or decorators. On emit
 
 > MVP: function declarations with required identifier params; primitives + plain object/interface props. See [Limitations](#limitations).
 
-`di-framework init` wires this by default (TypeScript 7+, `ttsc`, `@di-framework/tsc`, and `plugins` in `tsconfig`). Use the steps below for an existing app.
+`di-framework init` wires this by default (`@di-framework/tsc` and `plugins` in `tsconfig`; `ttsc` and TypeScript 7+ come with `@di-framework/tsc`). Use the steps below for an existing app.
 
 ## Installation
 
 ```bash
-npm i -D ttsc typescript @di-framework/tsc
+npm i -D @di-framework/tsc
 ```
 
-Consumers supply `ttsc` and TypeScript 7+; this package is the transform only.
+Pulls in `ttsc` and TypeScript 7+ transitively.
 
 The first build compiles a Go sidecar (cached afterward). Needs a Go toolchain (`go` 1.26+ recommended; `ttsc` can pin via `TTSC_GO_BINARY`).
 
@@ -84,7 +84,7 @@ Skipped today:
 
 ## Monorepo note
 
-`@di-framework/tsc` is isolated from the monorepo’s TypeScript 5.x `tsc` graph (package `build` is a no-op). Peers `ttsc` and TypeScript 7+ stay out of root / `@di-framework/*` core packages.
+`@di-framework/tsc` is isolated from the monorepo’s TypeScript 5.x `tsc` graph (package `build` is a no-op). `ttsc` and TypeScript 7+ are dependencies of `@di-framework/tsc` (kept out of root / other `@di-framework/*` packages).
 
 ## Next Steps
 

--- a/examples/packages/init-tsc-inspect/README.md
+++ b/examples/packages/init-tsc-inspect/README.md
@@ -1,0 +1,27 @@
+# init-tsc-inspect
+
+di-framework application scaffolded with `di-framework init`.
+
+Includes [`@di-framework/tsc`](https://www.npmjs.com/package/@di-framework/tsc) for emit-time runtime parameter checks (`ttsc`). The first `ttsc` build compiles a Go sidecar (needs a Go toolchain; see [ttsc](https://ttsc.dev)).
+
+## Setup
+
+```bash
+bun install
+bun run dev
+```
+
+## Scripts
+
+| Script    | Description |
+| --------- | ----------- |
+| `dev`   | Run `src/index.ts` with Bun (no emit; runtime checks not injected) |
+| `build` | `di-framework build` → `ttsc --emit` (injects runtime checks) |
+| `start` | Run emitted `dist/index.js` |
+| `check` | `di-framework check` → `ttsc --noEmit` |
+
+## Learn more
+
+- [Documentation](https://docs.di-framework.dev)
+- [Runtime type checks](https://docs.di-framework.dev/tsc.html)
+- Add packages: `bun add @di-framework/http` (or graphql, auth, config, …)

--- a/examples/packages/init-tsc-inspect/package.json
+++ b/examples/packages/init-tsc-inspect/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "init-tsc-inspect",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun run src/index.ts",
+    "build": "di-framework build",
+    "start": "node dist/index.js",
+    "check": "di-framework check"
+  },
+  "dependencies": {
+    "@di-framework/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@di-framework/cli": "workspace:*",
+    "@di-framework/tsc": "workspace:*",
+    "@types/bun": "latest"
+  }
+}

--- a/examples/packages/init-tsc-inspect/src/index.ts
+++ b/examples/packages/init-tsc-inspect/src/index.ts
@@ -1,0 +1,27 @@
+import { useContainer } from '@di-framework/core/container';
+import { Component, Container } from '@di-framework/core/decorators';
+
+// Top-level function declarations get runtime checks from @di-framework/tsc on emit.
+// Class methods are not transformed yet (MVP limitation).
+function greet(name: string): string {
+  return `Hello, ${name}!`;
+}
+
+@Container()
+class Greeter {
+  hello(name: string) {
+    return greet(name);
+  }
+}
+
+@Container()
+class App {
+  constructor(@Component(Greeter) private greeter: Greeter) {}
+
+  run() {
+    console.log(this.greeter.hello('di-framework'));
+  }
+}
+
+const app = useContainer().resolve(App);
+app.run();

--- a/examples/packages/init-tsc-inspect/tsconfig.json
+++ b/examples/packages/init-tsc-inspect/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "ESNext"
+    ],
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": [
+      "bun"
+    ],
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "skipLibCheck": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": false,
+    "plugins": [
+      {
+        "transform": "@di-framework/tsc"
+      }
+    ]
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/examples/packages/init-tsc-inspect/tsconfig.json
+++ b/examples/packages/init-tsc-inspect/tsconfig.json
@@ -1,14 +1,10 @@
 {
   "compilerOptions": {
-    "lib": [
-      "ESNext"
-    ],
+    "lib": ["ESNext"],
     "target": "ESNext",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "types": [
-      "bun"
-    ],
+    "types": ["bun"],
     "rootDir": "src",
     "outDir": "dist",
     "strict": true,
@@ -21,7 +17,5 @@
       }
     ]
   },
-  "include": [
-    "src/**/*"
-  ]
+  "include": ["src/**/*"]
 }

--- a/packages/di-framework-cli/README.md
+++ b/packages/di-framework-cli/README.md
@@ -24,8 +24,8 @@ di-framework <command> [args...]
 | Command | Description |
 | ------- | ----------- |
 | **`init [name]`** | Scaffold a new app (`package.json`, `tsconfig` with `@di-framework/tsc`, sample `src/index.ts`) |
-| **`build`** | Run the project’s `build` script, or `ttsc --emit` / `tsc -p tsconfig.json` if none |
-| **`check`** | Run the project’s `check` script, or `tsc --noEmit` against the nearest `tsconfig.json` |
+| **`build`** | Emit with `ttsc --emit` when available, otherwise `tsc -p tsconfig.json` |
+| **`check`** | Typecheck with `ttsc --noEmit` when available, otherwise `tsc --noEmit` |
 
 ```bash
 di-framework init my-api
@@ -35,7 +35,7 @@ di-framework check
 di-framework build
 ```
 
-`init` wires TypeScript 7+, `ttsc`, and `@di-framework/tsc` by default (`plugins` in `tsconfig`, `build`/`check` via `ttsc`). Runtime parameter checks are injected on `ttsc --emit` (`bun run build` / `bun start`). `bun run dev` executes source with Bun and skips emit-time checks. The first `ttsc` build needs a Go toolchain.
+`init` wires `@di-framework/tsc` and `@di-framework/cli` by default (`plugins` in `tsconfig`; `"build"` / `"check"` scripts call `di-framework`; `ttsc` and TypeScript 7+ come with `@di-framework/tsc`). Runtime parameter checks are injected on `ttsc --emit` (`bun run build` / `bun start`). `bun run dev` executes source with Bun and skips emit-time checks. The first `ttsc` build needs a Go toolchain.
 ### `init` options
 
 ```

--- a/packages/di-framework-cli/README.md
+++ b/packages/di-framework-cli/README.md
@@ -23,9 +23,9 @@ di-framework <command> [args...]
 
 | Command | Description |
 | ------- | ----------- |
-| **`init [name]`** | Scaffold a new app (`package.json`, decorator-ready `tsconfig`, sample `src/index.ts`) |
-| **`build`** | Run the project’s `build` script, or `tsc -p tsconfig.json` if none |
-| **`check`** | Typecheck with the nearest `tsconfig.json` (`tsc --noEmit`) |
+| **`init [name]`** | Scaffold a new app (`package.json`, `tsconfig` with `@di-framework/tsc`, sample `src/index.ts`) |
+| **`build`** | Run the project’s `build` script, or `ttsc --emit` / `tsc -p tsconfig.json` if none |
+| **`check`** | Run the project’s `check` script, or `tsc --noEmit` against the nearest `tsconfig.json` |
 
 ```bash
 di-framework init my-api
@@ -35,6 +35,7 @@ di-framework check
 di-framework build
 ```
 
+`init` wires TypeScript 7+, `ttsc`, and `@di-framework/tsc` by default (`plugins` in `tsconfig`, `build`/`check` via `ttsc`). Runtime parameter checks are injected on `ttsc --emit` (`bun run build` / `bun start`). `bun run dev` executes source with Bun and skips emit-time checks. The first `ttsc` build needs a Go toolchain.
 ### `init` options
 
 ```

--- a/packages/di-framework-cli/cmd/build.ts
+++ b/packages/di-framework-cli/cmd/build.ts
@@ -25,9 +25,10 @@ Usage:
   di-framework build [args...]
 
 Runs, in order of preference:
-  1. package.json "build" script  (bun run build / npm run build)
-  2. ttsc --emit -p tsconfig.json if ttsc is installed (or declared)
-  3. tsc -p tsconfig.json         if tsconfig exists and no build script
+  1. ttsc --emit -p tsconfig.json  if ttsc is installed (or declared)
+  2. tsc -p tsconfig.json          if tsconfig.json exists
+
+Init scaffolds \`\"build\": \"di-framework build\"\` so \`bun run build\` delegates here.
 
 Maintainer monorepo build: di-framework mx build
 `);
@@ -48,7 +49,24 @@ export function hasTtsc(
   },
 ): boolean {
   if (pkg?.dependencies?.ttsc || pkg?.devDependencies?.ttsc) return true;
-  return existsSync(join(cwd, 'node_modules', 'ttsc'));
+  if (pkg?.dependencies?.['@di-framework/tsc'] || pkg?.devDependencies?.['@di-framework/tsc']) {
+    return true;
+  }
+  if (existsSync(join(cwd, 'node_modules', 'ttsc'))) return true;
+  if (existsSync(join(cwd, 'node_modules', '@di-framework', 'tsc'))) return true;
+  return existsSync(join(cwd, 'node_modules', '@di-framework', 'tsc', 'node_modules', 'ttsc'));
+}
+
+export function readPkgJson(cwd: string): {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+} | null {
+  const pkgPath = join(cwd, 'package.json');
+  if (!existsSync(pkgPath)) return null;
+  return JSON.parse(readFileSync(pkgPath, 'utf-8')) as {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  };
 }
 
 export async function buildApp(
@@ -60,53 +78,28 @@ export async function buildApp(
     return;
   }
 
-  const pkgPath = join(opts.cwd, 'package.json');
-  if (!existsSync(pkgPath)) {
+  const pkg = readPkgJson(opts.cwd);
+  if (!pkg) {
     throw new Error(
       `No package.json in ${opts.cwd}. Run \`di-framework init\` first, or cd into your app.`,
     );
   }
 
-  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as {
-    scripts?: Record<string, string>;
-    dependencies?: Record<string, string>;
-    devDependencies?: Record<string, string>;
-  };
-  const hasBuildScript = Boolean(pkg.scripts?.build);
   const tsconfig = join(opts.cwd, 'tsconfig.json');
-  const pm = detectPackageManager(opts.cwd);
-
-  if (hasBuildScript) {
-    console.log(`Building with ${pm} run build…`);
-    if (pm === 'bun') {
-      await shell`bun run build ${opts.passthrough}`.cwd(opts.cwd);
-    } else if (pm === 'pnpm') {
-      await shell`pnpm run build ${opts.passthrough}`.cwd(opts.cwd);
-    } else if (pm === 'yarn') {
-      await shell`yarn run build ${opts.passthrough}`.cwd(opts.cwd);
-    } else {
-      await shell`npm run build -- ${opts.passthrough}`.cwd(opts.cwd);
-    }
-    console.log('✅ Build finished');
-    return;
+  if (!existsSync(tsconfig)) {
+    throw new Error(
+      'Nothing to build: add a tsconfig.json, or scaffold with `di-framework init`.',
+    );
   }
 
-  if (existsSync(tsconfig)) {
-    if (hasTtsc(opts.cwd, pkg)) {
-      console.log('No "build" script; running ttsc --emit -p tsconfig.json…');
-      await shell`bun x ttsc --emit -p ${tsconfig} ${opts.passthrough}`.cwd(opts.cwd);
-    } else {
-      console.log('No "build" script; running tsc -p tsconfig.json…');
-      await shell`bun x tsc -p ${tsconfig} ${opts.passthrough}`.cwd(opts.cwd);
-    }
-    console.log('✅ Build finished');
-    return;
+  if (hasTtsc(opts.cwd, pkg)) {
+    console.log('Building with ttsc --emit -p tsconfig.json…');
+    await shell`bun x ttsc --emit -p ${tsconfig} ${opts.passthrough}`.cwd(opts.cwd);
+  } else {
+    console.log('Building with tsc -p tsconfig.json…');
+    await shell`bun x tsc -p ${tsconfig} ${opts.passthrough}`.cwd(opts.cwd);
   }
-
-  throw new Error(
-    'Nothing to build: add a "build" script to package.json or a tsconfig.json. ' +
-      'Or scaffold with `di-framework init`.',
-  );
+  console.log('✅ Build finished');
 }
 
 export async function build(args: string[] = process.argv.slice(3)): Promise<void> {

--- a/packages/di-framework-cli/cmd/build.ts
+++ b/packages/di-framework-cli/cmd/build.ts
@@ -26,7 +26,8 @@ Usage:
 
 Runs, in order of preference:
   1. package.json "build" script  (bun run build / npm run build)
-  2. tsc -p tsconfig.json         if tsconfig exists and no build script
+  2. ttsc --emit -p tsconfig.json if ttsc is installed (or declared)
+  3. tsc -p tsconfig.json         if tsconfig exists and no build script
 
 Maintainer monorepo build: di-framework mx build
 `);
@@ -37,6 +38,17 @@ export function detectPackageManager(cwd: string): 'bun' | 'npm' | 'pnpm' | 'yar
   if (existsSync(join(cwd, 'pnpm-lock.yaml'))) return 'pnpm';
   if (existsSync(join(cwd, 'yarn.lock'))) return 'yarn';
   return existsSync(join(cwd, 'package-lock.json')) ? 'npm' : 'bun';
+}
+
+export function hasTtsc(
+  cwd: string,
+  pkg?: {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  },
+): boolean {
+  if (pkg?.dependencies?.ttsc || pkg?.devDependencies?.ttsc) return true;
+  return existsSync(join(cwd, 'node_modules', 'ttsc'));
 }
 
 export async function buildApp(
@@ -57,6 +69,8 @@ export async function buildApp(
 
   const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as {
     scripts?: Record<string, string>;
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
   };
   const hasBuildScript = Boolean(pkg.scripts?.build);
   const tsconfig = join(opts.cwd, 'tsconfig.json');
@@ -78,8 +92,13 @@ export async function buildApp(
   }
 
   if (existsSync(tsconfig)) {
-    console.log('No "build" script; running tsc -p tsconfig.json…');
-    await shell`bun x tsc -p ${tsconfig} ${opts.passthrough}`.cwd(opts.cwd);
+    if (hasTtsc(opts.cwd, pkg)) {
+      console.log('No "build" script; running ttsc --emit -p tsconfig.json…');
+      await shell`bun x ttsc --emit -p ${tsconfig} ${opts.passthrough}`.cwd(opts.cwd);
+    } else {
+      console.log('No "build" script; running tsc -p tsconfig.json…');
+      await shell`bun x tsc -p ${tsconfig} ${opts.passthrough}`.cwd(opts.cwd);
+    }
     console.log('✅ Build finished');
     return;
   }

--- a/packages/di-framework-cli/cmd/build.ts
+++ b/packages/di-framework-cli/cmd/build.ts
@@ -28,7 +28,7 @@ Runs, in order of preference:
   1. ttsc --emit -p tsconfig.json  if ttsc is installed (or declared)
   2. tsc -p tsconfig.json          if tsconfig.json exists
 
-Init scaffolds \`\"build\": \"di-framework build\"\` so \`bun run build\` delegates here.
+Init scaffolds \`"build": "di-framework build"\` so \`bun run build\` delegates here.
 
 Maintainer monorepo build: di-framework mx build
 `);
@@ -87,9 +87,7 @@ export async function buildApp(
 
   const tsconfig = join(opts.cwd, 'tsconfig.json');
   if (!existsSync(tsconfig)) {
-    throw new Error(
-      'Nothing to build: add a tsconfig.json, or scaffold with `di-framework init`.',
-    );
+    throw new Error('Nothing to build: add a tsconfig.json, or scaffold with `di-framework init`.');
   }
 
   if (hasTtsc(opts.cwd, pkg)) {

--- a/packages/di-framework-cli/cmd/check.ts
+++ b/packages/di-framework-cli/cmd/check.ts
@@ -1,7 +1,7 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { $ } from 'bun';
-import { detectPackageManager } from './build';
+import { hasTtsc, readPkgJson } from './build';
 
 export type CheckOptions = {
   cwd: string;
@@ -66,43 +66,16 @@ Options:
   --help, -h               Show this help
 
 Runs, in order of preference:
-  1. package.json "check" script  (when no explicit tsconfig path is given)
+  1. ttsc --noEmit -p <tsconfig>  if ttsc is installed (or declared)
   2. tsc --noEmit -p <tsconfig>   nearest tsconfig.json (or the path given)
+
+Init scaffolds \`\"check\": \"di-framework check\"\` so \`bun run check\` delegates here.
 
 Maintainer monorepo typecheck: di-framework mx typecheck
 `);
 }
 
-async function runCheckScript(cwd: string): Promise<void> {
-  const pm = detectPackageManager(cwd);
-  console.log(`ℹ️  Checking with ${pm} run check…`);
-  const proc =
-    pm === 'pnpm'
-      ? await $`pnpm run check`.cwd(cwd).nothrow()
-      : pm === 'yarn'
-        ? await $`yarn run check`.cwd(cwd).nothrow()
-        : pm === 'npm'
-          ? await $`npm run check`.cwd(cwd).nothrow()
-          : await $`bun run check`.cwd(cwd).nothrow();
-
-  if (proc.exitCode !== 0) {
-    throw new Error(`Typecheck failed (exit ${proc.exitCode})`);
-  }
-  console.log('✅ Check passed');
-}
-
 export async function checkApp(opts: CheckOptions): Promise<void> {
-  const pkgPath = join(opts.cwd, 'package.json');
-  if (!opts.tsconfigPath && existsSync(pkgPath)) {
-    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as {
-      scripts?: Record<string, string>;
-    };
-    if (pkg.scripts?.check) {
-      await runCheckScript(opts.cwd);
-      return;
-    }
-  }
-
   const tsconfigPath = opts.tsconfigPath
     ? resolve(opts.cwd, opts.tsconfigPath)
     : findNearestTsconfig(opts.cwd);
@@ -113,13 +86,17 @@ export async function checkApp(opts: CheckOptions): Promise<void> {
     );
   }
 
-  console.log(`ℹ️  Checking with ${tsconfigPath}`);
+  const pkg = readPkgJson(opts.cwd);
+  const useTtsc = hasTtsc(opts.cwd, pkg ?? undefined);
+  const tool = useTtsc ? 'ttsc' : 'tsc';
+  console.log(`ℹ️  Checking with ${tool} --noEmit -p ${tsconfigPath}`);
 
   const prettyFlag = opts.pretty ? [] : ['--pretty', 'false'];
-  const proc = await $`bun x tsc --noEmit -p ${tsconfigPath} ${prettyFlag}`.cwd(opts.cwd).nothrow();
+  const proc = useTtsc
+    ? await $`bun x ttsc --noEmit -p ${tsconfigPath} ${prettyFlag}`.cwd(opts.cwd).nothrow()
+    : await $`bun x tsc --noEmit -p ${tsconfigPath} ${prettyFlag}`.cwd(opts.cwd).nothrow();
 
   if (proc.exitCode !== 0) {
-    // tsc already printed diagnostics to stdout/stderr via inherit default
     throw new Error(`Typecheck failed (exit ${proc.exitCode})`);
   }
 

--- a/packages/di-framework-cli/cmd/check.ts
+++ b/packages/di-framework-cli/cmd/check.ts
@@ -1,6 +1,7 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { $ } from 'bun';
+import { detectPackageManager } from './build';
 
 export type CheckOptions = {
   cwd: string;
@@ -61,16 +62,47 @@ Usage:
   di-framework check [tsconfig.json] [options]
 
 Options:
-  --pretty=0|--no-pretty   Disable colored diagnostics
+  --pretty=0|--no-pretty   Disable colored diagnostics (tsc fallback only)
   --help, -h               Show this help
 
-Finds the nearest tsconfig.json above the current directory unless a path is given.
+Runs, in order of preference:
+  1. package.json "check" script  (when no explicit tsconfig path is given)
+  2. tsc --noEmit -p <tsconfig>   nearest tsconfig.json (or the path given)
 
 Maintainer monorepo typecheck: di-framework mx typecheck
 `);
 }
 
+async function runCheckScript(cwd: string): Promise<void> {
+  const pm = detectPackageManager(cwd);
+  console.log(`ℹ️  Checking with ${pm} run check…`);
+  const proc =
+    pm === 'pnpm'
+      ? await $`pnpm run check`.cwd(cwd).nothrow()
+      : pm === 'yarn'
+        ? await $`yarn run check`.cwd(cwd).nothrow()
+        : pm === 'npm'
+          ? await $`npm run check`.cwd(cwd).nothrow()
+          : await $`bun run check`.cwd(cwd).nothrow();
+
+  if (proc.exitCode !== 0) {
+    throw new Error(`Typecheck failed (exit ${proc.exitCode})`);
+  }
+  console.log('✅ Check passed');
+}
+
 export async function checkApp(opts: CheckOptions): Promise<void> {
+  const pkgPath = join(opts.cwd, 'package.json');
+  if (!opts.tsconfigPath && existsSync(pkgPath)) {
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as {
+      scripts?: Record<string, string>;
+    };
+    if (pkg.scripts?.check) {
+      await runCheckScript(opts.cwd);
+      return;
+    }
+  }
+
   const tsconfigPath = opts.tsconfigPath
     ? resolve(opts.cwd, opts.tsconfigPath)
     : findNearestTsconfig(opts.cwd);

--- a/packages/di-framework-cli/cmd/check.ts
+++ b/packages/di-framework-cli/cmd/check.ts
@@ -69,7 +69,7 @@ Runs, in order of preference:
   1. ttsc --noEmit -p <tsconfig>  if ttsc is installed (or declared)
   2. tsc --noEmit -p <tsconfig>   nearest tsconfig.json (or the path given)
 
-Init scaffolds \`\"check\": \"di-framework check\"\` so \`bun run check\` delegates here.
+Init scaffolds \`"check": "di-framework check"\` so \`bun run check\` delegates here.
 
 Maintainer monorepo typecheck: di-framework mx typecheck
 `);

--- a/packages/di-framework-cli/cmd/init.ts
+++ b/packages/di-framework-cli/cmd/init.ts
@@ -112,16 +112,18 @@ export function scaffoldApp(opts: InitOptions): void {
         type: 'module',
         scripts: {
           dev: 'bun run src/index.ts',
-          start: 'bun run src/index.ts',
-          build: 'bun build ./src/index.ts --outdir ./dist --target bun',
-          check: 'tsc --noEmit',
+          build: 'ttsc --emit',
+          start: 'node dist/index.js',
+          check: 'ttsc --noEmit',
         },
         dependencies: {
           '@di-framework/core': 'latest',
         },
         devDependencies: {
+          '@di-framework/tsc': 'latest',
           '@types/bun': 'latest',
-          typescript: '^5',
+          ttsc: '>=0.25.0',
+          typescript: '^7.0.0',
         },
       },
       null,
@@ -137,17 +139,15 @@ export function scaffoldApp(opts: InitOptions): void {
         compilerOptions: {
           lib: ['ESNext'],
           target: 'ESNext',
-          module: 'ESNext',
-          moduleDetection: 'force',
-          moduleResolution: 'bundler',
-          allowImportingTsExtensions: true,
-          verbatimModuleSyntax: true,
-          noEmit: true,
+          module: 'Node16',
+          moduleResolution: 'Node16',
+          rootDir: 'src',
+          outDir: 'dist',
           strict: true,
           skipLibCheck: true,
           experimentalDecorators: true,
           emitDecoratorMetadata: false,
-          types: ['bun'],
+          plugins: [{ transform: '@di-framework/tsc' }],
         },
         include: ['src/**/*'],
       },
@@ -190,6 +190,8 @@ app.run();
 
 di-framework application scaffolded with \`di-framework init\`.
 
+Includes [\`@di-framework/tsc\`](https://www.npmjs.com/package/@di-framework/tsc) for emit-time runtime parameter checks (\`ttsc\`). The first \`ttsc\` build compiles a Go sidecar (needs a Go toolchain; see [ttsc](https://ttsc.dev)).
+
 ## Setup
 
 \`\`\`bash
@@ -199,15 +201,17 @@ bun run dev
 
 ## Scripts
 
-| Script    | Description                          |
-| --------- | ------------------------------------ |
-| \`dev\`   | Run \`src/index.ts\` with Bun        |
-| \`build\` | Bundle to \`dist/\`                  |
-| \`check\` | Typecheck with \`tsc --noEmit\`      |
+| Script    | Description |
+| --------- | ----------- |
+| \`dev\`   | Run \`src/index.ts\` with Bun (no emit; runtime checks not injected) |
+| \`build\` | Emit to \`dist/\` with \`ttsc --emit\` (injects runtime checks) |
+| \`start\` | Run emitted \`dist/index.js\` |
+| \`check\` | Typecheck with \`ttsc --noEmit\` |
 
 ## Learn more
 
 - [Documentation](https://docs.di-framework.dev)
+- [Runtime type checks](https://docs.di-framework.dev/tsc.html)
 - Add packages: \`bun add @di-framework/http\` (or graphql, auth, config, …)
 `,
     force,

--- a/packages/di-framework-cli/cmd/init.ts
+++ b/packages/di-framework-cli/cmd/init.ts
@@ -112,18 +112,17 @@ export function scaffoldApp(opts: InitOptions): void {
         type: 'module',
         scripts: {
           dev: 'bun run src/index.ts',
-          build: 'ttsc --emit',
+          build: 'di-framework build',
           start: 'node dist/index.js',
-          check: 'ttsc --noEmit',
+          check: 'di-framework check',
         },
         dependencies: {
           '@di-framework/core': 'latest',
         },
         devDependencies: {
+          '@di-framework/cli': 'latest',
           '@di-framework/tsc': 'latest',
           '@types/bun': 'latest',
-          ttsc: '>=0.25.0',
-          typescript: '^7.0.0',
         },
       },
       null,
@@ -139,8 +138,9 @@ export function scaffoldApp(opts: InitOptions): void {
         compilerOptions: {
           lib: ['ESNext'],
           target: 'ESNext',
-          module: 'Node16',
-          moduleResolution: 'Node16',
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          types: ['bun'],
           rootDir: 'src',
           outDir: 'dist',
           strict: true,
@@ -162,10 +162,16 @@ export function scaffoldApp(opts: InitOptions): void {
     `import { useContainer } from '@di-framework/core/container';
 import { Component, Container } from '@di-framework/core/decorators';
 
+// Top-level function declarations get runtime checks from @di-framework/tsc on emit.
+// Class methods are not transformed yet (MVP limitation).
+function greet(name: string): string {
+  return \`Hello, \${name}!\`;
+}
+
 @Container()
 class Greeter {
-  greet(name: string) {
-    return \`Hello, \${name}!\`;
+  hello(name: string) {
+    return greet(name);
   }
 }
 
@@ -174,7 +180,7 @@ class App {
   constructor(@Component(Greeter) private greeter: Greeter) {}
 
   run() {
-    console.log(this.greeter.greet('di-framework'));
+    console.log(this.greeter.hello('di-framework'));
   }
 }
 
@@ -204,9 +210,9 @@ bun run dev
 | Script    | Description |
 | --------- | ----------- |
 | \`dev\`   | Run \`src/index.ts\` with Bun (no emit; runtime checks not injected) |
-| \`build\` | Emit to \`dist/\` with \`ttsc --emit\` (injects runtime checks) |
+| \`build\` | \`di-framework build\` → \`ttsc --emit\` (injects runtime checks) |
 | \`start\` | Run emitted \`dist/index.js\` |
-| \`check\` | Typecheck with \`ttsc --noEmit\` |
+| \`check\` | \`di-framework check\` → \`ttsc --noEmit\` |
 
 ## Learn more
 

--- a/packages/di-framework-cli/main.ts
+++ b/packages/di-framework-cli/main.ts
@@ -26,7 +26,7 @@ const COMMANDS: Record<string, Command> = {
     run: (args) => generateCommand(args),
   },
   build: {
-    description: 'Build the current application (package.json script or tsc)',
+    description: 'Build the current application (ttsc or tsc)',
     run: (args) => build(args),
   },
   check: {

--- a/packages/di-framework-cli/tests/app-build.test.ts
+++ b/packages/di-framework-cli/tests/app-build.test.ts
@@ -34,26 +34,42 @@ describe('app build command', () => {
     await expect(buildApp({ cwd: root, passthrough: [] })).rejects.toThrow('No package.json');
   });
 
-  it('runs package.json build script', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'app-build-script-'));
+  it('ignores package.json build script and runs tsc', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'app-build-ignore-script-'));
     temps.push(root);
+    mkdirSync(join(root, 'src'), { recursive: true });
     await Bun.write(
       join(root, 'package.json'),
       JSON.stringify({
         name: 'x',
-        scripts: { build: 'mkdir -p dist && echo ok > dist/out.txt' },
+        scripts: { build: 'echo should-not-run && exit 1' },
       }) + '\n',
     );
+    await Bun.write(
+      join(root, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          outDir: 'dist',
+          rootDir: 'src',
+          module: 'esnext',
+          target: 'esnext',
+          skipLibCheck: true,
+          noEmit: false,
+        },
+        include: ['src/**/*.ts'],
+      }) + '\n',
+    );
+    await Bun.write(join(root, 'src', 'index.ts'), 'export const n = 1;\n');
     const log = spyOn(console, 'log').mockImplementation(() => {});
     try {
       await buildApp({ cwd: root, passthrough: [] });
-      expect(await Bun.file(join(root, 'dist', 'out.txt')).text()).toContain('ok');
+      expect(await Bun.file(join(root, 'dist', 'index.js')).exists()).toBe(true);
     } finally {
       log.mockRestore();
     }
-  }, 30_000);
+  }, 60_000);
 
-  it('falls back to tsc when no build script', async () => {
+  it('runs tsc when no ttsc', async () => {
     const root = mkdtempSync(join(tmpdir(), 'app-build-tsc-'));
     temps.push(root);
     mkdirSync(join(root, 'src'), { recursive: true });
@@ -82,7 +98,7 @@ describe('app build command', () => {
     }
   }, 60_000);
 
-  it('falls back to ttsc --emit when ttsc is declared and no build script', async () => {
+  it('runs ttsc --emit when ttsc is declared', async () => {
     const { hasTtsc } = await import('../cmd/build');
     const root = mkdtempSync(join(tmpdir(), 'app-build-ttsc-'));
     temps.push(root);
@@ -112,6 +128,13 @@ describe('app build command', () => {
     } finally {
       log.mockRestore();
     }
+  });
+
+  it('treats @di-framework/tsc as implying ttsc', async () => {
+    const { hasTtsc } = await import('../cmd/build');
+    expect(
+      hasTtsc('/tmp', { devDependencies: { '@di-framework/tsc': 'latest' } }),
+    ).toBe(true);
   });
 
   it('hasTtsc detects node_modules/ttsc', async () => {
@@ -162,69 +185,57 @@ describe('app build command', () => {
     await buildApp({ cwd: '/tmp', passthrough: ['-h'] });
   });
 
-  it('throws when package.json has neither build script nor tsconfig', async () => {
+  it('throws when package.json has no tsconfig', async () => {
     const root = mkdtempSync(join(tmpdir(), 'app-build-empty-'));
     temps.push(root);
     await Bun.write(join(root, 'package.json'), JSON.stringify({ name: 'x' }) + '\n');
     await expect(buildApp({ cwd: root, passthrough: [] })).rejects.toThrow('Nothing to build');
   });
 
-  it('detects pnpm, yarn, and npm via lockfiles and runs matching installers', async () => {
+  it('detectPackageManager reads lockfiles', async () => {
     const { detectPackageManager } = await import('../cmd/build');
-    const log = spyOn(console, 'log').mockImplementation(() => {});
-    const seen: string[] = [];
-    const fakeShell = ((strings: TemplateStringsArray, ...exprs: unknown[]) => {
-      const cmd = strings.reduce((acc, s, i) => acc + s + (exprs[i] ?? ''), '');
-      seen.push(cmd);
-      return {
-        cwd: () => Promise.resolve(),
-      };
-    }) as unknown as import('../cmd/build').BuildShell;
-
-    try {
-      for (const [lock, expectedPm, needle] of [
-        ['pnpm-lock.yaml', 'pnpm', 'pnpm run build'],
-        ['yarn.lock', 'yarn', 'yarn run build'],
-        ['package-lock.json', 'npm', 'npm run build'],
-      ] as const) {
-        const root = mkdtempSync(join(tmpdir(), `app-build-${lock}-`));
-        temps.push(root);
-        await Bun.write(join(root, lock), '# lock\n');
-        await Bun.write(
-          join(root, 'package.json'),
-          JSON.stringify({
-            name: 'x',
-            scripts: { build: 'echo ok' },
-          }) + '\n',
-        );
-        expect(detectPackageManager(root)).toBe(expectedPm);
-        await buildApp({ cwd: root, passthrough: [] }, fakeShell);
-        expect(seen.some((c) => c.includes(needle))).toBe(true);
-      }
-    } finally {
-      log.mockRestore();
+    for (const [lock, expectedPm] of [
+      ['pnpm-lock.yaml', 'pnpm'],
+      ['yarn.lock', 'yarn'],
+      ['package-lock.json', 'npm'],
+      ['bun.lock', 'bun'],
+    ] as const) {
+      const root = mkdtempSync(join(tmpdir(), `app-build-${lock}-`));
+      temps.push(root);
+      await Bun.write(join(root, lock), '# lock\n');
+      expect(detectPackageManager(root)).toBe(expectedPm);
     }
   });
 
   it('build without flags runs buildApp', async () => {
     const root = mkdtempSync(join(tmpdir(), 'app-build-default-'));
     temps.push(root);
+    mkdirSync(join(root, 'src'), { recursive: true });
+    await Bun.write(join(root, 'package.json'), JSON.stringify({ name: 'x' }) + '\n');
     await Bun.write(
-      join(root, 'package.json'),
+      join(root, 'tsconfig.json'),
       JSON.stringify({
-        name: 'x',
-        scripts: { build: 'mkdir -p dist && echo ok > dist/out.txt' },
+        compilerOptions: {
+          outDir: 'dist',
+          rootDir: 'src',
+          module: 'esnext',
+          target: 'esnext',
+          skipLibCheck: true,
+          noEmit: false,
+        },
+        include: ['src/**/*.ts'],
       }) + '\n',
     );
+    await Bun.write(join(root, 'src', 'index.ts'), 'export const n = 1;\n');
     const log = spyOn(console, 'log').mockImplementation(() => {});
     const cwd = process.cwd();
     try {
       process.chdir(root);
       await build([]);
-      expect(await Bun.file(join(root, 'dist', 'out.txt')).text()).toContain('ok');
+      expect(await Bun.file(join(root, 'dist', 'index.js')).exists()).toBe(true);
     } finally {
       process.chdir(cwd);
       log.mockRestore();
     }
-  }, 30_000);
+  }, 60_000);
 });

--- a/packages/di-framework-cli/tests/app-build.test.ts
+++ b/packages/di-framework-cli/tests/app-build.test.ts
@@ -82,6 +82,47 @@ describe('app build command', () => {
     }
   }, 60_000);
 
+  it('falls back to ttsc --emit when ttsc is declared and no build script', async () => {
+    const { hasTtsc } = await import('../cmd/build');
+    const root = mkdtempSync(join(tmpdir(), 'app-build-ttsc-'));
+    temps.push(root);
+    await Bun.write(
+      join(root, 'package.json'),
+      JSON.stringify({
+        name: 'x',
+        devDependencies: { ttsc: '>=0.25.0' },
+      }) + '\n',
+    );
+    await Bun.write(join(root, 'tsconfig.json'), '{}\n');
+    expect(hasTtsc(root, { devDependencies: { ttsc: '>=0.25.0' } })).toBe(true);
+
+    const seen: string[] = [];
+    const fakeShell = ((strings: TemplateStringsArray, ...exprs: unknown[]) => {
+      const cmd = strings.reduce((acc, s, i) => acc + s + (exprs[i] ?? ''), '');
+      seen.push(cmd);
+      return {
+        cwd: () => Promise.resolve(),
+      };
+    }) as unknown as import('../cmd/build').BuildShell;
+
+    const log = spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await buildApp({ cwd: root, passthrough: [] }, fakeShell);
+      expect(seen.some((c) => c.includes('ttsc') && c.includes('--emit'))).toBe(true);
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  it('hasTtsc detects node_modules/ttsc', async () => {
+    const { hasTtsc } = await import('../cmd/build');
+    const root = mkdtempSync(join(tmpdir(), 'app-build-ttsc-nm-'));
+    temps.push(root);
+    mkdirSync(join(root, 'node_modules', 'ttsc'), { recursive: true });
+    expect(hasTtsc(root)).toBe(true);
+    expect(hasTtsc(root, {})).toBe(true);
+  });
+
   it('handleBuildFailure exits 1', () => {
     const err = spyOn(console, 'error').mockImplementation(() => {});
     const originalExit = process.exit;

--- a/packages/di-framework-cli/tests/app-build.test.ts
+++ b/packages/di-framework-cli/tests/app-build.test.ts
@@ -132,9 +132,7 @@ describe('app build command', () => {
 
   it('treats @di-framework/tsc as implying ttsc', async () => {
     const { hasTtsc } = await import('../cmd/build');
-    expect(
-      hasTtsc('/tmp', { devDependencies: { '@di-framework/tsc': 'latest' } }),
-    ).toBe(true);
+    expect(hasTtsc('/tmp', { devDependencies: { '@di-framework/tsc': 'latest' } })).toBe(true);
   });
 
   it('hasTtsc detects node_modules/ttsc', async () => {

--- a/packages/di-framework-cli/tests/check.test.ts
+++ b/packages/di-framework-cli/tests/check.test.ts
@@ -115,6 +115,34 @@ describe('check command', () => {
       }
     }, 30_000);
 
+    it('falls through to tsc when package.json has no check script', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'check-no-script-'));
+      temps.push(root);
+      mkdirSync(join(root, 'src'), { recursive: true });
+      await Bun.write(join(root, 'package.json'), JSON.stringify({ name: 'x' }) + '\n');
+      await Bun.write(
+        join(root, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: {
+            strict: true,
+            noEmit: true,
+            skipLibCheck: true,
+            module: 'esnext',
+            target: 'esnext',
+            moduleResolution: 'bundler',
+          },
+          include: ['src/**/*.ts'],
+        }) + '\n',
+      );
+      await Bun.write(join(root, 'src', 'index.ts'), 'export const x: number = 1;\n');
+      const log = spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        await checkApp({ cwd: root, pretty: false });
+      } finally {
+        log.mockRestore();
+      }
+    }, 60_000);
+
     it('skips check script when an explicit tsconfig path is given', async () => {
       const root = mkdtempSync(join(tmpdir(), 'check-explicit-'));
       temps.push(root);

--- a/packages/di-framework-cli/tests/check.test.ts
+++ b/packages/di-framework-cli/tests/check.test.ts
@@ -96,55 +96,8 @@ describe('check command', () => {
       await expect(checkApp({ cwd: root, pretty: false })).rejects.toThrow('tsconfig');
     });
 
-    it('prefers package.json check script when no explicit tsconfig path', async () => {
-      const root = mkdtempSync(join(tmpdir(), 'check-script-'));
-      temps.push(root);
-      await Bun.write(
-        join(root, 'package.json'),
-        JSON.stringify({
-          name: 'x',
-          scripts: { check: 'mkdir -p dist && echo ok > dist/checked.txt' },
-        }) + '\n',
-      );
-      const log = spyOn(console, 'log').mockImplementation(() => {});
-      try {
-        await checkApp({ cwd: root, pretty: false });
-        expect(await Bun.file(join(root, 'dist', 'checked.txt')).text()).toContain('ok');
-      } finally {
-        log.mockRestore();
-      }
-    }, 30_000);
-
-    it('falls through to tsc when package.json has no check script', async () => {
-      const root = mkdtempSync(join(tmpdir(), 'check-no-script-'));
-      temps.push(root);
-      mkdirSync(join(root, 'src'), { recursive: true });
-      await Bun.write(join(root, 'package.json'), JSON.stringify({ name: 'x' }) + '\n');
-      await Bun.write(
-        join(root, 'tsconfig.json'),
-        JSON.stringify({
-          compilerOptions: {
-            strict: true,
-            noEmit: true,
-            skipLibCheck: true,
-            module: 'esnext',
-            target: 'esnext',
-            moduleResolution: 'bundler',
-          },
-          include: ['src/**/*.ts'],
-        }) + '\n',
-      );
-      await Bun.write(join(root, 'src', 'index.ts'), 'export const x: number = 1;\n');
-      const log = spyOn(console, 'log').mockImplementation(() => {});
-      try {
-        await checkApp({ cwd: root, pretty: false });
-      } finally {
-        log.mockRestore();
-      }
-    }, 60_000);
-
-    it('skips check script when an explicit tsconfig path is given', async () => {
-      const root = mkdtempSync(join(tmpdir(), 'check-explicit-'));
+    it('ignores package.json check script and runs tsc', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'check-ignore-script-'));
       temps.push(root);
       mkdirSync(join(root, 'src'), { recursive: true });
       await Bun.write(
@@ -171,29 +124,100 @@ describe('check command', () => {
       await Bun.write(join(root, 'src', 'index.ts'), 'export const x: number = 1;\n');
       const log = spyOn(console, 'log').mockImplementation(() => {});
       try {
-        await checkApp({ cwd: root, tsconfigPath: 'tsconfig.json', pretty: false });
+        await checkApp({ cwd: root, pretty: false });
       } finally {
         log.mockRestore();
       }
     }, 60_000);
 
-    it('throws when package check script fails', async () => {
-      const root = mkdtempSync(join(tmpdir(), 'check-script-fail-'));
+    it('runs tsc when package.json has no ttsc', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'check-no-ttsc-'));
       temps.push(root);
+      mkdirSync(join(root, 'src'), { recursive: true });
+      await Bun.write(join(root, 'package.json'), JSON.stringify({ name: 'x' }) + '\n');
       await Bun.write(
-        join(root, 'package.json'),
+        join(root, 'tsconfig.json'),
         JSON.stringify({
-          name: 'x',
-          scripts: { check: 'exit 1' },
+          compilerOptions: {
+            strict: true,
+            noEmit: true,
+            skipLibCheck: true,
+            module: 'esnext',
+            target: 'esnext',
+            moduleResolution: 'bundler',
+          },
+          include: ['src/**/*.ts'],
         }) + '\n',
       );
+      await Bun.write(join(root, 'src', 'index.ts'), 'export const x: number = 1;\n');
       const log = spyOn(console, 'log').mockImplementation(() => {});
       try {
-        await expect(checkApp({ cwd: root, pretty: false })).rejects.toThrow('Typecheck failed');
+        await checkApp({ cwd: root, pretty: false });
+      } finally {
+        log.mockRestore();
+      }
+    }, 60_000);
+
+    it('prefers ttsc --noEmit when ttsc is installed locally', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'check-ttsc-'));
+      temps.push(root);
+      mkdirSync(join(root, 'node_modules', 'ttsc'), { recursive: true });
+      await Bun.write(
+        join(root, 'node_modules', 'ttsc', 'package.json'),
+        JSON.stringify({
+          name: 'ttsc',
+          version: '0.0.0',
+          bin: { ttsc: './cli.js' },
+        }) + '\n',
+      );
+      await Bun.write(
+        join(root, 'node_modules', 'ttsc', 'cli.js'),
+        '#!/usr/bin/env node\nprocess.exit(0);\n',
+      );
+      mkdirSync(join(root, 'node_modules', '.bin'), { recursive: true });
+      await Bun.write(
+        join(root, 'node_modules', '.bin', 'ttsc'),
+        `#!/usr/bin/env bash\nexec node "${join(root, 'node_modules', 'ttsc', 'cli.js')}" "$@"\n`,
+      );
+      await Bun.$`chmod +x ${join(root, 'node_modules', '.bin', 'ttsc')} ${join(root, 'node_modules', 'ttsc', 'cli.js')}`;
+      await Bun.write(join(root, 'package.json'), JSON.stringify({ name: 'x' }) + '\n');
+      await Bun.write(join(root, 'tsconfig.json'), '{}\n');
+      const log = spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        await checkApp({ cwd: root, pretty: false });
+        expect(log.mock.calls.some((c) => String(c[0]).includes('ttsc'))).toBe(true);
       } finally {
         log.mockRestore();
       }
     }, 30_000);
+
+    it('honors an explicit tsconfig path', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'check-explicit-'));
+      temps.push(root);
+      mkdirSync(join(root, 'src'), { recursive: true });
+      await Bun.write(join(root, 'package.json'), JSON.stringify({ name: 'x' }) + '\n');
+      await Bun.write(
+        join(root, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: {
+            strict: true,
+            noEmit: true,
+            skipLibCheck: true,
+            module: 'esnext',
+            target: 'esnext',
+            moduleResolution: 'bundler',
+          },
+          include: ['src/**/*.ts'],
+        }) + '\n',
+      );
+      await Bun.write(join(root, 'src', 'index.ts'), 'export const x: number = 1;\n');
+      const log = spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        await checkApp({ cwd: root, tsconfigPath: 'tsconfig.json', pretty: false });
+      } finally {
+        log.mockRestore();
+      }
+    }, 60_000);
 
     it('throws when tsc reports type errors', async () => {
       const root = mkdtempSync(join(tmpdir(), 'check-fail-'));

--- a/packages/di-framework-cli/tests/check.test.ts
+++ b/packages/di-framework-cli/tests/check.test.ts
@@ -96,6 +96,77 @@ describe('check command', () => {
       await expect(checkApp({ cwd: root, pretty: false })).rejects.toThrow('tsconfig');
     });
 
+    it('prefers package.json check script when no explicit tsconfig path', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'check-script-'));
+      temps.push(root);
+      await Bun.write(
+        join(root, 'package.json'),
+        JSON.stringify({
+          name: 'x',
+          scripts: { check: 'mkdir -p dist && echo ok > dist/checked.txt' },
+        }) + '\n',
+      );
+      const log = spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        await checkApp({ cwd: root, pretty: false });
+        expect(await Bun.file(join(root, 'dist', 'checked.txt')).text()).toContain('ok');
+      } finally {
+        log.mockRestore();
+      }
+    }, 30_000);
+
+    it('skips check script when an explicit tsconfig path is given', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'check-explicit-'));
+      temps.push(root);
+      mkdirSync(join(root, 'src'), { recursive: true });
+      await Bun.write(
+        join(root, 'package.json'),
+        JSON.stringify({
+          name: 'x',
+          scripts: { check: 'echo should-not-run && exit 1' },
+        }) + '\n',
+      );
+      await Bun.write(
+        join(root, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: {
+            strict: true,
+            noEmit: true,
+            skipLibCheck: true,
+            module: 'esnext',
+            target: 'esnext',
+            moduleResolution: 'bundler',
+          },
+          include: ['src/**/*.ts'],
+        }) + '\n',
+      );
+      await Bun.write(join(root, 'src', 'index.ts'), 'export const x: number = 1;\n');
+      const log = spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        await checkApp({ cwd: root, tsconfigPath: 'tsconfig.json', pretty: false });
+      } finally {
+        log.mockRestore();
+      }
+    }, 60_000);
+
+    it('throws when package check script fails', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'check-script-fail-'));
+      temps.push(root);
+      await Bun.write(
+        join(root, 'package.json'),
+        JSON.stringify({
+          name: 'x',
+          scripts: { check: 'exit 1' },
+        }) + '\n',
+      );
+      const log = spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        await expect(checkApp({ cwd: root, pretty: false })).rejects.toThrow('Typecheck failed');
+      } finally {
+        log.mockRestore();
+      }
+    }, 30_000);
+
     it('throws when tsc reports type errors', async () => {
       const root = mkdtempSync(join(tmpdir(), 'check-fail-'));
       temps.push(root);

--- a/packages/di-framework-cli/tests/init.test.ts
+++ b/packages/di-framework-cli/tests/init.test.ts
@@ -118,11 +118,12 @@ describe('init command', () => {
 
         const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf-8'));
         expect(pkg.dependencies['@di-framework/core']).toBe('latest');
+        expect(pkg.devDependencies['@di-framework/cli']).toBe('latest');
         expect(pkg.devDependencies['@di-framework/tsc']).toBe('latest');
-        expect(pkg.devDependencies.ttsc).toBe('>=0.25.0');
-        expect(pkg.devDependencies.typescript).toBe('^7.0.0');
-        expect(pkg.scripts.build).toBe('ttsc --emit');
-        expect(pkg.scripts.check).toBe('ttsc --noEmit');
+        expect(pkg.devDependencies.ttsc).toBeUndefined();
+        expect(pkg.devDependencies.typescript).toBeUndefined();
+        expect(pkg.scripts.build).toBe('di-framework build');
+        expect(pkg.scripts.check).toBe('di-framework check');
         expect(pkg.scripts.start).toBe('node dist/index.js');
 
         const ts = JSON.parse(readFileSync(join(dir, 'tsconfig.json'), 'utf-8'));
@@ -130,17 +131,22 @@ describe('init command', () => {
         expect(ts.compilerOptions.emitDecoratorMetadata).toBe(false);
         expect(ts.compilerOptions.outDir).toBe('dist');
         expect(ts.compilerOptions.rootDir).toBe('src');
+        expect(ts.compilerOptions.types).toEqual(['bun']);
+        expect(ts.compilerOptions.module).toBe('NodeNext');
+        expect(ts.compilerOptions.moduleResolution).toBe('NodeNext');
         expect(ts.compilerOptions.plugins).toEqual([{ transform: '@di-framework/tsc' }]);
         expect(ts.compilerOptions.noEmit).toBeUndefined();
         expect(ts.compilerOptions.allowImportingTsExtensions).toBeUndefined();
 
         const readme = readFileSync(join(dir, 'README.md'), 'utf-8');
         expect(readme).toContain('@di-framework/tsc');
-        expect(readme).toContain('ttsc --emit');
+        expect(readme).toContain('di-framework build');
+        expect(readme).toContain('di-framework check');
 
         const src = readFileSync(join(dir, 'src', 'index.ts'), 'utf-8');
         expect(src).toContain('@Container()');
         expect(src).toContain('@di-framework/core');
+        expect(src).toContain('function greet(name: string)');
       } finally {
         log.mockRestore();
       }

--- a/packages/di-framework-cli/tests/init.test.ts
+++ b/packages/di-framework-cli/tests/init.test.ts
@@ -118,12 +118,25 @@ describe('init command', () => {
 
         const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf-8'));
         expect(pkg.dependencies['@di-framework/core']).toBe('latest');
-        expect(pkg.scripts.build).toBeDefined();
-        expect(pkg.scripts.check).toBeDefined();
+        expect(pkg.devDependencies['@di-framework/tsc']).toBe('latest');
+        expect(pkg.devDependencies.ttsc).toBe('>=0.25.0');
+        expect(pkg.devDependencies.typescript).toBe('^7.0.0');
+        expect(pkg.scripts.build).toBe('ttsc --emit');
+        expect(pkg.scripts.check).toBe('ttsc --noEmit');
+        expect(pkg.scripts.start).toBe('node dist/index.js');
 
         const ts = JSON.parse(readFileSync(join(dir, 'tsconfig.json'), 'utf-8'));
         expect(ts.compilerOptions.experimentalDecorators).toBe(true);
         expect(ts.compilerOptions.emitDecoratorMetadata).toBe(false);
+        expect(ts.compilerOptions.outDir).toBe('dist');
+        expect(ts.compilerOptions.rootDir).toBe('src');
+        expect(ts.compilerOptions.plugins).toEqual([{ transform: '@di-framework/tsc' }]);
+        expect(ts.compilerOptions.noEmit).toBeUndefined();
+        expect(ts.compilerOptions.allowImportingTsExtensions).toBeUndefined();
+
+        const readme = readFileSync(join(dir, 'README.md'), 'utf-8');
+        expect(readme).toContain('@di-framework/tsc');
+        expect(readme).toContain('ttsc --emit');
 
         const src = readFileSync(join(dir, 'src', 'index.ts'), 'utf-8');
         expect(src).toContain('@Container()');

--- a/packages/di-framework-tsc/README.md
+++ b/packages/di-framework-tsc/README.md
@@ -6,6 +6,8 @@ Source stays plain TypeScript — no `assert()`, schemas, or decorators. On emit
 
 > MVP: function declarations with required identifier params; primitives + plain object/interface props. See [Limitations](#limitations).
 
+`di-framework init` wires this by default. Use the steps below for an existing app.
+
 ## Install
 
 ```bash

--- a/packages/di-framework-tsc/README.md
+++ b/packages/di-framework-tsc/README.md
@@ -11,10 +11,10 @@ Source stays plain TypeScript — no `assert()`, schemas, or decorators. On emit
 ## Install
 
 ```bash
-npm i -D ttsc typescript @di-framework/tsc
+npm i -D @di-framework/tsc
 ```
 
-Consumers supply `ttsc` and TypeScript 7+; this package is the transform only.
+Pulls in `ttsc` and TypeScript 7+ transitively.
 
 First build compiles the Go sidecar (cached afterward). Needs a Go toolchain (`go` 1.26+ recommended; `ttsc` can pin via `TTSC_GO_BINARY`).
 
@@ -84,9 +84,9 @@ Skipped today:
 
 ## Monorepo
 
-Workspace package at `packages/di-framework-tsc`. It is listed in the CLI build/publish allowlists; `build` is a no-op (plugin.cjs + Go sidecar, not the TS5 `tsc` graph). Peers `ttsc` and TypeScript 7+ stay out of root/`@di-framework/*` core packages.
+Workspace package at `packages/di-framework-tsc`. It is listed in the CLI build/publish allowlists; `build` is a no-op (plugin.cjs + Go sidecar, not the TS5 `tsc` graph). `ttsc` and TypeScript 7+ are dependencies of this package (kept out of root / other `@di-framework/*` packages).
 
-Isolated smoke fixture (installs its own ttsc + TS7):
+Isolated smoke fixture (pulls ttsc + TS7 via `@di-framework/tsc`):
 
 ```bash
 cd packages/di-framework-tsc/fixture
@@ -109,7 +109,7 @@ Smoke-test a packed tarball in another project:
 ```bash
 npm pack
 cd /path/to/other-project
-npm i -D ttsc typescript /path/to/di-framework-tsc-0.1.0.tgz
+npm i -D /path/to/di-framework-tsc-0.1.0.tgz
 # add plugins: [{ "transform": "@di-framework/tsc" }]
 npx ttsc --emit
 ```

--- a/packages/di-framework-tsc/fixture/package.json
+++ b/packages/di-framework-tsc/fixture/package.json
@@ -8,8 +8,6 @@
     "smoke:dtsc": "rm -rf dist && dtsc --emit && node ../scripts/check-emit.cjs"
   },
   "devDependencies": {
-    "@di-framework/tsc": "file:..",
-    "ttsc": ">=0.25.0",
-    "typescript": "^7.0.2"
+    "@di-framework/tsc": "file:.."
   }
 }

--- a/packages/di-framework-tsc/package.json
+++ b/packages/di-framework-tsc/package.json
@@ -47,17 +47,9 @@
     "url": "https://github.com/di-framework/di-framework/issues"
   },
   "homepage": "https://github.com/di-framework/di-framework#readme",
-  "peerDependencies": {
+  "dependencies": {
     "ttsc": ">=0.25.0",
-    "typescript": ">=7.0.0"
-  },
-  "peerDependenciesMeta": {
-    "ttsc": {
-      "optional": false
-    },
-    "typescript": {
-      "optional": false
-    }
+    "typescript": "^7.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- `di-framework init` scaffolds `@di-framework/cli` + `@di-framework/tsc` by default, with emit-ready `tsconfig` (`plugins`, `NodeNext`, `types: ["bun"]`, `outDir`/`rootDir`)
- App scripts call the CLI (`build` / `check` → `di-framework …`); the CLI owns the toolchain and runs `ttsc` or `tsc` directly (no package-script preference loop)
- `ttsc` and TypeScript 7+ come transitively from `@di-framework/tsc` — apps do not declare them
- Scaffold includes a top-level `function` so emit-time runtime checks are visible (class methods still MVP-skipped; tracked in #146)
- Writerside / package docs updated; `examples/packages/init-tsc-inspect` added for local inspection (`workspace:*`)

Closes #144

## Test plan
- [x] `bun test packages/di-framework-cli/tests/init.test.ts packages/di-framework-cli/tests/check.test.ts packages/di-framework-cli/tests/app-build.test.ts`
- [x] Pre-push suite + 100% line coverage
- [x] Rebuild `examples/packages/init-tsc-inspect` and confirm `greet` emit includes `typeof` / `TypeError` guards
- [ ] Fresh `di-framework init` + `bun install` + `bun run check` / `bun run build` (Go needed for first `ttsc` sidecar)
- [ ] Confirm `bun run dev` still runs source without requiring emit