### PR TITLE
fix(ci): run package build before tests in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Test
-        run: bun run test
-
       - name: Build packages
-        run: bun run packages/di-framework-cli/cmd/mx/build.ts
+        run: bun run build
+
+      - name: Test
+        run: bun run test:all
 
       - uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
Fixes release workflow failure by building packages before testing and using sequential test execution.