### PR TITLE
fix(core): remove postinstall build script from published package (#177)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "bun test",
     "publish": "bun run packages/di-framework-cli/main.ts mx publish",
     "link-cli": "(cd packages/di-framework-cli && bun link >/dev/null 2>&1)",
-    "postinstall": "git config core.hooksPath .githooks && bun link-cli && echo 'di-framework init | build | check  (mx: maintainers)'",
+    "postinstall": "git config core.hooksPath .githooks && bun link-cli && bun run build && echo 'di-framework init | build | check  (mx: maintainers)'",
     "tsc": "tsc",
     "lint": "biome check .",
     "typecheck": "bun x tsc -b --noEmit",

--- a/packages/di-framework-ai/package.json
+++ b/packages/di-framework-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@di-framework/ai",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Declarative library for building AI applications",
   "main": "./src/index.ts",
   "module": "./src/index.ts",

--- a/packages/di-framework-auth/package.json
+++ b/packages/di-framework-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@di-framework/auth",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Authentication for di-framework — sessions, JWT/JWS bearer, OAuth2/OIDC, and WebAuthn passkeys on WebCrypto with zero runtime dependencies",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/di-framework-authz/package.json
+++ b/packages/di-framework-authz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@di-framework/authz",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Declarative resource authorization policies for di-framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/di-framework-cli/package.json
+++ b/packages/di-framework-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@di-framework/cli",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "CLI for di-framework apps (init, build, check, generate) and monorepo maintainers (mx)",
   "private": false,
   "type": "module",

--- a/packages/di-framework-codegen/package.json
+++ b/packages/di-framework-codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@di-framework/codegen",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Code generation engine for @di-framework schema manifests",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/di-framework-config/package.json
+++ b/packages/di-framework-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@di-framework/config",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Typed, validated configuration for di-framework — load from env/files, validate, and inject via DI.",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/di-framework-core/package.json
+++ b/packages/di-framework-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@di-framework/core",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Lightweight, zero-dependency TypeScript Dependency Injection framework using decorators. Works seamlessly with SWC and TypeScript's native decorator support.",
   "main": "./dist/container.js",
   "types": "./dist/container.d.ts",
@@ -62,7 +62,6 @@
   "homepage": "https://github.com/di-framework/di-framework#readme",
   "scripts": {
     "build": "rm -rf dist && bun x tsc -p tsconfig.build.json",
-    "postinstall": "bun run build",
     "test": "bun test"
   },
   "peerDependencies": {

--- a/packages/di-framework-events/package.json
+++ b/packages/di-framework-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@di-framework/events",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Bridge di-framework container events to external brokers (Kafka, NATS) via pluggable transports.",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/di-framework-graphql/package.json
+++ b/packages/di-framework-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@di-framework/graphql",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Radically object-oriented, decorator-driven GraphQL for di-framework. Domain objects are the schema; decorators declare semantic exposure, ownership and boundaries.",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/di-framework-http/package.json
+++ b/packages/di-framework-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@di-framework/http",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Extends di-framework with HTTP features",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/di-framework-repo/package.json
+++ b/packages/di-framework-repo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@di-framework/repo",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "A coherent abstraction of repositories and storage adapters for di-framework.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/di-framework-rpc/package.json
+++ b/packages/di-framework-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@di-framework/rpc",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Decorator-centric JSON-RPC and per-method gRPC for di-framework",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/di-framework-socket/package.json
+++ b/packages/di-framework-socket/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@di-framework/socket",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Decorator-driven WebSocket, TCP, and UDP for di-framework — @SocketGateway / @OnMessage with a WebCrypto secure channel",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/di-framework-tsc/package.json
+++ b/packages/di-framework-tsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@di-framework/tsc",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "ttsc transform that injects runtime parameter checks from TypeScript types (assertAll)",
   "author": "@di-framework Contributors",
   "license": "(MIT OR Apache-2.0)",


### PR DESCRIPTION
## Description
This PR resolves an issue where installing `@di-framework/core` via standard npm or bun installation fails because a `postinstall` build hook attempts to recompile the package from TypeScript source files and `tsconfig.build.json` that are intentionally excluded from the published npm package tarball.

## Summary of Changes
1. **Removed `postinstall` from `@di-framework/core`**: Removed `"postinstall": "bun run build"` from `packages/di-framework-core/package.json`.
2. **Added workspace-level `postinstall` build**: Updated root `package.json`'s `postinstall` script to include `bun run build`. Because root `package.json` is `private: true`, workspace developers cloning the repo will automatically build all packages on `bun install` without triggering postinstall scripts for npm package consumers.

Closes #177